### PR TITLE
feat(waf): expose request.country via a Country resolver hook

### DIFF
--- a/pkg/waf/doc.go
+++ b/pkg/waf/doc.go
@@ -38,6 +38,7 @@
 //	request.proto         string  // "HTTP/1.1", "HTTP/2.0", ...
 //	request.scheme        string  // "http" or "https"
 //	request.remote_ip     string  // best-effort client IP (X-Real-IP -> X-Forwarded-For -> RemoteAddr)
+//	request.country       string  // ISO 3166-1 alpha-2 from WAF.Country (e.g. "TH"); "" if unresolved/unset
 //	request.content_length int
 //	request.headers       map<string, string>  // single value per name (canonicalised, lowercase keys)
 //	request.cookies       map<string, string>

--- a/pkg/waf/request.go
+++ b/pkg/waf/request.go
@@ -18,7 +18,7 @@ import (
 // The map keys are deliberately snake_case to match common WAF terminology
 // (e.g. ModSecurity variable names) and to leave camelCase free for any
 // future user-defined fields a caller may merge into the map.
-func buildRequestMap(r *http.Request, body string) map[string]any {
+func buildRequestMap(r *http.Request, body, country string) map[string]any {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
@@ -65,6 +65,7 @@ func buildRequestMap(r *http.Request, body string) map[string]any {
 			"proto":          r.Proto,
 			"scheme":         scheme,
 			"remote_ip":      clientIP(r),
+			"country":        country,
 			"content_length": r.ContentLength,
 			"headers":        headers,
 			"cookies":        cookies,

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -95,6 +95,14 @@ type WAF struct {
 	// to r.Body so downstream handlers can still read it.
 	InspectBody int64
 
+	// Country resolves the client's ISO 3166-1 alpha-2 country code for a
+	// request, exposed to rules as `request.country` (e.g. for GeoIP filtering:
+	// `request.country == "TH"`). The WAF stays storage-agnostic — the caller
+	// supplies the lookup (a GeoIP database, an edge header, etc.). nil leaves
+	// `request.country` as the empty string; the field is always present in the
+	// map, so a rule referencing it never errors on a missing key.
+	Country func(r *http.Request) string
+
 	// rules is an atomic pointer so SetRules can swap the ruleset
 	// lock-free; the request path performs only a single atomic load.
 	rules atomic.Pointer[ruleset]
@@ -252,7 +260,11 @@ func (w *WAF) ServeHandler(h http.Handler) http.Handler {
 			}
 		}
 
-		input := buildRequestMap(r, bodyStr)
+		var country string
+		if w.Country != nil {
+			country = w.Country(r)
+		}
+		input := buildRequestMap(r, bodyStr, country)
 
 		evalTimeout := w.EvalTimeout
 		if evalTimeout <= 0 {

--- a/pkg/waf/waf_test.go
+++ b/pkg/waf/waf_test.go
@@ -462,6 +462,47 @@ func TestEmptyRuleset(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
+func TestRequestCountry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("blocks by resolved country", func(t *testing.T) {
+		w := waf.New()
+		w.Country = func(_ *http.Request) string { return "CN" }
+		require.NoError(t, w.SetRules([]waf.Rule{{
+			ID: "block-cn", Expression: `request.country == "CN"`, Action: waf.ActionBlock,
+		}}))
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w.ServeHandler(passthroughHandler).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("resolver value passes through to a non-matching rule", func(t *testing.T) {
+		w := waf.New()
+		w.Country = func(_ *http.Request) string { return "TH" }
+		require.NoError(t, w.SetRules([]waf.Rule{{
+			ID: "block-cn", Expression: `request.country == "CN"`, Action: waf.ActionBlock,
+		}}))
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w.ServeHandler(passthroughHandler).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("nil resolver leaves request.country empty without a missing-key error", func(t *testing.T) {
+		// `request.country` is always present in the map, so a rule referencing
+		// it evaluates cleanly (no fail-open) and just doesn't match.
+		w := waf.New()
+		require.NoError(t, w.SetRules([]waf.Rule{{
+			ID: "block-cn", Expression: `request.country == "CN"`, Action: waf.ActionBlock,
+		}}))
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w.ServeHandler(passthroughHandler).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
 func TestPriorityOrdering(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds a `WAF.Country func(*http.Request) string` field. When set, its result populates **`request.country`** in the CEL request map, so rules can filter by country — e.g. GeoIP:

```
request.country == "TH"
containsAny(request.country, ["CN", "RU", "KP"])
```

The WAF stays **storage-agnostic**: the caller supplies the lookup (a GeoIP database, an edge header, etc.) — `pkg/waf` gains no new dependency.

Key property: `request.country` is **always present** in the map (empty string when the resolver is nil or returns empty), so a rule referencing it evaluates cleanly and never fails open — unlike reading an absent `request.headers[...]` entry, where the missing key errors and (fail-open) skips the rule. That distinction matters for allow-list rules like "block everything except TH".

Consumer: the parapet-ingress-controller WAF will set this to a MaxMind GeoLite2 lookup on the client IP.

- `request.go`: `buildRequestMap` takes + emits `country`.
- `waf.go`: resolve via `w.Country` before building the map.
- `doc.go` + `waf_test.go` updated. No new deps; `go test ./pkg/waf/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)