### PR TITLE
feat(authn): add JWT bearer-token authenticator

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,30 @@ s.Use(w)
 
 See [`pkg/waf/doc.go`](pkg/waf/doc.go) for the full list of `request.*` fields and helper functions exposed to expressions.
 
+## JWT authentication
+
+The [`authn`](pkg/authn) package verifies `Authorization: Bearer` tokens with
+`authn.JWT`. The accepted signature algorithms are **pinned by the caller** — a
+token signed with any other algorithm (including `none`) is rejected, which
+prevents algorithm-confusion attacks. The signature, `exp`/`nbf` (with leeway),
+and optional `iss`/`aud` claims are all verified; verified claims are placed on
+the request context for downstream handlers.
+
+```go
+import (
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/moonrhythm/parapet/pkg/authn"
+)
+
+m := authn.JWT([]byte(secret), jose.HS256) // []byte for HMAC; a public key for RS*/ES*/EdDSA
+m.Issuer = "https://issuer.example.com"
+m.Audience = "my-api"
+s.Use(m)
+
+// downstream
+claims, ok := authn.JWTClaimsFromContext(r.Context())
+```
+
 ## Trusted proxies
 
 Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes from a trusted CIDR. Configure trust with `TrustCIDRs(...)` or accept the defaults from `Trusted()` (standard private and loopback ranges). Servers created with `NewFrontend()` start with no trusted proxies by default.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	cloud.google.com/go/storage v1.62.2
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.14
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/google/brotli/go/cbrotli v0.0.0-20240919160234-350100a5bb9d
 	github.com/google/cel-go v0.28.1
@@ -39,7 +40,6 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/pkg/authn/jwt.go
+++ b/pkg/authn/jwt.go
@@ -1,0 +1,161 @@
+package authn
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+
+	"github.com/moonrhythm/parapet/pkg/header"
+)
+
+// ErrInvalidToken is returned when a bearer token is missing required
+// properties, fails signature verification, or fails claim validation.
+var ErrInvalidToken = errors.New("invalid token")
+
+// JWT creates a new JWT bearer-token authentication middleware. It reads the
+// token from the Authorization: Bearer header, verifies its signature against
+// key, and accepts only the listed signature algorithms.
+//
+// The algorithm allowlist is mandatory: a token signed with any other
+// algorithm — including "none" — is rejected. Pinning the algorithms this way
+// prevents algorithm-confusion attacks, where an attacker re-signs a token with
+// an algorithm the verifier did not intend to accept.
+//
+// key may be any type go-jose accepts for verification: []byte for HMAC
+// (HS256/384/512), an *rsa.PublicKey, *ecdsa.PublicKey or ed25519.PublicKey for
+// asymmetric signatures, or a *jose.JSONWebKey / *jose.JSONWebKeySet.
+func JWT(key any, algs ...jose.SignatureAlgorithm) *JWTAuthenticator {
+	return &JWTAuthenticator{
+		Key:        key,
+		Algorithms: algs,
+	}
+}
+
+// JWTAuthenticator middleware
+//
+//nolint:govet
+type JWTAuthenticator struct {
+	// Key verifies the token signature. See JWT for accepted types.
+	Key any
+
+	// Algorithms is the set of accepted signature algorithms. It is required;
+	// when empty every request is rejected.
+	Algorithms []jose.SignatureAlgorithm
+
+	// Issuer and Audience, when set, must match the token's "iss" and "aud"
+	// claims respectively.
+	Issuer   string
+	Audience string
+
+	// Leeway tolerates clock skew when checking the time-based claims "exp",
+	// "nbf" and "iat". Defaults to jwt.DefaultLeeway (1 minute).
+	Leeway time.Duration
+
+	// Realm is reported in the WWW-Authenticate challenge on rejection.
+	Realm string
+
+	// Now overrides the clock used for claim validation. Defaults to time.Now;
+	// mainly useful for tests.
+	Now func() time.Time
+
+	// ShareValueSlice shares the fixed WWW-Authenticate value slice across
+	// rejected responses instead of allocating one per request. See
+	// Authenticator.ShareValueSlice.
+	ShareValueSlice bool
+}
+
+// ServeHandler implements middleware interface
+func (m JWTAuthenticator) ServeHandler(h http.Handler) http.Handler {
+	challenge := "Bearer"
+	if m.Realm != "" {
+		challenge += ` realm="` + url.PathEscape(m.Realm) + `"`
+	}
+
+	leeway := m.Leeway
+	if leeway == 0 {
+		leeway = jwt.DefaultLeeway
+	}
+
+	now := m.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	return Authenticator{
+		Type:            challenge,
+		ShareValueSlice: m.ShareValueSlice,
+		Authenticate: func(r *http.Request) error {
+			raw, ok := bearerToken(r)
+			if !ok {
+				return ErrMissingAuthorization
+			}
+
+			// Fail closed when no algorithm is pinned, rather than trusting
+			// whatever the token header claims.
+			if len(m.Algorithms) == 0 {
+				return ErrInvalidToken
+			}
+
+			tok, err := jwt.ParseSigned(raw, m.Algorithms)
+			if err != nil {
+				return ErrInvalidToken
+			}
+
+			// Claims verifies the signature, then decodes the payload into the
+			// registered-claims struct (for validation) and a map (for
+			// downstream consumers).
+			var claims jwt.Claims
+			all := map[string]any{}
+			if err := tok.Claims(m.Key, &claims, &all); err != nil {
+				return ErrInvalidToken
+			}
+
+			expected := jwt.Expected{Time: now()}
+			if m.Issuer != "" {
+				expected.Issuer = m.Issuer
+			}
+			if m.Audience != "" {
+				expected.AnyAudience = jwt.Audience{m.Audience}
+			}
+			if err := claims.ValidateWithLeeway(expected, leeway); err != nil {
+				return ErrInvalidToken
+			}
+
+			// Expose the verified claims to downstream handlers. Authenticator
+			// reuses this *http.Request when calling the next handler, so update
+			// its context in place.
+			*r = *r.WithContext(context.WithValue(r.Context(), jwtClaimsContextKey{}, all))
+			return nil
+		},
+	}.ServeHandler(h)
+}
+
+// bearerToken extracts the token from an "Authorization: Bearer <token>"
+// header. The scheme is matched case-insensitively per RFC 7235.
+func bearerToken(r *http.Request) (string, bool) {
+	const prefix = "bearer "
+	v := header.Get(r.Header, header.Authorization)
+	if len(v) < len(prefix) || !strings.EqualFold(v[:len(prefix)], prefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(v[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+type jwtClaimsContextKey struct{}
+
+// JWTClaimsFromContext returns the verified JWT claims that JWTAuthenticator
+// stored on the request context, if the request was authenticated by it.
+func JWTClaimsFromContext(ctx context.Context) (map[string]any, bool) {
+	c, ok := ctx.Value(jwtClaimsContextKey{}).(map[string]any)
+	return c, ok
+}

--- a/pkg/authn/jwt_test.go
+++ b/pkg/authn/jwt_test.go
@@ -1,0 +1,193 @@
+package authn_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/moonrhythm/parapet/pkg/authn"
+	"github.com/moonrhythm/parapet/pkg/header"
+)
+
+var (
+	jwtSecret      = []byte("0123456789abcdef0123456789abcdef")
+	jwtOtherSecret = []byte("ffffffffffffffffffffffffffffffff")
+	jwtNow         = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+)
+
+func signToken(t *testing.T, alg jose.SignatureAlgorithm, key any, claims any) string {
+	t.Helper()
+	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: alg, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
+	require.NoError(t, err)
+	raw, err := jwt.Signed(sig).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+// serveJWT runs m over a request carrying token (omitted when empty) and
+// returns the recorder plus the request seen by the protected handler (nil when
+// the handler was not reached).
+func serveJWT(m *JWTAuthenticator, token string) (*httptest.ResponseRecorder, *http.Request) {
+	var got *http.Request
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r
+		w.WriteHeader(http.StatusOK)
+	}))
+	r := httptest.NewRequest("GET", "/", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w, got
+}
+
+func TestJWT(t *testing.T) {
+	t.Parallel()
+
+	fixedNow := func() time.Time { return jwtNow }
+
+	t.Run("Valid", func(t *testing.T) {
+		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{
+			Subject: "user1",
+			Expiry:  jwt.NewNumericDate(jwtNow.Add(time.Hour)),
+		})
+		m := JWT(jwtSecret, jose.HS256)
+		m.Now = fixedNow
+
+		w, got := serveJWT(m, token)
+		assert.Equal(t, http.StatusOK, w.Code)
+		require.NotNil(t, got)
+		claims, ok := JWTClaimsFromContext(got.Context())
+		assert.True(t, ok)
+		assert.Equal(t, "user1", claims["sub"])
+	})
+
+	t.Run("MissingAuthorization", func(t *testing.T) {
+		m := JWT(jwtSecret, jose.HS256)
+		m.Realm = "api"
+		w, got := serveJWT(m, "")
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Nil(t, got)
+		assert.Equal(t, `Bearer realm="api"`, w.Header().Get("WWW-Authenticate"))
+	})
+
+	t.Run("NotBearer", func(t *testing.T) {
+		m := JWT(jwtSecret, jose.HS256)
+		h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Fail(t, "must not be called")
+		}))
+		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("NoAlgorithmsFailsClosed", func(t *testing.T) {
+		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Subject: "user1"})
+		m := JWT(jwtSecret) // no algorithms pinned
+		m.Now = fixedNow
+		w, got := serveJWT(m, token)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Nil(t, got)
+	})
+
+	t.Run("WrongAlgorithmRejected", func(t *testing.T) {
+		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Subject: "user1"})
+		m := JWT(jwtSecret, jose.HS384) // token is HS256
+		m.Now = fixedNow
+		w, _ := serveJWT(m, token)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("BadSignatureRejected", func(t *testing.T) {
+		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Subject: "user1"})
+		m := JWT(jwtOtherSecret, jose.HS256) // verifies with the wrong key
+		m.Now = fixedNow
+		w, _ := serveJWT(m, token)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("ExpiredRejected", func(t *testing.T) {
+		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{
+			Subject: "user1",
+			Expiry:  jwt.NewNumericDate(jwtNow.Add(-time.Hour)),
+		})
+		m := JWT(jwtSecret, jose.HS256)
+		m.Now = fixedNow
+		w, _ := serveJWT(m, token)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("NotYetValidRejected", func(t *testing.T) {
+		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{
+			Subject:   "user1",
+			NotBefore: jwt.NewNumericDate(jwtNow.Add(time.Hour)),
+		})
+		m := JWT(jwtSecret, jose.HS256)
+		m.Now = fixedNow
+		w, _ := serveJWT(m, token)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("Issuer", func(t *testing.T) {
+		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Issuer: "good"})
+		m := JWT(jwtSecret, jose.HS256)
+		m.Now = fixedNow
+		m.Issuer = "good"
+		w, _ := serveJWT(m, token)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		m.Issuer = "other"
+		w, _ = serveJWT(m, token)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("Audience", func(t *testing.T) {
+		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Audience: jwt.Audience{"svc"}})
+		m := JWT(jwtSecret, jose.HS256)
+		m.Now = fixedNow
+		m.Audience = "svc"
+		w, _ := serveJWT(m, token)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		m.Audience = "other"
+		w, _ = serveJWT(m, token)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("ShareValueSlice", func(t *testing.T) {
+		m := JWT(jwtSecret, jose.HS256)
+		m.Realm = "api"
+		m.ShareValueSlice = true
+		h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Fail(t, "must not be called")
+		}))
+
+		serve := func() []string {
+			r := httptest.NewRequest("GET", "/", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+			return w.Header()[header.WWWAuthenticate]
+		}
+
+		v1 := serve()
+		v2 := serve()
+		require.NotEmpty(t, v1)
+		assert.Equal(t, `Bearer realm="api"`, v1[0])
+		assert.Same(t, &v1[0], &v2[0])
+	})
+
+	t.Run("NoClaimsInContextWithout", func(t *testing.T) {
+		_, ok := JWTClaimsFromContext(httptest.NewRequest("GET", "/", nil).Context())
+		assert.False(t, ok)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `authn.JWT` — a middleware that authenticates requests by verifying an `Authorization: Bearer` JWT. The package table already advertised "JWT" but no JWT code existed; this fills that gap.

## Security design

- **Algorithm allowlist is mandatory and caller-pinned.** A token signed with any algorithm not in the list — including `none` — is rejected. This is the primary defense against algorithm-confusion attacks. With no algorithms configured the middleware **fails closed** (rejects every request).
- Verifies the **signature**, the time claims **`exp`/`nbf`/`iat`** (with configurable `Leeway`, default 1 min), and the optional **`iss`/`aud`** claims.
- Errors are collapsed to a generic `ErrInvalidToken` → `401` with a `WWW-Authenticate: Bearer` challenge; no token contents leak into responses.

On success the verified claims are placed on the request context, readable downstream via `authn.JWTClaimsFromContext(ctx)`.

## Dependency

Uses [`github.com/go-jose/go-jose/v4`](https://github.com/go-jose/go-jose), which was **already in the module graph** (indirect). This change only promotes it to a direct dependency — no new dependency tree, and go-jose v4 enforces the explicit-algorithms API that makes this safe.

## Usage

```go
import (
    jose "github.com/go-jose/go-jose/v4"
    "github.com/moonrhythm/parapet/pkg/authn"
)

m := authn.JWT([]byte(secret), jose.HS256) // []byte for HMAC; a public key for RS*/ES*/EdDSA
m.Issuer = "https://issuer.example.com"
m.Audience = "my-api"
s.Use(m)

claims, ok := authn.JWTClaimsFromContext(r.Context())
```

`key` accepts anything go-jose verifies with: `[]byte` (HMAC), `*rsa.PublicKey`, `*ecdsa.PublicKey`, `ed25519.PublicKey`, or a `*jose.JSONWebKey` / `*jose.JSONWebKeySet`. It also inherits `ShareValueSlice` from `Authenticator` for the fixed challenge header.

## Tests

`jwt_test.go` signs real tokens and covers: valid token (+ claims in context), missing/non-Bearer header, fail-closed with no algorithms, wrong algorithm, bad signature, expired, not-yet-valid, issuer match/mismatch, audience match/mismatch, the `WWW-Authenticate` realm, shared value slice, and the empty-context case. `make` (vet + lint + test) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)