### PR TITLE
chore: bump cel-go to v0.28.1 and expand README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,59 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/moonrhythm/parapet)](https://goreportcard.com/report/github.com/moonrhythm/parapet)
 [![GoDoc](https://godoc.org/github.com/moonrhythm/parapet?status.svg)](https://godoc.org/github.com/moonrhythm/parapet)
 
-Reverse Proxy Framework
+A composable reverse proxy framework for Go. Parapet is a library, not a binary: you build your edge or backend by importing the pieces you need and chaining them together with `Use`.
+
+## Install
+
+```sh
+go get github.com/moonrhythm/parapet
+```
+
+Requires Go 1.25 or later.
+
+## Concepts
+
+- **`Middleware`** — anything that satisfies `ServeHandler(http.Handler) http.Handler`. Every feature in this library is a `Middleware`.
+- **`Middlewares`** — an ordered slice of `Middleware`, applied in reverse order so the first `Use` call sits outermost (like an onion).
+- **`Server`** — wraps `http.Server` with a middleware chain and adds TLS, H2C, graceful shutdown (30 s grace, 10 s wait), and reuseport.
+
+Three constructors pick sensible defaults for the role the server plays:
+
+| Constructor | Use for | Notable defaults |
+|---|---|---|
+| `parapet.New()` | General purpose, behind another proxy | Trusts standard private CIDRs, long idle timeout |
+| `parapet.NewFrontend()` | Edge / internet-facing | Read/write/header timeouts, no trusted proxies |
+| `parapet.NewBackend()` | Internal service behind parapet | H2C enabled, trusts private CIDRs |
+
+## Packages
+
+Each subdirectory under `pkg/` is a self-contained middleware:
+
+| Package | What it does |
+|---|---|
+| [`upstream`](pkg/upstream) | Reverse proxy and load balancing (round-robin) over HTTP, H2C, or HTTPS |
+| [`host`](pkg/host) | Virtual-host routing on the `Host` header, with wildcard prefixes |
+| [`location`](pkg/location) | Path routing — exact, prefix, and regexp matchers |
+| [`router`](pkg/router) | Simple URL router |
+| [`block`](pkg/block) | Conditional middleware container — match a request, then apply an inner chain |
+| [`ratelimit`](pkg/ratelimit) | Fixed-window, concurrent, and leaky-bucket limiters |
+| [`compress`](pkg/compress) | Content-negotiated compression (Gzip, Brotli, Deflate) |
+| [`body`](pkg/body) | Request body limiting and buffering |
+| [`headers`](pkg/headers) | Request/response header manipulation |
+| [`cors`](pkg/cors) | CORS handling |
+| [`hsts`](pkg/hsts) | `Strict-Transport-Security` (with preload) |
+| [`redirect`](pkg/redirect) | HTTPS, www/non-www, and arbitrary redirects |
+| [`requestid`](pkg/requestid) | Inject and propagate a request ID |
+| [`logger`](pkg/logger) | Structured request logging |
+| [`healthz`](pkg/healthz) | Health-check endpoint |
+| [`timeout`](pkg/timeout) | Per-request deadline enforcement |
+| [`fileserver`](pkg/fileserver) | Static file serving |
+| [`stripprefix`](pkg/stripprefix) | Strip a URL path prefix before proxying |
+| [`authn`](pkg/authn) | JWT and basic-auth helpers |
+| [`waf`](pkg/waf) | Web application firewall driven by CEL expressions, hot reloadable |
+| [`prom`](pkg/prom) | Prometheus metrics |
+| [`h2push`](pkg/h2push) | HTTP/2 server push helpers |
+| [`gcp`](pkg/gcp), [`gcs`](pkg/gcs), [`stackdriver`](pkg/stackdriver), [`trace`](pkg/trace) | Google Cloud integrations and distributed tracing |
 
 ## Example
 
@@ -41,12 +93,12 @@ func main() {
 	s.Use(body.BufferRequest())
 	s.Use(compress.Gzip())
 	s.Use(compress.Br())
-	
+
 	// sites
 	s.Use(example())
 	s.Use(mysite())
 	s.Use(wordpress())
-	
+
 	// health check
 	{
 		l := location.Exact("/healthz")
@@ -54,10 +106,9 @@ func main() {
 		l.Use(healthz.New())
 		s.Use(l)
 	}
-	
+
 	s.Addr = ":8080"
-	err := s.ListenAndServe()
-	if err != nil {
+	if err := s.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -73,13 +124,12 @@ func example() parapet.Middleware {
 		{Host: "example1.default.svc.cluster.local:8080", Transport: &upstream.H2CTransport{}},
 		{Host: "myexamplebackuphost.com", Transport: &upstream.HTTPSTransport{}},
 	})))
-	
 	return h
 }
 
 func mysite() parapet.Middleware {
 	var hs parapet.Middlewares
-	
+
 	{
 		h := host.New("mysiteaaa.io", "www.mysiteaaa.io")
 		h.Use(ratelimit.FixedWindowPerSecond(15))
@@ -98,19 +148,17 @@ func mysite() parapet.Middleware {
 			"x-guploader-uploadid",
 		))
 		h.Use(upstream.SingleHost("storage.googleapis.com", &upstream.HTTPSTransport{}))
-	
 		hs.Use(h)
 	}
-	
+
 	{
 		h := host.New("mail.mysiteaaa.io")
 		h.Use(redirect.HTTPS())
 		h.Use(hsts.Preload())
 		h.Use(redirect.To("https://mail.google.com/a/mysiteaaa.io", 302))
-	
 		hs.Use(h)
 	}
-	
+
 	return hs
 }
 
@@ -120,20 +168,50 @@ func wordpress() parapet.Middleware {
 	h.Use(redirect.HTTPS())
 	h.Use(hsts.Preload())
 	h.Use(redirect.NonWWW())
-	
+
 	backend := upstream.SingleHost("wordpress.default.svc.cluster.local", &upstream.HTTPTransport{})
-	
+
 	l := location.RegExp(`\.(js|css|svg|png|jp(e)?g|gif)$`)
 	l.Use(headers.SetResponse("Cache-Control", "public, max-age=31536000"))
 	l.Use(backend)
 	h.Use(l)
-	
+
 	h.Use(backend)
-	
+
 	return h
 }
 ```
 
+## WAF with CEL rules
+
+The [`waf`](pkg/waf) package runs [CEL](https://github.com/google/cel-go) expressions against incoming requests. Rules compile inside `SetRules`, so the hot path never parses or type-checks, and rules can be swapped atomically at runtime.
+
+```go
+import (
+	"net/http"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/waf"
+)
+
+w := waf.New()
+_ = w.SetRules([]waf.Rule{{
+	ID:         "block-sqli",
+	Expression: `request.query.contains("' OR '1'='1") || request.path.matches("(?i).*union.*select.*")`,
+	Action:     waf.ActionBlock,
+	Status:     http.StatusForbidden,
+}})
+
+s := parapet.NewFrontend()
+s.Use(w)
+```
+
+See [`pkg/waf/doc.go`](pkg/waf/doc.go) for the full list of `request.*` fields and helper functions exposed to expressions.
+
+## Trusted proxies
+
+Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes from a trusted CIDR. Configure trust with `TrustCIDRs(...)` or accept the defaults from `Trusted()` (standard private and loopback ranges). Servers created with `NewFrontend()` start with no trusted proxies by default.
+
 ## License
 
-MIT
+[MIT](LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/brotli/go/cbrotli v0.0.0-20240919160234-350100a5bb9d
-	github.com/google/cel-go v0.27.0
+	github.com/google/cel-go v0.28.1
 	github.com/kavu/go_reuseport v1.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
@@ -67,6 +67,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/brotli/go/cbrotli v0.0.0-20240919160234-350100a5bb9d h1:0TtWOcS8HiKXekwxgCCYDcFN8n2DaFVRmb7SQwvFNA4=
 github.com/google/brotli/go/cbrotli v0.0.0-20240919160234-350100a5bb9d/go.mod h1:nOPhAkwVliJdNTkj3gXpljmWhjc4wCaVqbMJcPKWP4s=
-github.com/google/cel-go v0.27.0 h1:e7ih85+4qVrBuqQWTW4FKSqZYokVuc3HnhH5keboFTo=
-github.com/google/cel-go v0.27.0/go.mod h1:tTJ11FWqnhw5KKpnWpvW9CJC3Y9GK4EIS0WXnBbebzw=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
## Summary

- Upgrade `github.com/google/cel-go` from v0.27.0 to v0.28.1 (the CEL runtime used by the WAF engine added in #166).
- Rewrite README with install instructions, core concepts (`Middleware`, `Middlewares`, `Server`), a constructor comparison table, a per-package index linking each `pkg/*`, a WAF/CEL example, and a note on trusted-proxy semantics.

## Test plan

- [x] `make` (vet + lint + race tests across all packages) passes after the upgrade
- [ ] Review README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)