### PR TITLE
perf(authn): add opt-in ShareValueSlice to BasicAuthenticator

### DIFF
--- a/pkg/authn/basic.go
+++ b/pkg/authn/basic.go
@@ -39,6 +39,13 @@ func Basic(username, password string) *BasicAuthenticator {
 type BasicAuthenticator struct {
 	Realm        string
 	Authenticate func(r *http.Request, username, password string) error
+
+	// ShareValueSlice writes the WWW-Authenticate value from a single slice
+	// shared across requests instead of allocating one per unauthenticated
+	// response. The value is fixed at construction (it depends only on Realm),
+	// so this is safe as long as nothing mutates the response header value
+	// slice in place. Off by default; see header.SetShared.
+	ShareValueSlice bool
 }
 
 // ServeHandler implements middleware interface
@@ -49,7 +56,8 @@ func (m BasicAuthenticator) ServeHandler(h http.Handler) http.Handler {
 	}
 
 	return Authenticator{
-		Type: t,
+		Type:            t,
+		ShareValueSlice: m.ShareValueSlice,
 		Authenticate: func(r *http.Request) error {
 			username, password, ok := r.BasicAuth()
 			header.Del(r.Header, header.Authorization)

--- a/pkg/authn/basic_test.go
+++ b/pkg/authn/basic_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	. "github.com/moonrhythm/parapet/pkg/authn"
+	"github.com/moonrhythm/parapet/pkg/header"
 )
 
 func TestBasic(t *testing.T) {
@@ -58,5 +59,28 @@ func TestBasic(t *testing.T) {
 		m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 		assert.Equal(t, `Basic realm="test"`, w.Header().Get("WWW-Authenticate"))
+	})
+
+	t.Run("Share Value Slice", func(t *testing.T) {
+		m := Basic("root", "pass")
+		m.Realm = "test"
+		m.ShareValueSlice = true
+		h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Fail(t, "must not be called")
+		}))
+
+		serve := func() []string {
+			r := httptest.NewRequest("GET", "/", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+			assert.Equal(t, `Basic realm="test"`, w.Header().Get("WWW-Authenticate"))
+			return w.Header()[header.WWWAuthenticate]
+		}
+
+		// the same backing slice is reused across unauthenticated responses
+		v1 := serve()
+		v2 := serve()
+		assert.Same(t, &v1[0], &v2[0])
 	})
 }


### PR DESCRIPTION
## Summary

`BasicAuthenticator` produces a `WWW-Authenticate` value that's fixed at construction (it depends only on `Realm`), but it always delegated to the embedded `Authenticator` **without** forwarding `ShareValueSlice` — so every unauthenticated response allocated a fresh `[]string{value}` on the `Set` path. `Authenticator` and `hsts` already expose this opt-in; this brings `BasicAuthenticator` in line.

## Change

- Add a `ShareValueSlice bool` field to `BasicAuthenticator`.
- Forward it into the `Authenticator` it constructs, so the `WWW-Authenticate` value slice is shared across responses via `header.SetShared` instead of reallocated per request.

Off by default. Safe because the value is constant after construction and parapet never mutates response header value slices in place (only `MapRequest` mutates, request-side).

## Usage

```go
m := authn.Basic("root", "pass")
m.Realm = "admin"
m.ShareValueSlice = true
s.Use(m)
```

## Tests

Adds a `Share Value Slice` subtest asserting the `WWW-Authenticate` value is correct on unauthenticated responses and that the **same backing slice is reused** across requests (`assert.Same`). `make` (vet + lint + test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)