### PR TITLE
perf: skip canonical-key scans and slice allocs on hot path

### DIFF
--- a/pkg/headers/add.go
+++ b/pkg/headers/add.go
@@ -8,10 +8,7 @@ import "net/http"
 // appends directly to the header map, skipping CanonicalMIMEHeaderKey
 // in http.Header.Add.
 func AddRequest(headerpairs ...string) *RequestInterceptor {
-	hs := buildHeaders(headerpairs)
-	for i := range hs {
-		hs[i].Key = http.CanonicalHeaderKey(hs[i].Key)
-	}
+	hs := buildCanonicalHeaders(headerpairs)
 
 	return InterceptRequest(func(h http.Header) {
 		for _, p := range hs {
@@ -22,10 +19,7 @@ func AddRequest(headerpairs ...string) *RequestInterceptor {
 
 // AddResponse creates new response interceptor for add headers.
 func AddResponse(headerpairs ...string) *ResponseInterceptor {
-	hs := buildHeaders(headerpairs)
-	for i := range hs {
-		hs[i].Key = http.CanonicalHeaderKey(hs[i].Key)
-	}
+	hs := buildCanonicalHeaders(headerpairs)
 
 	return InterceptResponse(func(w ResponseHeaderWriter) {
 		h := w.Header()

--- a/pkg/headers/add.go
+++ b/pkg/headers/add.go
@@ -2,25 +2,35 @@ package headers
 
 import "net/http"
 
-// AddRequest creates new request interceptor for add headers
+// AddRequest creates new request interceptor for add headers.
+//
+// Keys are canonicalized once at construction; the per-request path
+// appends directly to the header map, skipping CanonicalMIMEHeaderKey
+// in http.Header.Add.
 func AddRequest(headerpairs ...string) *RequestInterceptor {
 	hs := buildHeaders(headerpairs)
+	for i := range hs {
+		hs[i].Key = http.CanonicalHeaderKey(hs[i].Key)
+	}
 
 	return InterceptRequest(func(h http.Header) {
 		for _, p := range hs {
-			h.Add(p.Key, p.Value)
+			h[p.Key] = append(h[p.Key], p.Value)
 		}
 	})
 }
 
-// AddResponse creates new response interceptor for add headers
+// AddResponse creates new response interceptor for add headers.
 func AddResponse(headerpairs ...string) *ResponseInterceptor {
 	hs := buildHeaders(headerpairs)
+	for i := range hs {
+		hs[i].Key = http.CanonicalHeaderKey(hs[i].Key)
+	}
 
 	return InterceptResponse(func(w ResponseHeaderWriter) {
 		h := w.Header()
 		for _, p := range hs {
-			h.Add(p.Key, p.Value)
+			h[p.Key] = append(h[p.Key], p.Value)
 		}
 	})
 }

--- a/pkg/headers/del.go
+++ b/pkg/headers/del.go
@@ -2,21 +2,27 @@ package headers
 
 import "net/http"
 
-// DeleteRequest creates new request interceptor for delete headers
+// DeleteRequest creates new request interceptor for delete headers.
+//
+// Keys are canonicalized once at construction so the per-request path
+// can use a direct map delete instead of http.Header.Del, which scans
+// the key through CanonicalMIMEHeaderKey on every call.
 func DeleteRequest(headers ...string) *RequestInterceptor {
+	keys := canonKeys(headers)
 	return InterceptRequest(func(h http.Header) {
-		for _, p := range headers {
-			h.Del(p)
+		for _, k := range keys {
+			delete(h, k)
 		}
 	})
 }
 
-// DeleteResponse creates new response interceptor for delete headers
+// DeleteResponse creates new response interceptor for delete headers.
 func DeleteResponse(headers ...string) *ResponseInterceptor {
+	keys := canonKeys(headers)
 	return InterceptResponse(func(w ResponseHeaderWriter) {
 		h := w.Header()
-		for _, p := range headers {
-			h.Del(p)
+		for _, k := range keys {
+			delete(h, k)
 		}
 	})
 }

--- a/pkg/headers/header.go
+++ b/pkg/headers/header.go
@@ -19,21 +19,17 @@ func buildHeaders(pairs []string) []Header {
 	return hs
 }
 
-// canonHeader carries a pre-canonicalized header key and a pre-built
-// single-value slice so the per-request path skips both
-// CanonicalMIMEHeaderKey and the slice allocation in http.Header.Set.
-type canonHeader struct {
-	Key   string
-	Value []string
-}
-
-func buildCanonHeaders(pairs []string) []canonHeader {
-	var hs []canonHeader
-	for i := 1; i < len(pairs); i += 2 {
-		hs = append(hs, canonHeader{
-			Key:   http.CanonicalHeaderKey(pairs[i-1]),
-			Value: []string{pairs[i]},
-		})
+// buildCanonicalHeaders is buildHeaders with the key canonicalized once at
+// construction. Per-request paths can then use direct map operations and skip
+// CanonicalMIMEHeaderKey on every call.
+//
+// Crucially, the per-request path must still allocate a fresh []string{value}
+// for each Set: other middleware (e.g. MapRequest) mutate header value slices
+// in place, so any pre-built slice would leak mutations across requests.
+func buildCanonicalHeaders(pairs []string) []Header {
+	hs := buildHeaders(pairs)
+	for i := range hs {
+		hs[i].Key = http.CanonicalHeaderKey(hs[i].Key)
 	}
 	return hs
 }

--- a/pkg/headers/header.go
+++ b/pkg/headers/header.go
@@ -1,5 +1,7 @@
 package headers
 
+import "net/http"
+
 // Header type
 type Header struct {
 	Key   string
@@ -15,4 +17,33 @@ func buildHeaders(pairs []string) []Header {
 		})
 	}
 	return hs
+}
+
+// canonHeader carries a pre-canonicalized header key and a pre-built
+// single-value slice so the per-request path skips both
+// CanonicalMIMEHeaderKey and the slice allocation in http.Header.Set.
+type canonHeader struct {
+	Key   string
+	Value []string
+}
+
+func buildCanonHeaders(pairs []string) []canonHeader {
+	var hs []canonHeader
+	for i := 1; i < len(pairs); i += 2 {
+		hs = append(hs, canonHeader{
+			Key:   http.CanonicalHeaderKey(pairs[i-1]),
+			Value: []string{pairs[i]},
+		})
+	}
+	return hs
+}
+
+// canonKeys returns canonicalized copies of the input keys for use with
+// direct map operations like delete(h, key).
+func canonKeys(keys []string) []string {
+	out := make([]string, len(keys))
+	for i, k := range keys {
+		out[i] = http.CanonicalHeaderKey(k)
+	}
+	return out
 }

--- a/pkg/headers/set.go
+++ b/pkg/headers/set.go
@@ -4,27 +4,29 @@ import "net/http"
 
 // SetRequest creates new request interceptor for set headers.
 //
-// Keys are canonicalized once at construction; the per-request hot path
-// writes directly to the header map, skipping CanonicalMIMEHeaderKey and
-// the per-call []string{value} allocation that http.Header.Set incurs.
+// Keys are canonicalized once at construction; the per-request path writes
+// directly to the header map, skipping CanonicalMIMEHeaderKey in
+// http.Header.Set. A fresh []string{value} is allocated per request — sharing
+// a pre-built slice would let downstream in-place mutations (e.g. MapRequest)
+// leak across requests.
 func SetRequest(headerpairs ...string) *RequestInterceptor {
-	hs := buildCanonHeaders(headerpairs)
+	hs := buildCanonicalHeaders(headerpairs)
 
 	return InterceptRequest(func(h http.Header) {
 		for _, p := range hs {
-			h[p.Key] = p.Value
+			h[p.Key] = []string{p.Value}
 		}
 	})
 }
 
 // SetResponse creates new response interceptor for set headers.
 func SetResponse(headerpairs ...string) *ResponseInterceptor {
-	hs := buildCanonHeaders(headerpairs)
+	hs := buildCanonicalHeaders(headerpairs)
 
 	return InterceptResponse(func(w ResponseHeaderWriter) {
 		h := w.Header()
 		for _, p := range hs {
-			h[p.Key] = p.Value
+			h[p.Key] = []string{p.Value}
 		}
 	})
 }

--- a/pkg/headers/set.go
+++ b/pkg/headers/set.go
@@ -2,25 +2,29 @@ package headers
 
 import "net/http"
 
-// SetRequest creates new request interceptor for set headers
+// SetRequest creates new request interceptor for set headers.
+//
+// Keys are canonicalized once at construction; the per-request hot path
+// writes directly to the header map, skipping CanonicalMIMEHeaderKey and
+// the per-call []string{value} allocation that http.Header.Set incurs.
 func SetRequest(headerpairs ...string) *RequestInterceptor {
-	hs := buildHeaders(headerpairs)
+	hs := buildCanonHeaders(headerpairs)
 
 	return InterceptRequest(func(h http.Header) {
 		for _, p := range hs {
-			h.Set(p.Key, p.Value)
+			h[p.Key] = p.Value
 		}
 	})
 }
 
-// SetResponse creates new response interceptor for set headers
+// SetResponse creates new response interceptor for set headers.
 func SetResponse(headerpairs ...string) *ResponseInterceptor {
-	hs := buildHeaders(headerpairs)
+	hs := buildCanonHeaders(headerpairs)
 
 	return InterceptResponse(func(w ResponseHeaderWriter) {
 		h := w.Header()
 		for _, p := range hs {
-			h.Set(p.Key, p.Value)
+			h[p.Key] = p.Value
 		}
 	})
 }

--- a/pkg/headers/set_test.go
+++ b/pkg/headers/set_test.go
@@ -3,12 +3,34 @@ package headers_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/moonrhythm/parapet/pkg/headers"
 )
+
+// SetRequest must allocate a fresh value slice per request: downstream
+// middleware like MapRequest mutates header value slices in place, so any
+// shared/pre-built slice would leak mutations across requests.
+func TestSetRequestNoSharedSliceAcrossRequests(t *testing.T) {
+	t.Parallel()
+
+	set := SetRequest("X-Custom", "value")
+	mapUpper := MapRequest("X-Custom", strings.ToUpper)
+	chain := set.ServeHandler(mapUpper.ServeHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})))
+
+	// First request: MapRequest mutates the value slice in place.
+	chain.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+
+	// Second request through the same SetRequest must still see "value".
+	got := ""
+	set.ServeHandler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("X-Custom")
+	})).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+	assert.Equal(t, "value", got)
+}
 
 func TestSetRequest(t *testing.T) {
 	t.Parallel()

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -54,8 +54,10 @@ func New(host ...string) *block.Block {
 // optional ToLower / StripPort middlewares are installed upstream.
 //
 // The fast path detects an already-normalized input (lowercase ASCII, no
-// port, no trailing dot, no bracket) in a single scan and returns it
-// unchanged. The slow path falls back to the general handling.
+// colon, no trailing dot) in a single scan and returns it unchanged. The
+// slow path falls back to the general handling and matches the original
+// behavior — port stripping and bracket unwrapping only run when the input
+// actually contains a ':'.
 func normalizeHost(h string) string {
 	if h == "" {
 		return h
@@ -63,32 +65,31 @@ func normalizeHost(h string) string {
 
 	var (
 		needsLower bool
-		colonIdx   = -1
+		hasColon   bool
 	)
-	bracket := h[0] == '['
 	n := len(h)
 	for i := 0; i < n; i++ {
 		c := h[i]
 		if c >= 'A' && c <= 'Z' {
 			needsLower = true
 		} else if c == ':' {
-			colonIdx = i
+			hasColon = true
 		}
 	}
 	trailingDot := h[n-1] == '.'
 
-	if !needsLower && !bracket && colonIdx < 0 && !trailingDot {
+	if !needsLower && !hasColon && !trailingDot {
 		return h
 	}
 
-	return normalizeHostSlow(h, bracket, colonIdx, trailingDot, needsLower)
+	return normalizeHostSlow(h, hasColon, trailingDot, needsLower)
 }
 
-func normalizeHostSlow(h string, bracket bool, colonIdx int, trailingDot, needsLower bool) string {
-	if bracket || colonIdx >= 0 {
+func normalizeHostSlow(h string, hasColon, trailingDot, needsLower bool) string {
+	if hasColon {
 		if host, _, err := net.SplitHostPort(h); err == nil {
 			h = host
-		} else if bracket && h[len(h)-1] == ']' {
+		} else if h[0] == '[' && h[len(h)-1] == ']' {
 			// bare bracketed IPv6 literal without a port; SplitHostPort
 			// rejects it, so unwrap manually so it normalizes the same way
 			// as the "[::1]:8080" form.

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/moonrhythm/parapet/pkg/block"
 )
@@ -74,6 +75,12 @@ func normalizeHost(h string) string {
 			needsLower = true
 		} else if c == ':' {
 			hasColon = true
+		} else if c >= utf8.RuneSelf {
+			// Non-ASCII byte: defer to the Unicode-aware strings.ToLower in
+			// the slow path. A byte scan can't tell whether the rune has a
+			// lowercase form, and the original always called ToLower, so
+			// force the slow path to preserve that behavior.
+			needsLower = true
 		}
 	}
 	trailingDot := h[n-1] == '.'

--- a/pkg/host/host.go
+++ b/pkg/host/host.go
@@ -34,7 +34,7 @@ func New(host ...string) *block.Block {
 
 		// wildcard subdomains
 		for h != "" {
-			i := strings.Index(h, ".")
+			i := strings.IndexByte(h, '.')
 			if i <= 0 {
 				break
 			}
@@ -52,18 +52,59 @@ func New(host ...string) *block.Block {
 // normalizeHost lowercases the host, strips any :port, and strips a single
 // trailing dot. The matcher is meant to be safe regardless of whether the
 // optional ToLower / StripPort middlewares are installed upstream.
+//
+// The fast path detects an already-normalized input (lowercase ASCII, no
+// port, no trailing dot, no bracket) in a single scan and returns it
+// unchanged. The slow path falls back to the general handling.
 func normalizeHost(h string) string {
-	h = strings.ToLower(h)
-	if strings.Contains(h, ":") {
+	if h == "" {
+		return h
+	}
+
+	var (
+		needsLower bool
+		colonIdx   = -1
+	)
+	bracket := h[0] == '['
+	n := len(h)
+	for i := 0; i < n; i++ {
+		c := h[i]
+		if c >= 'A' && c <= 'Z' {
+			needsLower = true
+		} else if c == ':' {
+			colonIdx = i
+		}
+	}
+	trailingDot := h[n-1] == '.'
+
+	if !needsLower && !bracket && colonIdx < 0 && !trailingDot {
+		return h
+	}
+
+	return normalizeHostSlow(h, bracket, colonIdx, trailingDot, needsLower)
+}
+
+func normalizeHostSlow(h string, bracket bool, colonIdx int, trailingDot, needsLower bool) string {
+	if bracket || colonIdx >= 0 {
 		if host, _, err := net.SplitHostPort(h); err == nil {
 			h = host
-		} else if strings.HasPrefix(h, "[") && strings.HasSuffix(h, "]") {
+		} else if bracket && h[len(h)-1] == ']' {
 			// bare bracketed IPv6 literal without a port; SplitHostPort
 			// rejects it, so unwrap manually so it normalizes the same way
 			// as the "[::1]:8080" form.
 			h = h[1 : len(h)-1]
 		}
+		// after splitting, the trailing dot (if any) might have been
+		// stripped along with the port; recompute.
+		if len(h) > 0 {
+			trailingDot = h[len(h)-1] == '.'
+		}
 	}
-	h = strings.TrimSuffix(h, ".")
+	if trailingDot {
+		h = h[:len(h)-1]
+	}
+	if needsLower {
+		h = strings.ToLower(h)
+	}
 	return h
 }

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -40,6 +40,11 @@ func TestHost(t *testing.T) {
 		{"Strip trailing dot from request host", []string{"moonrhythm.io"}, "moonrhythm.io.", true},
 		{"Strip port wildcard", []string{"*.moonrhythm.io"}, "www.moonrhythm.io:443", true},
 		{"IPv6 with port", []string{"[::1]"}, "[::1]:8080", true},
+		// Malformed bracketed-but-colonless inputs must round-trip through the
+		// matcher with brackets intact, matching the pre-optimization behavior
+		// (the bracket-unwrap path only fires when a port separator is present).
+		{"Bracketed no colon configured matches itself", []string{"[host]"}, "[host]", true},
+		{"Bracketed no colon does not strip brackets", []string{"host"}, "[host]", false},
 	}
 
 	for _, c := range cases {

--- a/pkg/host/host_test.go
+++ b/pkg/host/host_test.go
@@ -36,6 +36,11 @@ func TestHost(t *testing.T) {
 		{"Edge case #4", []string{"moonrhythm.io"}, "", false},
 		{"Case insensitive request host", []string{"moonrhythm.io"}, "MoonRhythm.IO", true},
 		{"Case insensitive config host", []string{"MoonRhythm.IO"}, "moonrhythm.io", true},
+		// Non-ASCII case folding: the only uppercase char is non-ASCII, so the
+		// ASCII A-Z scan alone would miss it. Must still fold like the original
+		// unconditional strings.ToLower.
+		{"Case insensitive non-ASCII request host", []string{"éxample.io"}, "Éxample.io", true},
+		{"Case insensitive non-ASCII config host", []string{"Éxample.io"}, "éxample.io", true},
 		{"Strip port from request host", []string{"moonrhythm.io"}, "moonrhythm.io:8080", true},
 		{"Strip trailing dot from request host", []string{"moonrhythm.io"}, "moonrhythm.io.", true},
 		{"Strip port wildcard", []string{"*.moonrhythm.io"}, "www.moonrhythm.io:443", true},

--- a/proxy.go
+++ b/proxy.go
@@ -65,17 +65,12 @@ func (m *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.distrust(w, r)
 }
 
-// Pre-built single-value slices for the constant proto values let us assign
-// directly into the header map without allocating a fresh []string{value} on
-// every request.
-var (
-	xfpHTTP  = []string{"http"}
-	xfpHTTPS = []string{"https"}
-)
-
 func (m *proxy) trust(w http.ResponseWriter, r *http.Request) {
 	// The header constants are already in canonical form, so we read and write
 	// the header map directly to skip CanonicalMIMEHeaderKey on every access.
+	// Each write allocates its own []string{value}: downstream middleware
+	// (e.g. headers.MapRequest) may mutate header value slices in place, so
+	// any shared/global slice would leak across requests.
 	h := r.Header
 
 	// TODO: handle compute full forwarded for from server
@@ -94,9 +89,9 @@ func (m *proxy) trust(w http.ResponseWriter, r *http.Request) {
 
 	if headerFirst(h, headerXForwardedProto) == "" {
 		if r.TLS == nil {
-			h[headerXForwardedProto] = xfpHTTP
+			h[headerXForwardedProto] = []string{"http"}
 		} else {
-			h[headerXForwardedProto] = xfpHTTPS
+			h[headerXForwardedProto] = []string{"https"}
 		}
 	}
 
@@ -106,14 +101,15 @@ func (m *proxy) trust(w http.ResponseWriter, r *http.Request) {
 func (m *proxy) distrust(w http.ResponseWriter, r *http.Request) {
 	h := r.Header
 	remoteIP := parseHost(r.RemoteAddr)
-	v := []string{remoteIP}
-	h[headerXForwardedFor] = v
-	h[headerXRealIP] = v
+	// Independent slices for XFF and XRI: sharing one would couple in-place
+	// mutations of one header to the other within a single request.
+	h[headerXForwardedFor] = []string{remoteIP}
+	h[headerXRealIP] = []string{remoteIP}
 
 	if r.TLS == nil {
-		h[headerXForwardedProto] = xfpHTTP
+		h[headerXForwardedProto] = []string{"http"}
 	} else {
-		h[headerXForwardedProto] = xfpHTTPS
+		h[headerXForwardedProto] = []string{"https"}
 	}
 
 	m.Handler.ServeHTTP(w, r)

--- a/proxy.go
+++ b/proxy.go
@@ -65,26 +65,38 @@ func (m *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.distrust(w, r)
 }
 
+// Pre-built single-value slices for the constant proto values let us assign
+// directly into the header map without allocating a fresh []string{value} on
+// every request.
+var (
+	xfpHTTP  = []string{"http"}
+	xfpHTTPS = []string{"https"}
+)
+
 func (m *proxy) trust(w http.ResponseWriter, r *http.Request) {
+	// The header constants are already in canonical form, so we read and write
+	// the header map directly to skip CanonicalMIMEHeaderKey on every access.
+	h := r.Header
+
 	// TODO: handle compute full forwarded for from server
 	if m.ComputeFullForwardedFor {
 		remoteIP := parseHost(r.RemoteAddr)
-		if p := r.Header.Get(headerXForwardedFor); p == "" {
-			r.Header.Set(headerXForwardedFor, remoteIP)
+		if p := headerFirst(h, headerXForwardedFor); p == "" {
+			h[headerXForwardedFor] = []string{remoteIP}
 		} else {
-			r.Header.Set(headerXForwardedFor, p+", "+remoteIP)
+			h[headerXForwardedFor] = []string{p + ", " + remoteIP}
 		}
 	}
 
-	if r.Header.Get(headerXRealIP) == "" {
-		r.Header.Set(headerXRealIP, firstHost(r.Header.Get(headerXForwardedFor)))
+	if headerFirst(h, headerXRealIP) == "" {
+		h[headerXRealIP] = []string{firstHost(headerFirst(h, headerXForwardedFor))}
 	}
 
-	if r.Header.Get(headerXForwardedProto) == "" {
+	if headerFirst(h, headerXForwardedProto) == "" {
 		if r.TLS == nil {
-			r.Header.Set(headerXForwardedProto, "http")
+			h[headerXForwardedProto] = xfpHTTP
 		} else {
-			r.Header.Set(headerXForwardedProto, "https")
+			h[headerXForwardedProto] = xfpHTTPS
 		}
 	}
 
@@ -92,17 +104,30 @@ func (m *proxy) trust(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *proxy) distrust(w http.ResponseWriter, r *http.Request) {
+	h := r.Header
 	remoteIP := parseHost(r.RemoteAddr)
-	r.Header.Set(headerXForwardedFor, remoteIP)
-	r.Header.Set(headerXRealIP, remoteIP)
+	v := []string{remoteIP}
+	h[headerXForwardedFor] = v
+	h[headerXRealIP] = v
 
 	if r.TLS == nil {
-		r.Header.Set(headerXForwardedProto, "http")
+		h[headerXForwardedProto] = xfpHTTP
 	} else {
-		r.Header.Set(headerXForwardedProto, "https")
+		h[headerXForwardedProto] = xfpHTTPS
 	}
 
 	m.Handler.ServeHTTP(w, r)
+}
+
+// headerFirst returns the first value for a header key without going through
+// http.Header.Get's CanonicalMIMEHeaderKey path. Callers must pass an
+// already-canonical key.
+func headerFirst(h http.Header, key string) string {
+	v := h[key]
+	if len(v) == 0 {
+		return ""
+	}
+	return v[0]
 }
 
 func parseHost(s string) string {

--- a/proxy_bench_test.go
+++ b/proxy_bench_test.go
@@ -1,0 +1,64 @@
+package parapet
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The proxy middleware runs on every request the server handles, so its
+// per-request cost — header reads/writes for X-Forwarded-For, X-Real-Ip,
+// X-Forwarded-Proto — sets a floor on the framework's overhead.
+
+var benchNoopHandler = http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+func benchProxy(b *testing.B, p *proxy, prep func(r *http.Request)) {
+	b.Helper()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "10.0.0.1:12345"
+	if prep != nil {
+		prep(r)
+	}
+	w := newBenchProxyRW()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.ServeHTTP(w, r)
+	}
+}
+
+// BenchmarkProxyDistrust covers the most common shape: the caller is not a
+// trusted proxy, so X-Forwarded-* are unconditionally overwritten from
+// r.RemoteAddr / r.TLS. Three header writes.
+func BenchmarkProxyDistrust(b *testing.B) {
+	p := &proxy{Handler: benchNoopHandler}
+	benchProxy(b, p, nil)
+}
+
+// BenchmarkProxyTrustNoHeaders measures the trust path when the upstream
+// did not supply X-Forwarded-* at all — every read returns empty, so the
+// branch writes all three headers.
+func BenchmarkProxyTrustNoHeaders(b *testing.B) {
+	p := &proxy{Trust: Trusted(), Handler: benchNoopHandler}
+	benchProxy(b, p, nil)
+}
+
+// BenchmarkProxyTrustWithHeaders measures the trust path when the upstream
+// already supplied X-Forwarded-* — the reads short-circuit each branch and
+// no writes happen. This is the typical edge → backend hop cost.
+func BenchmarkProxyTrustWithHeaders(b *testing.B) {
+	p := &proxy{Trust: Trusted(), Handler: benchNoopHandler}
+	benchProxy(b, p, func(r *http.Request) {
+		r.Header.Set("X-Forwarded-For", "203.0.113.5")
+		r.Header.Set("X-Real-Ip", "203.0.113.5")
+		r.Header.Set("X-Forwarded-Proto", "https")
+	})
+}
+
+type benchProxyRW struct{ h http.Header }
+
+func newBenchProxyRW() *benchProxyRW                  { return &benchProxyRW{h: make(http.Header)} }
+func (w *benchProxyRW) Header() http.Header           { return w.h }
+func (w *benchProxyRW) Write(p []byte) (int, error)   { return io.Discard.Write(p) }
+func (w *benchProxyRW) WriteHeader(int)               {}

--- a/proxy_internal_test.go
+++ b/proxy_internal_test.go
@@ -148,3 +148,45 @@ func TestProxyTrustComputesXFFAppendsRemote(t *testing.T) {
 		}),
 	}).ServeHTTP(w, r)
 }
+
+// The proxy must not share value slices between X-Forwarded-For and
+// X-Real-Ip in distrust: downstream code that mutates one header's slice
+// in place (or appends with cap room) must not surprise the other.
+func TestProxyDistrustWritesIndependentSlices(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.0.0.1:12345"
+	(&proxy{
+		Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			xff := r.Header["X-Forwarded-For"]
+			xri := r.Header["X-Real-Ip"]
+			if assert.Len(t, xff, 1) && assert.Len(t, xri, 1) {
+				// Mutating XFF's backing array must not leak into XRI.
+				xff[0] = "mutated"
+				assert.Equal(t, "10.0.0.1", xri[0])
+			}
+		}),
+	}).ServeHTTP(httptest.NewRecorder(), r)
+}
+
+// The proxy must not write package-global slices into r.Header — any
+// downstream in-place mutation would corrupt every future request.
+func TestProxyXForwardedProtoIsNotGlobalSlice(t *testing.T) {
+	t.Parallel()
+
+	r1 := httptest.NewRequest("GET", "/", nil)
+	r1.RemoteAddr = "10.0.0.1:12345"
+	(&proxy{Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		v := r.Header["X-Forwarded-Proto"]
+		if assert.Len(t, v, 1) {
+			v[0] = "mutated"
+		}
+	})}).ServeHTTP(httptest.NewRecorder(), r1)
+
+	r2 := httptest.NewRequest("GET", "/", nil)
+	r2.RemoteAddr = "10.0.0.2:12345"
+	(&proxy{Handler: http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "http", r.Header.Get("X-Forwarded-Proto"))
+	})}).ServeHTTP(httptest.NewRecorder(), r2)
+}


### PR DESCRIPTION
## Summary

Reduce per-request overhead in the framework's hottest middlewares — the proxy
header handling, the `headers` Set/Add/Delete interceptors, and `host` matching —
by precomputing the canonical header keys once at construction and taking a
single-pass fast path in host normalization.

> **Note:** an earlier revision of this branch also shared/pre-built the header
> *value* slices to drop allocations. That was **unsafe** and has been reverted
> (`fee2199`); see Correctness below. This description reflects the current code.

### What's slow today

- `http.Header.{Get,Set,Add,Del}` runs `CanonicalMIMEHeaderKey` on every call.
  The `headers.SetRequest/AddRequest/DeleteRequest` middlewares already have
  constant keys at construction time, and the proxy hard-codes its keys in
  canonical form — paying for the canonical scan on every request is pure
  overhead.
- `host.normalizeHost` calls `strings.ToLower` + `strings.Contains` +
  `net.SplitHostPort` + `TrimSuffix` on every request, even though the
  overwhelmingly common case is a host that is already lowercase, has no port,
  and has no trailing dot.

### Changes

- `pkg/headers`: canonicalize keys once via `buildCanonicalHeaders` / `canonKeys`
  at setup; per-request paths use direct map ops (`h[k] = ...`, `delete(h, k)`)
  instead of `http.Header.{Set,Add,Del}`. Set/Add still allocate a fresh
  `[]string{value}` per request (required — see Correctness).
- `proxy.go`: `trust`/`distrust` read/write the header map directly against the
  already-canonical constants via a `headerFirst` helper. Each write allocates
  its own slice.
- `pkg/host/host.go`: `normalizeHost` gains a single-pass scan that returns an
  already-normalized host unchanged; the slow path runs `SplitHostPort` /
  bracket-unwrap / `ToLower` only when needed. Non-ASCII bytes route to the
  Unicode-aware slow path so case-folding parity with the original is preserved
  (`11b4faa`).
- Added `proxy_bench_test.go` covering distrust, trust-with-headers, and
  trust-no-headers.

### Measured impact

Apple M1 Ultra, `-count=6`, benchstat medians (master → this branch):

| Benchmark | Before | After | Delta |
|---|---|---|---|
| `headers.SetRequest` | 86.6 ns, 32 B, 2 allocs | 53.9 ns, 32 B, 2 allocs | **-38%** |
| `headers.SetResponse` | 131.2 ns, 80 B, 3 allocs | 78.8 ns, 80 B, 3 allocs | **-40%** |
| `headers.DeleteRequest` | 77.8 ns, 16 B, 1 alloc | 9.5 ns, 0 B, 0 allocs | **-88%** |
| `headers.DeleteResponse` | 58.0 ns, 48 B, 1 alloc | 33.8 ns, 48 B, 1 alloc | **-42%** |
| `host.ExactMatch` | 27.7 ns, 0 allocs | 26.6 ns, 0 allocs | **-4%** |
| `host.WildcardShallow` | 53.2 ns, 0 allocs | 50.6 ns, 0 allocs | **-5%** |
| `host.WildcardDeep` | 127.4 ns, 0 allocs | 122.1 ns, 0 allocs | **-4%** |
| `host.Miss` | 157.5 ns, 0 allocs | 150.4 ns, 0 allocs | **-5%** |

`Set` keeps its allocations on purpose: the fresh per-request `[]string{value}`
is a correctness requirement, not missed overhead. `Delete` drops to zero allocs
because a direct `delete(h, k)` replaces `http.Header.Del`.

New proxy benchmarks (no prior baseline):

- `ProxyDistrust`: 81.3 ns, 48 B, 3 allocs (one slice each for XFF / XRI / proto)
- `ProxyTrustNoHeaders`: 52.2 ns, 16 B, 1 alloc
- `ProxyTrustWithHeaders`: 19.5 ns, 0 allocs (all reads short-circuit)

> `headers.Add{Request,Response}` benchmarks are intentionally omitted from the
> table: they append to a header map reused across iterations, so the value
> slice grows unbounded and the per-op numbers are not meaningful.

### Correctness

- **Header value slices must be freshly allocated per request.** Other
  middleware mutate header value slices in place — `pkg/headers/map.go`
  `MapRequest` does `h[header][i] = ...` — so any pre-built or shared slice would
  leak mutations across requests. `SetRequest`/`SetResponse` and the proxy's
  `trust`/`distrust` therefore allocate a fresh `[]string{value}` on every write,
  and `distrust` uses independent slices for `X-Forwarded-For` and `X-Real-Ip`.
  No package-global value slices. Guarded by:
  - `pkg/headers/set_test.go::TestSetRequestNoSharedSliceAcrossRequests`
  - `proxy_internal_test.go::TestProxyDistrustWritesIndependentSlices`
  - `proxy_internal_test.go::TestProxyXForwardedProtoIsNotGlobalSlice`
- **Header keys.** Pre-canonicalizing keys matches `http.Header.{Set,Add,Del}`
  semantics exactly (those methods canonicalize before map access). The proxy
  constants `headerXForwardedFor` / `headerXForwardedProto` / `headerXRealIP` are
  already spelled in canonical form, so direct map access is identical.
- **`host.normalizeHost`.** The fast path only fires when the input is
  verifiably already canonical (no `A-Z`, no non-ASCII byte, no `:`, no trailing
  `.`); everything else takes the slow path, which preserves the original
  `SplitHostPort` + bracketed-IPv6 + trailing-dot + `strings.ToLower` handling.
  Non-ASCII bytes are routed to the slow path specifically so Unicode case
  folding still happens — a byte scan can't tell whether a rune has a lowercase
  form. `TestHost` covers case-insensitivity (ASCII and non-ASCII), port
  stripping, trailing dots, IPv6, and brackets-intact inputs.

## Test plan

- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (0 issues)
- [x] Benchmark deltas confirmed with benchstat against master on the same host

---
_Generated by [Claude Code](https://claude.com/claude-code)_
