### PR TITLE
test: broaden test coverage across core abstractions and middleware

### DIFF
--- a/cert_test.go
+++ b/cert_test.go
@@ -1,0 +1,55 @@
+package parapet_test
+
+import (
+	"crypto/x509"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet"
+)
+
+func TestGenerateSelfSignCertificateDefaults(t *testing.T) {
+	t.Parallel()
+
+	cert, err := GenerateSelfSignCertificate(SelfSign{
+		CommonName: "test",
+		Hosts:      []string{"localhost", "127.0.0.1"},
+	})
+	assert.NoError(t, err)
+	if !assert.NotEmpty(t, cert.Certificate) {
+		return
+	}
+
+	x, err := x509.ParseCertificate(cert.Certificate[0])
+	assert.NoError(t, err)
+	assert.Equal(t, "test", x.Subject.CommonName)
+	assert.Contains(t, x.DNSNames, "localhost")
+	if assert.NotEmpty(t, x.IPAddresses) {
+		assert.Equal(t, "127.0.0.1", x.IPAddresses[0].String())
+	}
+	// NotAfter should default to ~10 years from now
+	assert.True(t, x.NotAfter.After(time.Now().AddDate(9, 0, 0)))
+	assert.True(t, x.NotAfter.Before(time.Now().AddDate(11, 0, 0)))
+}
+
+func TestGenerateSelfSignCertificateExplicitDates(t *testing.T) {
+	t.Parallel()
+
+	notBefore := time.Now().Add(-time.Hour).Truncate(time.Second)
+	notAfter := notBefore.Add(24 * time.Hour)
+	cert, err := GenerateSelfSignCertificate(SelfSign{
+		CommonName: "explicit",
+		Hosts:      []string{"example.com"},
+		NotBefore:  notBefore,
+		NotAfter:   notAfter,
+	})
+	assert.NoError(t, err)
+
+	x, err := x509.ParseCertificate(cert.Certificate[0])
+	assert.NoError(t, err)
+	assert.WithinDuration(t, notBefore, x.NotBefore, time.Second)
+	assert.WithinDuration(t, notAfter, x.NotAfter, time.Second)
+	assert.Equal(t, []string{"example.com"}, x.DNSNames)
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,173 @@
+package parapet_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet"
+)
+
+func tagMiddleware(tag string) Middleware {
+	return MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("<" + tag + ">"))
+			next.ServeHTTP(w, r)
+			_, _ = w.Write([]byte("</" + tag + ">"))
+		})
+	})
+}
+
+func TestMiddlewaresAppliedInOrder(t *testing.T) {
+	t.Parallel()
+
+	var ms Middlewares
+	ms.Use(tagMiddleware("a"))
+	ms.Use(tagMiddleware("b"))
+	ms.Use(tagMiddleware("c"))
+
+	h := ms.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("X"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, "<a><b><c>X</c></b></a>", w.Body.String())
+}
+
+func TestMiddlewaresIgnoresNil(t *testing.T) {
+	t.Parallel()
+
+	var ms Middlewares
+	ms.Use(nil)
+	ms.Use(tagMiddleware("a"))
+	ms.Use(nil)
+	assert.Len(t, ms, 1)
+
+	h := ms.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("X"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, "<a>X</a>", w.Body.String())
+}
+
+func TestMiddlewaresUseFunc(t *testing.T) {
+	t.Parallel()
+
+	var ms Middlewares
+	ms.UseFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("F"))
+			next.ServeHTTP(w, r)
+		})
+	})
+
+	h := ms.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("X"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, "FX", w.Body.String())
+}
+
+func TestCondThen(t *testing.T) {
+	t.Parallel()
+
+	c := Cond{
+		If:   func(r *http.Request) bool { return r.URL.Path == "/then" },
+		Then: tagMiddleware("then"),
+		Else: tagMiddleware("else"),
+	}
+	h := c.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("X"))
+	}))
+
+	t.Run("then", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/then", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		assert.Equal(t, "<then>X</then>", w.Body.String())
+	})
+	t.Run("else", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/other", nil)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		assert.Equal(t, "<else>X</else>", w.Body.String())
+	})
+}
+
+func TestCondElseDefaultsToPassthrough(t *testing.T) {
+	t.Parallel()
+
+	c := Cond{
+		If:   func(r *http.Request) bool { return false },
+		Then: tagMiddleware("then"),
+	}
+	h := c.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("plain"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, "plain", w.Body.String())
+}
+
+func TestHandler(t *testing.T) {
+	t.Parallel()
+
+	h := Handler(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hi"))
+	})
+
+	// ServeHandler ignores the inner handler since Handler is terminal
+	served := h.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("inner handler must not be called")
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	served.ServeHTTP(w, r)
+
+	assert.Equal(t, "hi", w.Body.String())
+
+	// also works as plain http.Handler
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, r)
+	assert.Equal(t, "hi", w2.Body.String())
+}
+
+func TestMiddlewareFuncServeHandler(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	mf := MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			next.ServeHTTP(w, r)
+		})
+	})
+
+	h := mf.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called)
+	assert.Equal(t, "ok", w.Body.String())
+}

--- a/new_test.go
+++ b/new_test.go
@@ -1,0 +1,162 @@
+package parapet_test
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet"
+)
+
+func TestNewDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	assert.Equal(t, 620*time.Second, s.IdleTimeout)
+	assert.Equal(t, 3*time.Minute, s.TCPKeepAlivePeriod)
+	assert.Equal(t, 30*time.Second, s.GraceTimeout)
+	assert.Equal(t, 10*time.Second, s.WaitBeforeShutdown)
+	assert.NotNil(t, s.TrustProxy)
+	assert.NotNil(t, s.Handler)
+}
+
+func TestNewFrontendDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := NewFrontend()
+	assert.Equal(t, 10*time.Second, s.ReadHeaderTimeout)
+	assert.Equal(t, time.Minute, s.ReadTimeout)
+	assert.Equal(t, time.Minute, s.WriteTimeout)
+	assert.Equal(t, 75*time.Second, s.IdleTimeout)
+	assert.Nil(t, s.TrustProxy, "frontend should not trust proxy by default")
+	assert.False(t, s.H2C)
+}
+
+func TestNewBackendDefaults(t *testing.T) {
+	t.Parallel()
+
+	s := NewBackend()
+	assert.True(t, s.H2C)
+	assert.NotNil(t, s.TrustProxy)
+	assert.Equal(t, 620*time.Second, s.IdleTimeout)
+}
+
+func TestTrustedAlwaysTrue(t *testing.T) {
+	t.Parallel()
+
+	c := Trusted()
+	r := httptest.NewRequest("GET", "/", nil)
+	assert.True(t, c(r))
+}
+
+func TestTrustCIDRs(t *testing.T) {
+	t.Parallel()
+
+	c := TrustCIDRs([]string{"10.0.0.0/8", "192.168.1.0/24"})
+
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"10.1.2.3:1", true},
+		{"192.168.1.5:1", true},
+		{"192.168.2.5:1", false},
+		{"8.8.8.8:1", false},
+		{"not-an-ip", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.RemoteAddr = tc.addr
+		assert.Equal(t, tc.want, c(r), "addr=%q", tc.addr)
+	}
+}
+
+func TestTrustCIDRsEmpty(t *testing.T) {
+	t.Parallel()
+
+	c := TrustCIDRs(nil)
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.0.0.1:1"
+	assert.False(t, c(r))
+}
+
+func TestServerUseAppliesChain(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("inner"))
+	})
+	s.Use(MiddlewareFunc(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("["))
+			next.ServeHTTP(w, r)
+			_, _ = w.Write([]byte("]"))
+		})
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "127.0.0.1:1"
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, r)
+
+	assert.Equal(t, "[inner]", w.Body.String())
+}
+
+func TestServerUsePanicsAfterServe(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	s.Handler = http.NotFoundHandler()
+
+	// trigger handler config
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "127.0.0.1:1"
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, r)
+
+	assert.Panics(t, func() {
+		s.Use(MiddlewareFunc(func(next http.Handler) http.Handler { return next }))
+	})
+}
+
+func TestServerContextKey(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	s.WaitBeforeShutdown = 0
+	s.GraceTimeout = 100 * time.Millisecond
+	srvFromCtx := func() any { return nil }
+	s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srvFromCtx = func() any { return r.Context().Value(ServerContextKey) }
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// http.Server populates BaseContext on Serve(). Drive a real listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer ln.Close()
+	s.Addr = ln.Addr().String()
+
+	go s.Serve(ln)
+	defer s.Shutdown()
+
+	// wait for server to be ready
+	time.Sleep(100 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", "http://"+s.Addr, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if assert.NoError(t, err) {
+		resp.Body.Close()
+	}
+
+	assert.Same(t, s, srvFromCtx())
+}

--- a/pkg/cors/cors_test.go
+++ b/pkg/cors/cors_test.go
@@ -1,0 +1,189 @@
+package cors_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet/pkg/cors"
+)
+
+func TestNewDefaults(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	assert.True(t, m.AllowAllOrigins)
+	assert.Equal(t, time.Hour, m.MaxAge)
+	assert.Contains(t, m.AllowMethods, "GET")
+	assert.Contains(t, m.AllowHeaders, "Authorization")
+}
+
+func TestAllowOrigins(t *testing.T) {
+	t.Parallel()
+
+	f := AllowOrigins("https://a.example.com", "https://b.example.com")
+	assert.True(t, f("https://a.example.com"))
+	assert.True(t, f("https://b.example.com"))
+	assert.False(t, f("https://c.example.com"))
+	assert.False(t, f(""))
+}
+
+func TestCORSAllowAllOrigins(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCORSNoOrigin(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := New()
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called)
+	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSPreflight(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &CORS{
+		AllowAllOrigins:  true,
+		AllowMethods:     []string{"GET", "POST"},
+		AllowHeaders:     []string{"Content-Type", "Authorization"},
+		ExposeHeaders:    []string{"X-Custom"},
+		AllowCredentials: true,
+		MaxAge:           2 * time.Hour,
+	}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	r := httptest.NewRequest("OPTIONS", "/", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.False(t, called, "preflight should not invoke downstream")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "GET,POST", w.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "Content-Type,Authorization", w.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "true", w.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, "7200", w.Header().Get("Access-Control-Max-Age"))
+}
+
+func TestCORSExposeHeadersOnNonPreflight(t *testing.T) {
+	t.Parallel()
+
+	m := &CORS{
+		AllowAllOrigins: true,
+		ExposeHeaders:   []string{"X-Custom", "X-Other"},
+	}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, "X-Custom,X-Other", w.Header().Get("Access-Control-Expose-Headers"))
+}
+
+func TestCORSRestrictedOriginsAllowed(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &CORS{
+		AllowOrigins: AllowOrigins("https://allowed.example.com"),
+		AllowMethods: []string{"GET"},
+	}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Origin", "https://allowed.example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "https://allowed.example.com", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "Origin", w.Header().Get("Vary"))
+}
+
+func TestCORSRestrictedOriginsForbidden(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &CORS{
+		AllowOrigins: AllowOrigins("https://allowed.example.com"),
+	}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Origin", "https://other.example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestCORSMissingOriginConfig(t *testing.T) {
+	t.Parallel()
+
+	m := &CORS{}
+	assert.Panics(t, func() {
+		m.ServeHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	})
+}
+
+func TestCORSPreflightVaryWhenRestricted(t *testing.T) {
+	t.Parallel()
+
+	m := &CORS{
+		AllowOrigins: AllowOrigins("https://allowed.example.com"),
+		AllowMethods: []string{"GET"},
+	}
+	h := m.ServeHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	r := httptest.NewRequest("OPTIONS", "/", nil)
+	r.Header.Set("Origin", "https://allowed.example.com")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	vary := w.Header().Values("Vary")
+	assert.Contains(t, vary, "Origin")
+	assert.Contains(t, vary, "Access-Control-Request-Method")
+	assert.Contains(t, vary, "Access-Control-Request-Headers")
+}

--- a/pkg/fileserver/fileserver_test.go
+++ b/pkg/fileserver/fileserver_test.go
@@ -1,0 +1,110 @@
+package fileserver_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet/pkg/fileserver"
+)
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFileServerServesFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "hello.txt", "hi there")
+
+	m := New(dir)
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	r := httptest.NewRequest("GET", "/hello.txt", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.False(t, called, "fallback should not run when file is served")
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "hi there", string(body))
+}
+
+func TestFileServerFallbackOnMissing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	m := New(dir)
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("fallback"))
+	}))
+
+	r := httptest.NewRequest("GET", "/does-not-exist.txt", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusTeapot, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "fallback", string(body))
+}
+
+func TestFileServerDirectoryListingDisabled(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "sub/inside.txt", "x")
+
+	m := New(dir)
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	r := httptest.NewRequest("GET", "/sub/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called, "directory should fall through to handler")
+}
+
+func TestFileServerListDirectoryEnabled(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeFile(t, dir, "sub/inside.txt", "x")
+
+	m := &FileServer{Root: dir, ListDirectory: true}
+	h := m.ServeHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("fallback should not be called")
+	}))
+
+	r := httptest.NewRequest("GET", "/sub/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Contains(t, string(body), "inside.txt")
+}

--- a/pkg/gcp/headers_test.go
+++ b/pkg/gcp/headers_test.go
@@ -1,0 +1,62 @@
+package gcp_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet/pkg/gcp"
+)
+
+func runHLB(t *testing.T, proxy int, xff string) string {
+	t.Helper()
+
+	m := HLBImmediateIP(proxy)
+	var captured string
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured = r.Header.Get("X-Real-Ip")
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	if xff != "" {
+		r.Header.Set("X-Forwarded-For", xff)
+	}
+	h.ServeHTTP(httptest.NewRecorder(), r)
+	return captured
+}
+
+func TestHLBImmediateIP(t *testing.T) {
+	t.Parallel()
+
+	// XFF format from GCP HLB: client, ...hops, lb-ip
+	// proxy=0 picks the second-to-last hop (the actual client as seen by GCP)
+	assert.Equal(t, "203.0.113.1", runHLB(t, 0, "203.0.113.1, 35.191.0.1"))
+
+	// with extra proxy hops
+	assert.Equal(t, "203.0.113.1", runHLB(t, 1, "203.0.113.1, 10.0.0.1, 35.191.0.1"))
+
+	// trims whitespace
+	assert.Equal(t, "203.0.113.1", runHLB(t, 0, " 203.0.113.1 ,  35.191.0.1 "))
+}
+
+func TestHLBImmediateIPInsufficientHops(t *testing.T) {
+	t.Parallel()
+
+	// single entry, proxy=0 needs at least 2 -> do nothing
+	assert.Empty(t, runHLB(t, 0, "203.0.113.1"))
+}
+
+func TestHLBImmediateIPNoHeader(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, runHLB(t, 0, ""))
+}
+
+func TestHLBImmediateIPNegativeProxy(t *testing.T) {
+	t.Parallel()
+
+	// negative is normalized to 0
+	assert.Equal(t, "203.0.113.1", runHLB(t, -5, "203.0.113.1, 35.191.0.1"))
+}

--- a/pkg/h2push/h2push_test.go
+++ b/pkg/h2push/h2push_test.go
@@ -1,0 +1,117 @@
+package h2push_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet/pkg/h2push"
+)
+
+type pushRecorder struct {
+	http.ResponseWriter
+	pushes []string
+}
+
+func (p *pushRecorder) Push(target string, _ *http.PushOptions) error {
+	p.pushes = append(p.pushes, target)
+	return nil
+}
+
+func TestLinkPusherEmptyDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	m := Push("")
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_, ok := w.(http.Pusher)
+		assert.False(t, ok, "should not wrap response writer when Link empty")
+	}))
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	assert.True(t, called)
+}
+
+func TestLinkPusherPushes(t *testing.T) {
+	t.Parallel()
+
+	m := Push("/static/app.js")
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := &pushRecorder{ResponseWriter: httptest.NewRecorder()}
+	r := httptest.NewRequest("GET", "/", nil)
+	h.ServeHTTP(rec, r)
+
+	assert.Equal(t, []string{"/static/app.js"}, rec.pushes)
+}
+
+func TestLinkPusherNoPusherNoop(t *testing.T) {
+	t.Parallel()
+
+	m := Push("/static/app.js")
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	// httptest.ResponseRecorder is not a Pusher
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called)
+}
+
+func TestPreloadPusherSkipsWithoutPusher(t *testing.T) {
+	t.Parallel()
+
+	m := Preload()
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called)
+}
+
+func TestPreloadPusherSkipsNopushAndNonPreload(t *testing.T) {
+	t.Parallel()
+
+	m := Preload()
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Link", "</b.js>; rel=preload; nopush")
+		w.Header().Add("Link", "</c.png>; rel=icon")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := &pushRecorder{ResponseWriter: httptest.NewRecorder()}
+	r := httptest.NewRequest("GET", "/", nil)
+	h.ServeHTTP(rec, r)
+
+	assert.Empty(t, rec.pushes, "nopush and non-preload links must not be pushed")
+}
+
+func TestPreloadPusherImplicitWriteHeader(t *testing.T) {
+	t.Parallel()
+
+	m := Preload()
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	rec := &pushRecorder{ResponseWriter: httptest.NewRecorder()}
+	r := httptest.NewRequest("GET", "/", nil)
+	h.ServeHTTP(rec, r)
+
+	// implicit Write must have produced an OK response on the underlying writer
+	assert.Equal(t, http.StatusOK, rec.ResponseWriter.(*httptest.ResponseRecorder).Code)
+}

--- a/pkg/internal/pool/pool_test.go
+++ b/pkg/internal/pool/pool_test.go
@@ -1,0 +1,37 @@
+package pool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSize(t *testing.T) {
+	t.Parallel()
+
+	assert.EqualValues(t, 16*1024, Size())
+}
+
+func TestGetReturnsBufferOfExpectedSize(t *testing.T) {
+	t.Parallel()
+
+	b := Get()
+	if assert.NotNil(t, b) {
+		assert.Len(t, *b, int(Size()))
+	}
+	Put(b)
+}
+
+func TestPutGetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	b := Get()
+	(*b)[0] = 0xAB
+	Put(b)
+
+	// We can't assert pool reuse strictly (sync.Pool may evict), but Get must
+	// still return a usable buffer of the right size.
+	b2 := Get()
+	defer Put(b2)
+	assert.Len(t, *b2, int(Size()))
+}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,0 +1,181 @@
+package logger_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet/pkg/logger"
+)
+
+func decodeLog(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var d map[string]any
+	if err := json.Unmarshal(b, &d); err != nil {
+		t.Fatalf("not valid json: %v\n%s", err, string(b))
+	}
+	return d
+}
+
+func TestStdoutStderrConstructors(t *testing.T) {
+	t.Parallel()
+
+	assert.NotNil(t, Stdout())
+	assert.True(t, Stdout().OmitEmpty)
+	assert.NotNil(t, Stderr())
+	assert.True(t, Stderr().OmitEmpty)
+}
+
+func TestLoggerWritesRecord(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	m := &Logger{Writer: buf}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("hello"))
+	}))
+
+	r := httptest.NewRequest("GET", "/path?x=1", nil)
+	r.Header.Set("X-Forwarded-Proto", "https")
+	r.Header.Set("Referer", "https://ref.example")
+	r.Header.Set("User-Agent", "ua")
+	r.RemoteAddr = "192.0.2.10:1234"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	d := decodeLog(t, buf.Bytes())
+	assert.Equal(t, "GET", d["requestMethod"])
+	assert.EqualValues(t, http.StatusCreated, d["status"])
+	assert.EqualValues(t, len("hello"), d["responseBodySize"])
+	assert.Equal(t, "192.0.2.10", d["remoteIp"])
+	assert.Equal(t, "https://ref.example", d["referer"])
+	assert.Equal(t, "ua", d["userAgent"])
+	assert.Equal(t, "https://example.com/path?x=1", d["requestUrl"])
+	assert.Contains(t, d, "duration")
+	assert.Contains(t, d, "durationHuman")
+}
+
+func TestLoggerWritesStatus200WhenHandlerOnlyWrites(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	m := &Logger{Writer: buf}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hi"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "127.0.0.1:1"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	d := decodeLog(t, buf.Bytes())
+	assert.EqualValues(t, http.StatusOK, d["status"])
+}
+
+func TestLoggerOmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	m := &Logger{Writer: buf, OmitEmpty: true}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "127.0.0.1:1"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	d := decodeLog(t, buf.Bytes())
+	_, hasReferer := d["referer"]
+	_, hasUA := d["userAgent"]
+	_, hasFF := d["forwardedFor"]
+	_, hasRealIP := d["realIp"]
+	assert.False(t, hasReferer)
+	assert.False(t, hasUA)
+	assert.False(t, hasFF)
+	assert.False(t, hasRealIP)
+}
+
+func TestDisableSkipsRecord(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	m := &Logger{Writer: buf}
+	inner := Disable().ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	h := m.ServeHandler(inner)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "127.0.0.1:1"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Empty(t, buf.Bytes(), "disabled logger should not write")
+}
+
+func TestSetGet(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	m := &Logger{Writer: buf}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Set(r.Context(), "custom", "value")
+		assert.Equal(t, "value", Get(r.Context(), "custom"))
+		w.WriteHeader(http.StatusOK)
+	})
+	h := m.ServeHandler(inner)
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "127.0.0.1:1"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	d := decodeLog(t, buf.Bytes())
+	assert.Equal(t, "value", d["custom"])
+}
+
+func TestSetGetWithoutRecord(t *testing.T) {
+	t.Parallel()
+
+	Set(context.Background(), "x", 1)
+	assert.Nil(t, Get(context.Background(), "x"))
+}
+
+func TestLoggerDefaultWriter(t *testing.T) {
+	t.Parallel()
+
+	m := &Logger{}
+	// just ensure that calling ServeHandler with a nil Writer does not panic
+	assert.NotPanics(t, func() {
+		_ = m.ServeHandler(http.NotFoundHandler())
+	})
+}
+
+func TestLoggerCanceledContextStatus499(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	m := &Logger{Writer: buf}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// don't write anything; statusCode stays 0
+	}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := httptest.NewRequest("GET", "/", nil).WithContext(ctx)
+	r.RemoteAddr = "127.0.0.1:1"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	d := decodeLog(t, buf.Bytes())
+	assert.EqualValues(t, 499, d["status"])
+}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -1,0 +1,90 @@
+package router_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moonrhythm/parapet"
+	. "github.com/moonrhythm/parapet/pkg/router"
+)
+
+func handler(body string) parapet.Middleware {
+	return parapet.MiddlewareFunc(func(_ http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(body))
+		})
+	})
+}
+
+func TestRouterRoutesByPrefix(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.Handle("/a", handler("got-a"))
+	m.Handle("/b/", handler("got-b"))
+
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("fallback"))
+	})
+	h := m.ServeHandler(fallback)
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/a", "got-a"},
+		{"/a/", "got-a"},
+		{"/a/sub", "got-a"},
+		{"/b/", "got-b"},
+		{"/b/sub", "got-b"},
+		{"/c", "fallback"},
+		{"/", "fallback"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			r := httptest.NewRequest("GET", tc.path, nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			body, _ := io.ReadAll(w.Body)
+			assert.Equal(t, tc.want, string(body))
+		})
+	}
+}
+
+func TestRouterOverridesRoot(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.Handle("/", handler("root"))
+
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("fallback"))
+	})
+	h := m.ServeHandler(fallback)
+
+	r := httptest.NewRequest("GET", "/anything", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "root", string(body))
+}
+
+func TestRouterEmpty(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	r := httptest.NewRequest("GET", "/anything", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	assert.True(t, called)
+}

--- a/pkg/timeout/timeout_test.go
+++ b/pkg/timeout/timeout_test.go
@@ -1,0 +1,140 @@
+package timeout_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet/pkg/timeout"
+)
+
+func TestTimeoutZeroDisables(t *testing.T) {
+	t.Parallel()
+
+	m := New(0)
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestTimeoutPasses(t *testing.T) {
+	t.Parallel()
+
+	m := New(time.Second)
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Custom", "yes")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("hello"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+	assert.Equal(t, "yes", w.Header().Get("X-Custom"))
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "hello", string(body))
+}
+
+func TestTimeoutFires(t *testing.T) {
+	t.Parallel()
+
+	m := New(20 * time.Millisecond)
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		// after the timeout has fired, these writes must be swallowed.
+		// Calling WriteHeader/Write also synchronizes with the timeout goroutine
+		// via timeoutRW.mu, so the test can safely observe the recorder afterwards.
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("should be discarded"))
+	}))
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusGatewayTimeout, resp.StatusCode)
+	assert.Contains(t, string(body), "Gateway Timeout")
+	assert.NotContains(t, string(body), "should be discarded")
+}
+
+func TestTimeoutCustomHandler(t *testing.T) {
+	t.Parallel()
+
+	custom := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("custom"))
+	})
+	m := &Timout{Timeout: 20 * time.Millisecond, TimeoutHandler: custom}
+
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		// touch the timeoutRW to synchronize with the timeout goroutine
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	assert.Equal(t, "custom", string(body))
+}
+
+func TestTimeoutHeadersCopied(t *testing.T) {
+	t.Parallel()
+
+	m := New(time.Second)
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Foo", "bar")
+		w.Header().Set("X-Baz", "qux")
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "bar", w.Header().Get("X-Foo"))
+	assert.Equal(t, "qux", w.Header().Get("X-Baz"))
+}
+
+func TestTimeoutWriteWithoutExplicitHeader(t *testing.T) {
+	t.Parallel()
+
+	m := New(time.Second)
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("body"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "body", string(body))
+}

--- a/proxy_internal_test.go
+++ b/proxy_internal_test.go
@@ -81,3 +81,65 @@ func TestParseCIDRs(t *testing.T) {
 		assert.Equal(t, "8.8.0.0/16", ns[1].String())
 	}
 }
+
+func TestParseCIDRsSkipsInvalid(t *testing.T) {
+	t.Parallel()
+
+	ns := parseCIDRs([]string{"not-a-cidr", "1.1.1.1/32", ""})
+	if assert.Len(t, ns, 1) {
+		assert.Equal(t, "1.1.1.1/32", ns[0].String())
+	}
+}
+
+func TestFirstHost(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "1.2.3.4", firstHost("1.2.3.4, 5.6.7.8, 9.9.9.9"))
+	assert.Equal(t, "1.2.3.4", firstHost("1.2.3.4"))
+	assert.Equal(t, "", firstHost(""))
+}
+
+func TestParseHost(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "1.2.3.4", parseHost("1.2.3.4:5678"))
+	assert.Equal(t, "", parseHost("garbage"))
+}
+
+func TestProxyTrustComputesXFFWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.0.0.1:12345"
+	w := httptest.NewRecorder()
+	called := false
+	(&proxy{
+		Trust:                   Trusted(),
+		ComputeFullForwardedFor: true,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			assert.Equal(t, "10.0.0.1", r.Header.Get("X-Forwarded-For"))
+			assert.Equal(t, "10.0.0.1", r.Header.Get("X-Real-Ip"))
+			assert.Equal(t, "http", r.Header.Get("X-Forwarded-Proto"))
+		}),
+	}).ServeHTTP(w, r)
+	assert.True(t, called)
+}
+
+func TestProxyTrustComputesXFFAppendsRemote(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.0.0.1:12345"
+	r.Header.Set("X-Forwarded-For", "203.0.113.5, 1.2.3.4")
+	w := httptest.NewRecorder()
+	(&proxy{
+		Trust:                   Trusted(),
+		ComputeFullForwardedFor: true,
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "203.0.113.5, 1.2.3.4, 10.0.0.1", r.Header.Get("X-Forwarded-For"))
+			// X-Real-Ip is filled from the first hop in XFF since it was empty
+			assert.Equal(t, "203.0.113.5", r.Header.Get("X-Real-Ip"))
+		}),
+	}).ServeHTTP(w, r)
+}


### PR DESCRIPTION
## Summary

Adds unit tests for previously untested packages and root abstractions so the
library has guard-rails around its main contracts.

New test files:

- `pkg/cors` — preflight, restricted origins (allowed/denied), expose headers, panic when origin policy unset, vary headers when restricted
- `pkg/fileserver` — file serving, fallback on miss, directory listing on/off
- `pkg/timeout` — pass-through, timeout firing, custom timeout handler, header copying, implicit `WriteHeader`
- `pkg/router` — prefix routing, root override, empty router fallthrough
- `pkg/logger` — full record encoding, omit-empty, `Disable()`, `Set`/`Get`, canceled context → status 499
- `pkg/h2push` — `LinkPusher` push and noop paths, `PreloadPusher` skip paths
- `pkg/gcp` — `HLBImmediateIP` with varying proxy hop count and edge cases
- `pkg/internal/pool` — buffer size and round-trip
- Root: `Middlewares` ordering & nil skipping, `Cond` with/without `Else`, `Handler`, `MiddlewareFunc`, `Trusted`/`TrustCIDRs`, `Server.Use` behaviors and `ServerContextKey`, `GenerateSelfSignCertificate` defaults & explicit dates, proxy helpers `firstHost`/`parseHost`/`ComputeFullForwardedFor`

## Test plan

- [x] `make` (vet + golangci-lint + `go test -race ./...`) is clean
- [x] All new tests pass under `-race`

https://claude.ai/code/session_01Mooc1eoiqi8b63KjLGKQJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mooc1eoiqi8b63KjLGKQJS)_