### PR TITLE
feat(waf): expose request.asn via an ASN resolver hook

### DIFF
--- a/pkg/waf/doc.go
+++ b/pkg/waf/doc.go
@@ -39,6 +39,7 @@
 //	request.scheme        string  // "http" or "https"
 //	request.remote_ip     string  // best-effort client IP (X-Real-IP -> X-Forwarded-For -> RemoteAddr)
 //	request.country       string  // ISO 3166-1 alpha-2 from WAF.Country (e.g. "TH"); "" if unresolved/unset
+//	request.asn           int     // autonomous system number from WAF.ASN (e.g. 13335); 0 if unresolved/unset
 //	request.content_length int
 //	request.headers       map<string, string>  // single value per name (canonicalised, lowercase keys)
 //	request.cookies       map<string, string>

--- a/pkg/waf/request.go
+++ b/pkg/waf/request.go
@@ -18,7 +18,7 @@ import (
 // The map keys are deliberately snake_case to match common WAF terminology
 // (e.g. ModSecurity variable names) and to leave camelCase free for any
 // future user-defined fields a caller may merge into the map.
-func buildRequestMap(r *http.Request, body, country string) map[string]any {
+func buildRequestMap(r *http.Request, body, country string, asn int64) map[string]any {
 	scheme := "http"
 	if r.TLS != nil {
 		scheme = "https"
@@ -66,6 +66,7 @@ func buildRequestMap(r *http.Request, body, country string) map[string]any {
 			"scheme":         scheme,
 			"remote_ip":      clientIP(r),
 			"country":        country,
+			"asn":            asn,
 			"content_length": r.ContentLength,
 			"headers":        headers,
 			"cookies":        cookies,

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -103,6 +103,16 @@ type WAF struct {
 	// map, so a rule referencing it never errors on a missing key.
 	Country func(r *http.Request) string
 
+	// ASN resolves the client's autonomous system number for a request,
+	// exposed to rules as `request.asn` (e.g. for ASN filtering:
+	// `request.asn == 13335`). The WAF stays storage-agnostic — the caller
+	// supplies the lookup (an IP-to-ASN database, an edge header, etc.). nil
+	// leaves `request.asn` as 0; the field is always present in the map, so a
+	// rule referencing it never errors on a missing key. The value is an int64
+	// (not uint) so rules compare against plain CEL integer literals; valid
+	// ASNs fit losslessly, and 0 — reserved by RFC 7607 — means unresolved.
+	ASN func(r *http.Request) int64
+
 	// rules is an atomic pointer so SetRules can swap the ruleset
 	// lock-free; the request path performs only a single atomic load.
 	rules atomic.Pointer[ruleset]
@@ -264,7 +274,11 @@ func (w *WAF) ServeHandler(h http.Handler) http.Handler {
 		if w.Country != nil {
 			country = w.Country(r)
 		}
-		input := buildRequestMap(r, bodyStr, country)
+		var asn int64
+		if w.ASN != nil {
+			asn = w.ASN(r)
+		}
+		input := buildRequestMap(r, bodyStr, country, asn)
 
 		evalTimeout := w.EvalTimeout
 		if evalTimeout <= 0 {

--- a/pkg/waf/waf_test.go
+++ b/pkg/waf/waf_test.go
@@ -503,6 +503,60 @@ func TestRequestCountry(t *testing.T) {
 	})
 }
 
+func TestRequestASN(t *testing.T) {
+	t.Parallel()
+
+	t.Run("blocks by resolved ASN", func(t *testing.T) {
+		w := waf.New()
+		w.ASN = func(_ *http.Request) int64 { return 13335 }
+		require.NoError(t, w.SetRules([]waf.Rule{{
+			ID: "block-asn", Expression: `request.asn == 13335`, Action: waf.ActionBlock,
+		}}))
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w.ServeHandler(passthroughHandler).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+
+	t.Run("resolver value passes through to a non-matching rule", func(t *testing.T) {
+		w := waf.New()
+		w.ASN = func(_ *http.Request) int64 { return 15169 }
+		require.NoError(t, w.SetRules([]waf.Rule{{
+			ID: "block-asn", Expression: `request.asn == 13335`, Action: waf.ActionBlock,
+		}}))
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w.ServeHandler(passthroughHandler).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("nil resolver leaves request.asn 0 without a missing-key error", func(t *testing.T) {
+		// `request.asn` is always present in the map (0 when unset), so a rule
+		// referencing it evaluates cleanly (no fail-open) and just doesn't match.
+		w := waf.New()
+		require.NoError(t, w.SetRules([]waf.Rule{{
+			ID: "block-asn", Expression: `request.asn == 13335`, Action: waf.ActionBlock,
+		}}))
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w.ServeHandler(passthroughHandler).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("rule can match the unresolved sentinel explicitly", func(t *testing.T) {
+		// request.asn == 0 is a usable predicate ("block traffic we can't
+		// attribute to an AS"), proving the field is present even when unset.
+		w := waf.New()
+		require.NoError(t, w.SetRules([]waf.Rule{{
+			ID: "block-unknown-asn", Expression: `request.asn == 0`, Action: waf.ActionBlock,
+		}}))
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w.ServeHandler(passthroughHandler).ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+}
+
 func TestPriorityOrdering(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds an optional **ASN resolver hook** to the WAF, exposing `request.asn` to rules. Mirrors the `Country` hook from #179.

```go
w.ASN = func(r *http.Request) int64 { /* IP-to-ASN lookup */ }
```
```yaml
- id: block-cloudflare-asn
  expression: request.asn == 13335
  action: block
```

## Why

The WAF builds its CEL `request.*` map internally (`buildRequestMap`), so callers can only surface new fields through dedicated resolver hooks — there's no generic injection path. A downstream consumer (parapet-ingress-controller) wants ASN-based filtering backed by an IP-to-ASN database, which isn't possible without this hook. The WAF stays storage-agnostic: the caller supplies the lookup (a DB, an edge header, etc.).

## Details

- New `WAF.ASN func(r *http.Request) int64` field; `ServeHandler` invokes it and feeds the value into the request map.
- `request.asn` is **always present** (like `request.country`): `0` when the resolver is `nil` or can't place the IP — `0` is reserved by RFC 7607, so it doubles as a usable "unknown AS" predicate (`request.asn == 0`) without ever failing open on a missing key.
- Type is **`int64`, not `uint`**, deliberately: CEL is strict about int-vs-uint, so a uint would force rules to write `request.asn == 13335u`. `int64` lets them use plain integer literals (`request.asn == 13335`), holds every valid ASN losslessly, and matches how `request.content_length` is already exposed.

## Tests

`TestRequestASN` covers: blocks on a matching ASN, passes a non-matching value through, `nil` resolver leaves `request.asn == 0` with no missing-key error, and the explicit `request.asn == 0` sentinel rule. Full `pkg/waf` suite + `go vet` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)