### PR TITLE
perf(ratelimit): eliminate per-request allocations on hot path

### DIFF
--- a/pkg/ratelimit/fixedwindow.go
+++ b/pkg/ratelimit/fixedwindow.go
@@ -51,8 +51,11 @@ func (b *FixedWindowStrategy) Take(key string) bool {
 	if b.lastWindow != currentWindow {
 		// window outdated, create new window
 		b.lastWindow = currentWindow
-		if len(b.storage) > 0 || b.storage == nil {
+		if b.storage == nil {
 			b.storage = make(map[string]int)
+		} else if len(b.storage) > 0 {
+			// reuse existing map to avoid heap churn at window boundary
+			clear(b.storage)
 		}
 	}
 

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -72,7 +72,19 @@ func (m RateLimiter) ServeHandler(h http.Handler) http.Handler {
 		m.ExceededHandler = defaultExceededHandler
 	}
 
-	modifyRW := m.ReleaseOnWriteHeader || m.ReleaseOnHijacked
+	// Fast path: no response-writer wrapping needed. Avoids allocating a
+	// release closure and an escaped bool on every request.
+	if !m.ReleaseOnWriteHeader && !m.ReleaseOnHijacked {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := m.Key(r)
+			if !m.Strategy.Take(key) {
+				m.ExceededHandler(w, r, m.Strategy.After(key))
+				return
+			}
+			defer m.Strategy.Put(key) // use defer to always put token back when panic
+			h.ServeHTTP(w, r)
+		})
+	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key := m.Key(r)
@@ -80,39 +92,38 @@ func (m RateLimiter) ServeHandler(h http.Handler) http.Handler {
 			m.ExceededHandler(w, r, m.Strategy.After(key))
 			return
 		}
-		released := false
-		release := func() {
-			if released {
-				return
-			}
-			released = true
-			m.Strategy.Put(key)
-		}
-		defer release() // use defer to always put token back when panic
 
-		if modifyRW {
-			nw := responseWriter{
-				ResponseWriter: w,
-			}
-			if m.ReleaseOnWriteHeader {
-				nw.OnWriteHeader = release
-			}
-			if m.ReleaseOnHijacked {
-				nw.OnHijack = release
-			}
-			w = &nw
+		// Release state lives inside the responseWriter, which already
+		// escapes — avoids allocating a separate closure + bool.
+		nw := &responseWriter{
+			ResponseWriter:       w,
+			strategy:             m.Strategy,
+			key:                  key,
+			releaseOnWriteHeader: m.ReleaseOnWriteHeader,
+			releaseOnHijack:      m.ReleaseOnHijacked,
 		}
-
-		h.ServeHTTP(w, r)
+		defer nw.release() // use defer to always put token back when panic
+		h.ServeHTTP(nw, r)
 	})
 }
 
 type responseWriter struct {
 	http.ResponseWriter
-	OnWriteHeader func()
-	OnHijack      func()
+	strategy Strategy
+	key      string
 
-	wroteHeader bool
+	wroteHeader          bool
+	released             bool
+	releaseOnWriteHeader bool
+	releaseOnHijack      bool
+}
+
+func (w *responseWriter) release() {
+	if w.released {
+		return
+	}
+	w.released = true
+	w.strategy.Put(w.key)
 }
 
 func (w *responseWriter) WriteHeader(statusCode int) {
@@ -120,8 +131,8 @@ func (w *responseWriter) WriteHeader(statusCode int) {
 		return
 	}
 	w.wroteHeader = true
-	if w.OnWriteHeader != nil {
-		w.OnWriteHeader()
+	if w.releaseOnWriteHeader {
+		w.release()
 	}
 	w.ResponseWriter.WriteHeader(statusCode)
 }
@@ -155,8 +166,8 @@ func (w *responseWriter) Flush() {
 // Hijack implements Hijacker interface
 func (w *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if nw, ok := w.ResponseWriter.(http.Hijacker); ok {
-		if w.OnHijack != nil {
-			w.OnHijack()
+		if w.releaseOnHijack {
+			w.release()
 		}
 		return nw.Hijack()
 	}


### PR DESCRIPTION
## Summary

The rate-limit middleware allocated a `release` closure **and** an escaped `bool` on every single request — even when `ReleaseOnWriteHeader`/`ReleaseOnHijacked` were unset (the common case). The closure escaped to the heap because it might be assigned to `nw.OnWriteHeader`/`OnHijack` further down the function.

- **Fast path**: when neither release-hook flag is set (the default), `ServeHandler` now uses a plain `defer m.Strategy.Put(key)` — no closure, no escaped bool.
- **Slow path**: the release state (`strategy`, `key`, `released`) is folded into the `responseWriter` struct, which was already going to escape to the heap. The hooks become simple struct-field branches instead of stored func values.
- **FixedWindow**: reuse the storage map across window rotations via `clear()` instead of allocating a fresh map.

## Benchmarks

Intel Xeon @ 2.80 GHz, best-of-3, `-benchtime=3s`:

| Benchmark | Before | After | Δ |
|---|---|---|---|
| `FixedWindow` | 152 ns, 2 allocs, 81 B | 99 ns, **0 allocs**, **0 B** | **−35%** |
| `Concurrent` | 161 ns, 2 allocs, 81 B | 100 ns, **0 allocs**, **0 B** | **−38%** |
| `LeakyBucket` | 160 ns, 2 allocs, 81 B | 103 ns, **0 allocs**, **0 B** | **−36%** |
| `FixedWindowParallel` | 270 ns, 2 allocs, 81 B | 220 ns, **0 allocs**, **0 B** | **−19%** |

The strategy implementations themselves were already lean — all the per-request overhead lived in `ServeHandler`. With the closure gone, every strategy benefits equally.

## Compatibility

- Public API unchanged (`RateLimiter`, `Strategy`, `ExceededHandler`, `ClientIP`, all constructors).
- `responseWriter` is unexported; gained internal fields but the surface (`WriteHeader`/`Write`/`Hijack`/`Flush`/`Push`/`Unwrap`) is identical.
- Existing semantics preserved: `Put` is still called via `defer` (panic-safe), `release` is still idempotent, and `WriteHeader` / `Hijack` still trigger early release when the flags are set.

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run` — 0 issues
- [x] Existing `ratelimit_test.go` covers fast path, slow path (`Release on write header`), exceed path, and `Hijack` — all still pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01QEsBtaQjhP8mH4TDbHD3ha)_