### PR TITLE
fix: harden middleware against header, path, and matcher abuse

### DIFF
--- a/pkg/authn/basic.go
+++ b/pkg/authn/basic.go
@@ -16,11 +16,16 @@ var (
 
 // Basic creates new basic auth middleware
 func Basic(username, password string) *BasicAuthenticator {
+	expectedUser := []byte(username)
+	expectedPass := []byte(password)
 	return &BasicAuthenticator{
 		Authenticate: func(_ *http.Request, u, p string) error {
-			ok := u == username &&
-				subtle.ConstantTimeCompare([]byte(p), []byte(password)) == 1
-			if !ok {
+			// Compare both fields in constant time and AND the results, so
+			// that timing reveals neither which field mismatched nor how many
+			// leading bytes matched.
+			userOK := subtle.ConstantTimeCompare([]byte(u), expectedUser)
+			passOK := subtle.ConstantTimeCompare([]byte(p), expectedPass)
+			if userOK&passOK != 1 {
 				return ErrInvalidCredentials
 			}
 			return nil

--- a/pkg/cors/cors.go
+++ b/pkg/cors/cors.go
@@ -47,6 +47,12 @@ func (m CORS) ServeHandler(h http.Handler) http.Handler {
 	if !m.AllowAllOrigins && m.AllowOrigins == nil {
 		panic("cors: AllowOrigins must be set if AllowAllOrigins is false")
 	}
+	if m.AllowAllOrigins && m.AllowCredentials {
+		// Browsers reject Access-Control-Allow-Origin: * combined with
+		// Access-Control-Allow-Credentials: true. Refuse the misconfig
+		// at setup time rather than silently emitting a broken policy.
+		panic("cors: AllowCredentials cannot be combined with AllowAllOrigins; set AllowOrigins instead")
+	}
 
 	preflightHeaders := make(http.Header)
 	headers := make(http.Header)

--- a/pkg/cors/cors_test.go
+++ b/pkg/cors/cors_test.go
@@ -71,7 +71,7 @@ func TestCORSPreflight(t *testing.T) {
 
 	called := false
 	m := &CORS{
-		AllowAllOrigins:  true,
+		AllowOrigins:     AllowOrigins("https://example.com"),
 		AllowMethods:     []string{"GET", "POST"},
 		AllowHeaders:     []string{"Content-Type", "Authorization"},
 		ExposeHeaders:    []string{"X-Custom"},
@@ -89,11 +89,23 @@ func TestCORSPreflight(t *testing.T) {
 
 	assert.False(t, called, "preflight should not invoke downstream")
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "https://example.com", w.Header().Get("Access-Control-Allow-Origin"))
 	assert.Equal(t, "GET,POST", w.Header().Get("Access-Control-Allow-Methods"))
 	assert.Equal(t, "Content-Type,Authorization", w.Header().Get("Access-Control-Allow-Headers"))
 	assert.Equal(t, "true", w.Header().Get("Access-Control-Allow-Credentials"))
 	assert.Equal(t, "7200", w.Header().Get("Access-Control-Max-Age"))
+}
+
+func TestCORSPanicsOnAllowAllWithCredentials(t *testing.T) {
+	t.Parallel()
+
+	m := &CORS{
+		AllowAllOrigins:  true,
+		AllowCredentials: true,
+	}
+	assert.Panics(t, func() {
+		m.ServeHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	})
 }
 
 func TestCORSExposeHeadersOnNonPreflight(t *testing.T) {

--- a/pkg/fileserver/fileserver.go
+++ b/pkg/fileserver/fileserver.go
@@ -3,6 +3,8 @@ package fileserver
 import (
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 )
 
 // FileServer serves file
@@ -42,17 +44,56 @@ func (fs *fileSystem) Open(name string) (http.File, error) {
 		return nil, err
 	}
 
+	// Reject any opened path whose resolved real path escapes the configured
+	// root through a symlink. http.Dir cleans ".." but transparently follows
+	// symlinks via os.Open.
+	if osf, ok := f.(*os.File); ok {
+		if err := fs.checkInsideRoot(osf.Name()); err != nil {
+			f.Close()
+			return nil, err
+		}
+	}
+
 	if !fs.listDir {
 		fi, err := f.Stat()
 		if err != nil {
+			f.Close()
 			return nil, err
 		}
 		if fi.IsDir() {
+			f.Close()
 			return nil, os.ErrNotExist
 		}
 	}
 
 	return f, nil
+}
+
+func (fs *fileSystem) checkInsideRoot(target string) error {
+	realRoot, err := resolveReal(fs.root)
+	if err != nil {
+		return err
+	}
+	realTarget, err := resolveReal(target)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(realRoot, realTarget)
+	if err != nil {
+		return os.ErrNotExist
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return os.ErrNotExist
+	}
+	return nil
+}
+
+func resolveReal(p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(abs)
 }
 
 type responseWriter struct {

--- a/pkg/fileserver/fileserver_test.go
+++ b/pkg/fileserver/fileserver_test.go
@@ -89,6 +89,59 @@ func TestFileServerDirectoryListingDisabled(t *testing.T) {
 	assert.True(t, called, "directory should fall through to handler")
 }
 
+func TestFileServerRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	outside := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	linkPath := filepath.Join(root, "escape.txt")
+	if err := os.Symlink(filepath.Join(outside, "secret.txt"), linkPath); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	m := New(root)
+	called := false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	r := httptest.NewRequest("GET", "/escape.txt", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called, "symlink escaping the root must fall through to the not-found handler")
+}
+
+func TestFileServerAllowsInternalSymlink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "real.txt"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(root, "real.txt"), filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	m := New(root)
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("fallback should not run")
+	}))
+
+	r := httptest.NewRequest("GET", "/link.txt", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body, _ := io.ReadAll(w.Body)
+	assert.Equal(t, "hi", string(body))
+}
+
 func TestFileServerListDirectoryEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/host/cidr.go
+++ b/pkg/host/cidr.go
@@ -3,21 +3,26 @@ package host
 import (
 	"net"
 	"net/http"
+	"strconv"
 
 	"github.com/moonrhythm/parapet/pkg/block"
 )
 
-// NewCIDR creates new CIDR host matcher block
+// NewCIDR creates new CIDR host matcher block.
+//
+// Panics on any unparsable CIDR so a configuration typo cannot silently
+// collapse the matcher to an empty (always-false) set.
 func NewCIDR(pattern ...string) *block.Block {
-	var nets []*net.IPNet
-	for _, p := range pattern {
-		_, n, _ := net.ParseCIDR(p)
-		if n != nil {
-			nets = append(nets, n)
-		}
-	}
-	if len(nets) == 0 {
+	if len(pattern) == 0 {
 		return block.New(func(_ *http.Request) bool { return false })
+	}
+	nets := make([]*net.IPNet, 0, len(pattern))
+	for _, p := range pattern {
+		_, n, err := net.ParseCIDR(p)
+		if err != nil {
+			panic("host: invalid CIDR " + strconv.Quote(p) + ": " + err.Error())
+		}
+		nets = append(nets, n)
 	}
 
 	return block.New(func(r *http.Request) bool {

--- a/pkg/host/cidr_test.go
+++ b/pkg/host/cidr_test.go
@@ -27,7 +27,6 @@ func TestCIDR(t *testing.T) {
 		{"2rd Match", []string{"10.55.55.55/32", "10.0.0.0/8"}, "10.0.0.2", true},
 		{"Not Matched", []string{"10.0.1.1/32"}, "10.0.1.2", false},
 		{"Not Matched Hostname", []string{"10.0.1.1/32"}, "localhost", false},
-		{"Invalid CIDR", []string{"10.0.1.1"}, "10.0.1.1", false},
 	}
 
 	for _, c := range cases {
@@ -53,4 +52,15 @@ func TestCIDR(t *testing.T) {
 			assert.NotEqual(t, c.Matched, falled)
 		})
 	}
+}
+
+func TestCIDRPanicsOnInvalid(t *testing.T) {
+	t.Parallel()
+
+	assert.Panics(t, func() {
+		NewCIDR("10.0.1.1") // missing prefix length
+	})
+	assert.Panics(t, func() {
+		NewCIDR("10.0.0.0/8", "not-a-cidr")
+	})
 }

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"net"
 	"net/http"
 	"strings"
 
@@ -9,10 +10,10 @@ import (
 
 // New creates new host block
 func New(host ...string) *block.Block {
-	// build host map
+	// build host map (normalized: lowercase, no port, no trailing dot)
 	hostMap := make(map[string]bool)
 	for _, x := range host {
-		hostMap[x] = true
+		hostMap[normalizeHost(x)] = true
 	}
 
 	if len(host) == 0 {
@@ -24,25 +25,45 @@ func New(host ...string) *block.Block {
 	}
 
 	return block.New(func(r *http.Request) bool {
+		h := normalizeHost(r.Host)
+
 		// exact match
-		if hostMap[r.Host] {
+		if hostMap[h] {
 			return true
 		}
 
 		// wildcard subdomains
-		host := r.Host
-		for host != "" {
-			i := strings.Index(host, ".")
+		for h != "" {
+			i := strings.Index(h, ".")
 			if i <= 0 {
 				break
 			}
 
-			if hostMap["*"+host[i:]] {
+			if hostMap["*"+h[i:]] {
 				return true
 			}
-			host = host[i+1:]
+			h = h[i+1:]
 		}
 
 		return false
 	})
+}
+
+// normalizeHost lowercases the host, strips any :port, and strips a single
+// trailing dot. The matcher is meant to be safe regardless of whether the
+// optional ToLower / StripPort middlewares are installed upstream.
+func normalizeHost(h string) string {
+	h = strings.ToLower(h)
+	if strings.Contains(h, ":") {
+		if host, _, err := net.SplitHostPort(h); err == nil {
+			h = host
+		} else if strings.HasPrefix(h, "[") && strings.HasSuffix(h, "]") {
+			// bare bracketed IPv6 literal without a port; SplitHostPort
+			// rejects it, so unwrap manually so it normalizes the same way
+			// as the "[::1]:8080" form.
+			h = h[1 : len(h)-1]
+		}
+	}
+	h = strings.TrimSuffix(h, ".")
+	return h
 }

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -34,6 +34,12 @@ func TestHost(t *testing.T) {
 		{"Edge case #2", []string{"moonrhythm.io"}, ".com", false},
 		{"Edge case #3", []string{"moonrhythm.io"}, ".", false},
 		{"Edge case #4", []string{"moonrhythm.io"}, "", false},
+		{"Case insensitive request host", []string{"moonrhythm.io"}, "MoonRhythm.IO", true},
+		{"Case insensitive config host", []string{"MoonRhythm.IO"}, "moonrhythm.io", true},
+		{"Strip port from request host", []string{"moonrhythm.io"}, "moonrhythm.io:8080", true},
+		{"Strip trailing dot from request host", []string{"moonrhythm.io"}, "moonrhythm.io.", true},
+		{"Strip port wildcard", []string{"*.moonrhythm.io"}, "www.moonrhythm.io:443", true},
+		{"IPv6 with port", []string{"[::1]"}, "[::1]:8080", true},
 	}
 
 	for _, c := range cases {

--- a/pkg/location/prefix.go
+++ b/pkg/location/prefix.go
@@ -7,13 +7,28 @@ import (
 	"github.com/moonrhythm/parapet/pkg/block"
 )
 
-// Prefix creates new prefix location matcher block
+// Prefix creates new prefix location matcher block.
+//
+// Matching only succeeds on a path-segment boundary: pattern "/admin"
+// matches "/admin" and "/admin/anything" but not "/adminxyz".
 func Prefix(pattern string) *block.Block {
 	if pattern == "" {
 		return block.New(nil)
 	}
 
 	return block.New(func(r *http.Request) bool {
-		return strings.HasPrefix(r.URL.Path, pattern)
+		p := r.URL.Path
+		if !strings.HasPrefix(p, pattern) {
+			return false
+		}
+		if len(p) == len(pattern) {
+			return true
+		}
+		// pattern already ends with "/" → the next char is part of the sub-path
+		if pattern[len(pattern)-1] == '/' {
+			return true
+		}
+		// otherwise the next char must be a path separator
+		return p[len(pattern)] == '/'
 	})
 }

--- a/pkg/location/prefix_test.go
+++ b/pkg/location/prefix_test.go
@@ -21,10 +21,12 @@ func TestPrefixMatcher(t *testing.T) {
 		Matched bool
 	}{
 		{"Exact Matched", "/path1", "/path1", true},
-		{"Prefix Matched", "/path1", "/path123", true},
+		{"Prefix Sub-path Matched", "/path1", "/path1/sub", true},
 		{"Prefix Slash Matched", "/path1/", "/path1/123", true},
 		{"Catch-all Matched", "", "/path", true},
 		{"Unmatched", "/path1", "/path2", false},
+		{"Boundary not crossed", "/path1", "/path123", false},
+		{"Boundary not crossed underscore", "/admin", "/admin_export", false},
 	}
 
 	for _, c := range cases {

--- a/pkg/requestid/requestid.go
+++ b/pkg/requestid/requestid.go
@@ -31,6 +31,10 @@ func New() *RequestID {
 // DefaultHeader is the default request, response header
 const DefaultHeader = header.XRequestID
 
+// maxClientRequestIDLen caps the length of a client-supplied request id so a
+// caller cannot pass an unbounded blob into logs/upstream headers.
+const maxClientRequestIDLen = 128
+
 // ServeHandler implements middleware interface
 func (m RequestID) ServeHandler(h http.Handler) http.Handler {
 	if m.Header == "" {
@@ -40,7 +44,7 @@ func (m RequestID) ServeHandler(h http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		id := header.Get(r.Header, m.Header)
-		if id == "" || !m.TrustProxy {
+		if id == "" || !m.TrustProxy || !isValidRequestID(id) {
 			id = uuid.Must(uuid.NewV4()).String()
 			header.Set(r.Header, m.Header, id)
 		}
@@ -49,4 +53,24 @@ func (m RequestID) ServeHandler(h http.Handler) http.Handler {
 
 		h.ServeHTTP(w, r)
 	})
+}
+
+// isValidRequestID accepts only a conservative charset so a client cannot
+// inject control characters or oversized values into logs and upstream headers.
+func isValidRequestID(s string) bool {
+	if s == "" || len(s) > maxClientRequestIDLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c == '-' || c == '_' || c == '.' || c == ':' || c == '+' || c == '=' || c == '/':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/requestid/requestid_test.go
+++ b/pkg/requestid/requestid_test.go
@@ -3,6 +3,7 @@ package requestid_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,6 +72,37 @@ func TestRequestID(t *testing.T) {
 		w := httptest.NewRecorder()
 		m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.NotEqual(t, r.Header.Get(DefaultHeader), value)
+		})).ServeHTTP(w, r)
+		assert.NotEqual(t, value, w.Header().Get(DefaultHeader))
+	})
+
+	t.Run("Reject invalid characters even with TrustProxy", func(t *testing.T) {
+		cases := []string{
+			"bad value with space",
+			"crlf\r\ninjection",
+			"tab\there",
+			"<script>",
+		}
+		for _, value := range cases {
+			m := RequestID{TrustProxy: true}
+			r := httptest.NewRequest("GET", "/", nil)
+			r.Header.Set(DefaultHeader, value)
+			w := httptest.NewRecorder()
+			m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.NotEqual(t, value, r.Header.Get(DefaultHeader), "input=%q", value)
+			})).ServeHTTP(w, r)
+			assert.NotEqual(t, value, w.Header().Get(DefaultHeader))
+		}
+	})
+
+	t.Run("Reject oversized id even with TrustProxy", func(t *testing.T) {
+		value := strings.Repeat("a", 129)
+		m := RequestID{TrustProxy: true}
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set(DefaultHeader, value)
+		w := httptest.NewRecorder()
+		m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.NotEqual(t, value, r.Header.Get(DefaultHeader))
 		})).ServeHTTP(w, r)
 		assert.NotEqual(t, value, w.Header().Get(DefaultHeader))
 	})

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -58,7 +59,12 @@ func (m Upstream) ServeHandler(h http.Handler) http.Handler {
 	var p http.Handler
 	p = &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
-			req.URL.Path = singleJoiningSlash(targetPath.Path, req.URL.Path)
+			// Resolve dot-segments on the request path before joining so that
+			// requests like "/foo/../bar" cannot escape the configured prefix.
+			req.URL.Path = singleJoiningSlash(targetPath.Path, cleanRequestPath(req.URL.Path))
+			// RawPath may no longer correspond to Path after cleaning; clear it
+			// so net/url re-encodes Path on write.
+			req.URL.RawPath = ""
 
 			if targetPath.RawQuery == "" || req.URL.RawQuery == "" {
 				req.URL.RawQuery = targetPath.RawQuery + req.URL.RawQuery
@@ -116,6 +122,23 @@ func (m *Upstream) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp, err := m.Transport.RoundTrip(r)
 	logger.Set(r.Context(), "upstream", r.URL.Host)
 	return resp, err
+}
+
+// cleanRequestPath resolves dot-segments from the request path while
+// preserving a trailing slash. An empty result is normalized to "/".
+func cleanRequestPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	trailing := strings.HasSuffix(p, "/")
+	cleaned := path.Clean(p)
+	if cleaned == "." {
+		cleaned = "/"
+	}
+	if trailing && !strings.HasSuffix(cleaned, "/") {
+		cleaned += "/"
+	}
+	return cleaned
 }
 
 func singleJoiningSlash(a, b string) string {

--- a/pkg/upstream/upstream_test.go
+++ b/pkg/upstream/upstream_test.go
@@ -90,6 +90,47 @@ func TestUpstream(t *testing.T) {
 		assert.True(t, called)
 	})
 
+	t.Run("Dot-segments are resolved before joining prefix", func(t *testing.T) {
+		// httptest.NewRequest parses the target through url.Parse, which
+		// normalizes "/api/../admin" too aggressively for this test;
+		// construct the request manually instead.
+		r := httptest.NewRequest("GET", "/", nil)
+		r.URL.Path = "/foo/../admin"
+		w := httptest.NewRecorder()
+
+		called := false
+		Upstream{
+			Transport: &mockTransport{
+				roundTripFunc: func(r *http.Request) (*http.Response, error) {
+					called = true
+					assert.Equal(t, "/prefix/admin", r.URL.Path)
+					return httptest.NewRecorder().Result(), nil
+				},
+			},
+			Path: "/prefix",
+		}.ServeHandler(nil).ServeHTTP(w, r)
+		assert.True(t, called)
+	})
+
+	t.Run("Traversal cannot escape configured prefix", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		r.URL.Path = "/../../etc/passwd"
+		w := httptest.NewRecorder()
+
+		called := false
+		Upstream{
+			Transport: &mockTransport{
+				roundTripFunc: func(r *http.Request) (*http.Response, error) {
+					called = true
+					assert.Equal(t, "/prefix/etc/passwd", r.URL.Path)
+					return httptest.NewRecorder().Result(), nil
+				},
+			},
+			Path: "/prefix",
+		}.ServeHandler(nil).ServeHTTP(w, r)
+		assert.True(t, called)
+	})
+
 	t.Run("Override Host", func(t *testing.T) {
 		r := httptest.NewRequest("GET", "/", nil)
 		w := httptest.NewRecorder()

--- a/proxy.go
+++ b/proxy.go
@@ -3,6 +3,7 @@ package parapet
 import (
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -110,20 +111,22 @@ func parseHost(s string) string {
 }
 
 func firstHost(s string) string {
-	i := strings.Index(s, ",")
-	if i < 0 {
-		return s
+	if i := strings.Index(s, ","); i >= 0 {
+		s = s[:i]
 	}
-	return s[:i]
+	return strings.TrimSpace(s)
 }
 
 func parseCIDRs(xs []string) []*net.IPNet {
-	var rs []*net.IPNet
+	rs := make([]*net.IPNet, 0, len(xs))
 	for _, x := range xs {
-		_, n, _ := net.ParseCIDR(x)
-		if n != nil {
-			rs = append(rs, n)
+		_, n, err := net.ParseCIDR(x)
+		if err != nil {
+			// Misconfigured trust list silently collapsing to an empty set
+			// is a security footgun; fail fast at setup time.
+			panic("parapet: invalid CIDR " + strconv.Quote(x) + ": " + err.Error())
 		}
+		rs = append(rs, n)
 	}
 	return rs
 }

--- a/proxy_internal_test.go
+++ b/proxy_internal_test.go
@@ -82,13 +82,15 @@ func TestParseCIDRs(t *testing.T) {
 	}
 }
 
-func TestParseCIDRsSkipsInvalid(t *testing.T) {
+func TestParseCIDRsPanicsOnInvalid(t *testing.T) {
 	t.Parallel()
 
-	ns := parseCIDRs([]string{"not-a-cidr", "1.1.1.1/32", ""})
-	if assert.Len(t, ns, 1) {
-		assert.Equal(t, "1.1.1.1/32", ns[0].String())
-	}
+	assert.Panics(t, func() {
+		parseCIDRs([]string{"not-a-cidr"})
+	})
+	assert.Panics(t, func() {
+		parseCIDRs([]string{"1.1.1.1/32", ""})
+	})
 }
 
 func TestFirstHost(t *testing.T) {
@@ -97,6 +99,9 @@ func TestFirstHost(t *testing.T) {
 	assert.Equal(t, "1.2.3.4", firstHost("1.2.3.4, 5.6.7.8, 9.9.9.9"))
 	assert.Equal(t, "1.2.3.4", firstHost("1.2.3.4"))
 	assert.Equal(t, "", firstHost(""))
+	// Leading whitespace from " hop1, hop2" or after split must be stripped.
+	assert.Equal(t, "1.2.3.4", firstHost(" 1.2.3.4 , 5.6.7.8"))
+	assert.Equal(t, "1.2.3.4", firstHost("\t1.2.3.4"))
 }
 
 func TestParseHost(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a batch of security findings turned up during a manual review. Each item is a real, testable behavior change — not a "defense in depth" cleanup.

| # | Area | Change |
|---|---|---|
| 6 | `pkg/host` | Matcher now normalizes host on both config and request side: lowercase, strip `:port` (incl. IPv6 brackets), strip trailing dot. Previously `Host: Admin.Example.com:8080` would bypass an `example.com` rule. |
| 8 | `pkg/requestid` | Trusted client `X-Request-Id` is validated (128-char cap, `[A-Za-z0-9._:\-+=/]`) before being echoed back, forwarded upstream, and written to structured logs. Invalid input gets a fresh UUID. Prevents log poisoning / control-char injection. |
| 9 | `pkg/cors` | Panic at setup time on `AllowAllOrigins && AllowCredentials` — the combination produces a policy browsers reject and is a known footgun. |
| 10 | `pkg/location` | `Prefix("/admin")` no longer matches `/admin_export`; matching is now only on path-segment boundaries. |
| 11 | `pkg/upstream` | Director resolves dot-segments on the request path before joining the configured prefix, so `/foo/../admin` cannot escape `Path: "/prefix"`. |
| 12 | `pkg/fileserver` | `Open` verifies the resolved real path stays inside the resolved root via `filepath.EvalSymlinks`; symlinks that point outside the root are now rejected (`os.ErrNotExist` → falls through to the configured not-found handler). In-root symlinks still work. |
| 18 | `pkg/authn` | Basic auth username compared with `subtle.ConstantTimeCompare` and AND-combined with the password compare, so timing reveals neither which field mismatched nor how many bytes matched. |
| 19 | `proxy.go`, `pkg/host/cidr.go` | `parseCIDRs` / `NewCIDR` panic on unparsable CIDR instead of silently dropping it. The silent-skip behavior fail-opens when the matcher is used as a deny-list. |
| 22 | `proxy.go` | `firstHost` `TrimSpace`s its result so the typical `"hop1, hop2"` form doesn't leak a leading space into `X-Real-IP`. |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (clean)
- [x] `go test -race ./...` — all packages pass
- [x] New tests added for every behavior change (boundary matching, symlink escape, CIDR panic, request-id rejection, CORS panic, dot-segment resolution, etc.)
- [x] Existing tests that documented the old broken semantics are updated, not deleted blindly (e.g. `TestParseCIDRsSkipsInvalid` → `TestParseCIDRsPanicsOnInvalid`; the prefix test that expected `/path1` to match `/path123` is replaced with a boundary-respecting case).

## Notes for reviewers

- A handful of constructors now panic at setup time (CORS, `parseCIDRs`, `NewCIDR`). This is consistent with the existing convention in this repo — e.g. [cors.go:48](https://github.com/moonrhythm/parapet/blob/master/pkg/cors/cors.go) already panics for `AllowOrigins == nil && !AllowAllOrigins`. Misconfig surfaces immediately at boot rather than at the first malicious request.
- The fileserver change uses `filepath.EvalSymlinks` on both the root and the resolved file path so platforms where `t.TempDir()` returns a symlink path (macOS `/var` → `/private/var`) still behave correctly. In-root symlinks intentionally continue to work; only symlinks whose target escapes the root are blocked.
- This PR does **not** address the highest-severity findings from the same review (default `Trusted()` proxy, `InsecureSkipVerify: true` upstream defaults, redirect-via-`Host` open redirect). Those are intentionally out of scope — they're API/default changes that warrant separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)