### PR TITLE
perf: opt-in Share*Slice fields for constant header value slices

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,23 +214,34 @@ Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes fro
 
 ## Performance tuning
 
-`Server.EnableSharedProtoSlice()` makes that server's proxy write a single
-shared `[]string` for `X-Forwarded-Proto` instead of allocating a fresh slice
-per request, saving one allocation on every request that sets the header (~16%
-on the distrust path in the proxy benchmarks). It is off by default and scoped
-to the server it is called on.
+`Server.ShareProtoSlice` makes that server's proxy write a single shared
+`[]string` for `X-Forwarded-Proto` instead of allocating a fresh slice per
+request, saving one allocation on every request that sets the header (~16% on
+the distrust path in the proxy benchmarks). It is off by default and scoped to
+the server.
 
 This is **unsafe if any middleware mutates the `X-Forwarded-Proto` value slice in
 place** — e.g. `headers.MapRequest("X-Forwarded-Proto", …)` or code doing
 `r.Header["X-Forwarded-Proto"][0] = …` — because the mutation would corrupt the
 shared slice for every subsequent request. Appending (`headers.AddRequest`) is
-safe. Enable it only if you control the whole middleware chain, and call it once
-at startup before serving (it panics if called after the server starts):
+safe. Enable it only if you control the whole middleware chain, and set it
+before serving:
 
 ```go
 s := parapet.NewBackend()
-s.EnableSharedProtoSlice()
+s.ShareProtoSlice = true
 ```
+
+The `hsts` and `authn` middlewares expose the same opt-in for their fixed
+response headers via a `ShareValueSlice` field (off by default), sharing one
+`Strict-Transport-Security` / `WWW-Authenticate` slice across requests:
+
+```go
+hsts.HSTS{MaxAge: 365 * 24 * time.Hour, ShareValueSlice: true}
+```
+
+The same caveat applies — only enable it when nothing in the chain mutates that
+response header's value slice in place.
 
 ## License
 

--- a/pkg/authn/authn.go
+++ b/pkg/authn/authn.go
@@ -13,6 +13,13 @@ type Authenticator struct {
 	Type         string
 	Authenticate func(*http.Request) error
 	Forbidden    func(w http.ResponseWriter, r *http.Request, err error)
+
+	// ShareValueSlice writes the WWW-Authenticate value from a single slice
+	// shared across requests instead of allocating one per unauthenticated
+	// response. Type is fixed at construction, so this is safe as long as
+	// nothing mutates the response header value slice in place. Off by
+	// default; see header.SetShared.
+	ShareValueSlice bool
 }
 
 // ServeHandler implements middleware interface
@@ -26,10 +33,21 @@ func (m Authenticator) ServeHandler(h http.Handler) http.Handler {
 		}
 	}
 
+	// When sharing is enabled, WWW-Authenticate is fixed at construction, so
+	// build the value slice once and share it across unauthenticated responses.
+	var wwwAuthenticate []string
+	if m.Type != "" && m.ShareValueSlice {
+		wwwAuthenticate = []string{m.Type}
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := m.Authenticate(r); err != nil {
 			if m.Type != "" {
-				header.Set(w.Header(), header.WWWAuthenticate, m.Type)
+				if m.ShareValueSlice {
+					header.SetShared(w.Header(), header.WWWAuthenticate, wwwAuthenticate)
+				} else {
+					header.Set(w.Header(), header.WWWAuthenticate, m.Type)
+				}
 			}
 			m.Forbidden(w, r, err)
 			return

--- a/pkg/authn/authn_test.go
+++ b/pkg/authn/authn_test.go
@@ -24,4 +24,40 @@ func TestAuthenticator(t *testing.T) {
 		})).ServeHTTP(w, r)
 		assert.True(t, called)
 	})
+
+	deny := func(*http.Request) error { return assert.AnError }
+
+	t.Run("WWW-Authenticate set on failure (default, fresh slice)", func(t *testing.T) {
+		m := Authenticator{Type: "Bearer", Authenticate: deny}
+		handler := m.ServeHandler(http.NotFoundHandler())
+
+		w1 := httptest.NewRecorder()
+		handler.ServeHTTP(w1, httptest.NewRequest("GET", "/", nil))
+		w2 := httptest.NewRecorder()
+		handler.ServeHTTP(w2, httptest.NewRequest("GET", "/", nil))
+
+		v1 := w1.Header()["Www-Authenticate"]
+		v2 := w2.Header()["Www-Authenticate"]
+		if assert.Len(t, v1, 1) && assert.Len(t, v2, 1) {
+			assert.Equal(t, "Bearer", v1[0])
+			assert.NotSame(t, &v1[0], &v2[0])
+		}
+	})
+
+	t.Run("ShareValueSlice shares WWW-Authenticate across failures", func(t *testing.T) {
+		m := Authenticator{Type: "Bearer", Authenticate: deny, ShareValueSlice: true}
+		handler := m.ServeHandler(http.NotFoundHandler())
+
+		w1 := httptest.NewRecorder()
+		handler.ServeHTTP(w1, httptest.NewRequest("GET", "/", nil))
+		w2 := httptest.NewRecorder()
+		handler.ServeHTTP(w2, httptest.NewRequest("GET", "/", nil))
+
+		v1 := w1.Header()["Www-Authenticate"]
+		v2 := w2.Header()["Www-Authenticate"]
+		if assert.Len(t, v1, 1) && assert.Len(t, v2, 1) {
+			assert.Equal(t, "Bearer", v1[0])
+			assert.Same(t, &v1[0], &v2[0])
+		}
+	})
 }

--- a/pkg/header/header.go
+++ b/pkg/header/header.go
@@ -49,6 +49,23 @@ func Set(h http.Header, key, value string) {
 	h[key] = []string{value}
 }
 
+// SetShared assigns a pre-built value slice directly into the header map,
+// sharing its backing array across every call instead of allocating a fresh
+// []string{value} per request the way Set does.
+//
+// Use it only for values fixed at construction time, and only on response
+// headers: the shared slice must be treated as immutable. parapet's own
+// middleware never mutate response header value slices in place — MapResponse
+// rebuilds the slice, and only MapRequest mutates in place (request headers
+// only) — so sharing is safe response-side. The cors middleware shares its
+// precomputed header slices the same way.
+func SetShared(h http.Header, key string, vs []string) {
+	if h == nil {
+		return
+	}
+	h[key] = vs
+}
+
 func Add(h http.Header, key, value string) {
 	if h == nil {
 		return

--- a/pkg/header/header_test.go
+++ b/pkg/header/header_test.go
@@ -1,0 +1,37 @@
+package header_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/moonrhythm/parapet/pkg/header"
+)
+
+func TestSetShared(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets value", func(t *testing.T) {
+		h := http.Header{}
+		header.SetShared(h, "X-Test", []string{"v"})
+		assert.Equal(t, "v", h.Get("X-Test"))
+	})
+
+	t.Run("shares the backing array across calls", func(t *testing.T) {
+		vs := []string{"v"}
+		h1 := http.Header{}
+		h2 := http.Header{}
+		header.SetShared(h1, "X-Test", vs)
+		header.SetShared(h2, "X-Test", vs)
+		// Both maps reference the same slice — no per-call allocation.
+		assert.Same(t, &h1["X-Test"][0], &h2["X-Test"][0])
+		assert.Same(t, &vs[0], &h1["X-Test"][0])
+	})
+
+	t.Run("nil header is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			header.SetShared(nil, "X-Test", []string{"v"})
+		})
+	})
+}

--- a/pkg/hsts/hsts.go
+++ b/pkg/hsts/hsts.go
@@ -13,6 +13,13 @@ type HSTS struct {
 	MaxAge            time.Duration
 	IncludeSubDomains bool
 	Preload           bool
+
+	// ShareValueSlice writes the Strict-Transport-Security value from a single
+	// slice shared across requests instead of allocating one per request. The
+	// value is fixed at construction, so this is safe as long as nothing
+	// mutates the response header value slice in place. Off by default; see
+	// header.SetShared.
+	ShareValueSlice bool
 }
 
 // Default returns default hsts
@@ -41,6 +48,16 @@ func (m HSTS) ServeHandler(h http.Handler) http.Handler {
 	}
 	if m.Preload {
 		hs += "; preload"
+	}
+
+	if m.ShareValueSlice {
+		// Value is fixed for the life of this middleware: build the slice once
+		// and share it across requests instead of allocating per request.
+		hsValue := []string{hs}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			header.SetShared(w.Header(), header.StrictTransportSecurity, hsValue)
+			h.ServeHTTP(w, r)
+		})
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/hsts/hsts_test.go
+++ b/pkg/hsts/hsts_test.go
@@ -43,4 +43,39 @@ func TestHSTS(t *testing.T) {
 		assert.NotEmpty(t, w.Header().Get("Strict-Transport-Security"))
 		assert.Equal(t, "max-age=10; includeSubDomains", w.Header().Get("Strict-Transport-Security"))
 	})
+
+	t.Run("ShareValueSlice shares the value slice across requests", func(t *testing.T) {
+		handler := HSTS{MaxAge: 10 * time.Second, ShareValueSlice: true}.
+			ServeHandler(http.NotFoundHandler())
+
+		w1 := httptest.NewRecorder()
+		handler.ServeHTTP(w1, httptest.NewRequest("GET", "/", nil))
+		w2 := httptest.NewRecorder()
+		handler.ServeHTTP(w2, httptest.NewRequest("GET", "/", nil))
+
+		v1 := w1.Header()["Strict-Transport-Security"]
+		v2 := w2.Header()["Strict-Transport-Security"]
+		if assert.Len(t, v1, 1) && assert.Len(t, v2, 1) {
+			assert.Equal(t, "max-age=10", v1[0])
+			// Same backing array on every request — value slice built once.
+			assert.Same(t, &v1[0], &v2[0])
+		}
+	})
+
+	t.Run("default allocates a fresh value slice per request", func(t *testing.T) {
+		handler := Default().ServeHandler(http.NotFoundHandler())
+
+		w1 := httptest.NewRecorder()
+		handler.ServeHTTP(w1, httptest.NewRequest("GET", "/", nil))
+		w2 := httptest.NewRecorder()
+		handler.ServeHTTP(w2, httptest.NewRequest("GET", "/", nil))
+
+		v1 := w1.Header()["Strict-Transport-Security"]
+		v2 := w2.Header()["Strict-Transport-Security"]
+		if assert.Len(t, v1, 1) && assert.Len(t, v2, 1) {
+			assert.Equal(t, v1[0], v2[0])
+			// Distinct backing arrays — not shared when the flag is off.
+			assert.NotSame(t, &v1[0], &v2[0])
+		}
+	})
 }

--- a/proxy.go
+++ b/proxy.go
@@ -45,7 +45,7 @@ const (
 )
 
 // xfpHTTP and xfpHTTPS back the shared X-Forwarded-Proto slice fast path.
-// They must never be mutated; see Server.EnableSharedProtoSlice.
+// They must never be mutated; see Server.ShareProtoSlice.
 var (
 	xfpHTTP  = []string{"http"}
 	xfpHTTPS = []string{"https"}
@@ -59,12 +59,12 @@ type proxy struct {
 
 	// shareProtoSlice, when set, makes protoValue return a shared package-global
 	// slice for X-Forwarded-Proto instead of allocating a fresh one per request.
-	// Set from Server.EnableSharedProtoSlice when the proxy is built.
+	// Set from Server.ShareProtoSlice when the proxy is built.
 	shareProtoSlice bool
 }
 
 // protoValue returns the X-Forwarded-Proto value slice for the request's
-// scheme. When shareProtoSlice is set (see Server.EnableSharedProtoSlice) it
+// scheme. When shareProtoSlice is set (see Server.ShareProtoSlice) it
 // returns a shared package-global slice; otherwise it allocates a fresh slice
 // (the safe default).
 func (m *proxy) protoValue(isTLS bool) []string {
@@ -101,7 +101,7 @@ func (m *proxy) trust(w http.ResponseWriter, r *http.Request) {
 	// always allocate a fresh []string: downstream middleware (e.g.
 	// headers.MapRequest) may mutate header value slices in place, so sharing
 	// would leak across requests. The X-Forwarded-Proto value comes from a
-	// fixed pair of constants and may be shared via EnableSharedProtoSlice.
+	// fixed pair of constants and may be shared via Server.ShareProtoSlice.
 	h := r.Header
 
 	// TODO: handle compute full forwarded for from server

--- a/proxy_internal_test.go
+++ b/proxy_internal_test.go
@@ -244,10 +244,10 @@ func TestProxySharedProtoSlice(t *testing.T) {
 	}).ServeHTTP(httptest.NewRecorder(), r)
 }
 
-// TestServerEnableSharedProtoSlice covers the Server-level wiring: the setting
-// is per-server, off by default, threaded into the proxy that configHandler
-// builds, and locked once the server starts serving.
-func TestServerEnableSharedProtoSlice(t *testing.T) {
+// TestServerShareProtoSlice covers the Server-level wiring: the setting is
+// per-server, off by default, and threaded into the proxy that configHandler
+// builds.
+func TestServerShareProtoSlice(t *testing.T) {
 	t.Parallel()
 
 	t.Run("off by default", func(t *testing.T) {
@@ -259,18 +259,10 @@ func TestServerEnableSharedProtoSlice(t *testing.T) {
 	})
 
 	t.Run("enabled threads into the proxy", func(t *testing.T) {
-		s := &Server{}
-		s.EnableSharedProtoSlice()
-		assert.True(t, s.sharedProtoSlice)
+		s := &Server{ShareProtoSlice: true}
 		s.configHandler()
 		if p, ok := s.s.Handler.(*proxy); assert.True(t, ok) {
 			assert.True(t, p.shareProtoSlice)
 		}
-	})
-
-	t.Run("panics after serve", func(t *testing.T) {
-		s := &Server{}
-		s.configHandler() // builds the handler, as the first request would
-		assert.Panics(t, func() { s.EnableSharedProtoSlice() })
 	})
 }

--- a/server.go
+++ b/server.go
@@ -20,12 +20,11 @@ import (
 //
 //nolint:govet
 type Server struct {
-	s                http.Server
-	once             sync.Once
-	ms               Middlewares
-	onShutdown       []func()
-	modifyConn       []func(conn net.Conn) net.Conn
-	sharedProtoSlice bool
+	s          http.Server
+	once       sync.Once
+	ms         Middlewares
+	onShutdown []func()
+	modifyConn []func(conn net.Conn) net.Conn
 
 	Addr               string
 	Handler            http.Handler
@@ -44,6 +43,19 @@ type Server struct {
 	ConnState          func(conn net.Conn, state http.ConnState)
 	TLSConfig          *tls.Config
 	BaseContext        func(net.Listener) context.Context
+
+	// ShareProtoSlice makes the proxy write a single shared []string for the
+	// X-Forwarded-Proto header ("http"/"https") instead of allocating a fresh
+	// slice per request, saving one allocation on every request that sets it.
+	//
+	// UNSAFE if any middleware mutates the X-Forwarded-Proto value slice in
+	// place — e.g. headers.MapRequest("X-Forwarded-Proto", …) or code doing
+	// r.Header["X-Forwarded-Proto"][0] = …; the mutation would corrupt the
+	// shared slice for every subsequent request. Appending (headers.AddRequest)
+	// is safe. Enable it only if you control the whole middleware chain. Like
+	// the other fields it must be set before serving; setting it afterwards has
+	// no effect.
+	ShareProtoSlice bool
 }
 
 type serverContextKey struct{}
@@ -61,27 +73,6 @@ func (s *Server) Use(m Middleware) {
 
 func (s *Server) UseFunc(m MiddlewareFunc) {
 	s.Use(m)
-}
-
-// EnableSharedProtoSlice makes the proxy write a single shared []string for the
-// X-Forwarded-Proto header ("http"/"https") instead of allocating a fresh slice
-// on every request, saving one allocation per request that sets the header.
-//
-// This is UNSAFE if any middleware mutates the X-Forwarded-Proto value slice in
-// place — for example headers.MapRequest("X-Forwarded-Proto", …), or any code
-// doing r.Header["X-Forwarded-Proto"][0] = …. Such a write would corrupt the
-// shared slice for every subsequent request across all goroutines. Appending
-// (headers.AddRequest) is safe: the slice has len == cap == 1, so append copies
-// instead of mutating in place.
-//
-// Enable this only if you control the whole middleware chain and are certain
-// X-Forwarded-Proto is never mutated in place. It must be called before the
-// server starts serving; calling it afterwards panics.
-func (s *Server) EnableSharedProtoSlice() {
-	if s.s.Handler != nil {
-		panic("parapet: can not EnableSharedProtoSlice after serve")
-	}
-	s.sharedProtoSlice = true
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -111,7 +102,7 @@ func (s *Server) configHandler() {
 		h = &proxy{
 			Trust:           s.TrustProxy,
 			Handler:         h,
-			shareProtoSlice: s.sharedProtoSlice,
+			shareProtoSlice: s.ShareProtoSlice,
 		}
 		s.s.BaseContext = func(l net.Listener) context.Context {
 			ctx := context.Background()


### PR DESCRIPTION
## Summary

Several middlewares write a header whose value is **fixed at construction** but
re-wrap it in a fresh `[]string{value}` on every response — one allocation per
request for a value that never changes. This exposes slice-sharing as a
consistent, **opt-in struct-field** API across them:

| Surface | What it shares |
|---|---|
| `header.SetShared(h, key, vs)` | helper: assign a pre-built value slice directly |
| `HSTS.ShareValueSlice` | `Strict-Transport-Security` |
| `Authenticator.ShareValueSlice` | `WWW-Authenticate` |
| `Server.ShareProtoSlice` | `X-Forwarded-Proto` (proxy) |

All are `Share*Slice bool` fields, **default off**, keeping the safe
fresh-allocation path.

## Naming unification

This also replaces the unreleased `Server.EnableSharedProtoSlice()` **method**
(from #173) with a plain `Server.ShareProtoSlice` **field**, so the proxy's
X-Forwarded-Proto sharing follows the same `Share*Slice` convention as the new
middleware fields. `EnableSharedProtoSlice` is not in any release tag, so this
is **not a breaking change**.

Consequence: the method's "panic if enabled after serve" guard is gone. The
field now behaves like every other `Server` config field — read once when the
handler is built, silently ignored if set after serving. Consistent with
`Addr`, `TrustProxy`, etc.

## Why opt-in (not default)

A shared value slice is safe only while nothing mutates that response header's
value slice in place. Verified nothing in parapet does: the only in-place
mutation is `pkg/headers/map.go` `MapRequest` (`h[k][i] = …`, request-side);
`MapResponse` rebuilds the slice; and `cors` already shares precomputed response
slices the same way. Gating keeps the default conservative and puts the choice
with the caller who controls the chain.

```go
s := parapet.NewBackend()
s.ShareProtoSlice = true

hsts.HSTS{MaxAge: 365 * 24 * time.Hour, ShareValueSlice: true}
authn.Authenticator{Type: "Bearer", Authenticate: fn, ShareValueSlice: true}
```

## Tests

- `header.SetShared` — value, backing-array sharing, nil-safe.
- `hsts` / `authn` — value slice shared across requests when on, freshly
  allocated when off.
- `Server.ShareProtoSlice` — off by default, threads into the proxy when set.

## Test plan

- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (0 issues)

---
_Generated by [Claude Code](https://claude.com/claude-code)_
