### PR TITLE
feat(compress): add zstd support and per-encoder benchmarks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/brotli/go/cbrotli v0.0.0-20240919160234-350100a5bb9d
 	github.com/google/cel-go v0.28.1
 	github.com/kavu/go_reuseport v1.5.0
+	github.com/klauspost/compress v1.18.5
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tomnomnom/linkheader v0.0.0-20250811210735-e5fe3b51442e

--- a/pkg/compress/br_test.go
+++ b/pkg/compress/br_test.go
@@ -1,0 +1,21 @@
+//go:build cbrotli
+
+package compress_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/moonrhythm/parapet/pkg/compress"
+)
+
+func BenchmarkCompressBr(b *testing.B) {
+	data := make([]byte, 5000)
+	rand.Read(data)
+
+	text := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog. "), 256)
+
+	b.Run("Random", func(b *testing.B) { benchmarkCompress(b, compress.Br(), data) })
+	b.Run("Text", func(b *testing.B) { benchmarkCompress(b, compress.Br(), text) })
+}

--- a/pkg/compress/compress_test.go
+++ b/pkg/compress/compress_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/moonrhythm/parapet/pkg/compress"
@@ -68,21 +69,110 @@ func TestCompress(t *testing.T) {
 	})
 }
 
-func BenchmarkCompress(b *testing.B) {
-	data := make([]byte, 5000)
-	rand.Read(data)
+func TestZstd(t *testing.T) {
+	t.Parallel()
 
-	h := compress.Gzip().ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	smallData := []byte("data")
+	largeData := make([]byte, 5000)
+	rand.Read(largeData)
+
+	makeCompressHandler := func(data []byte) http.Handler {
+		return compress.Zstd().ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+			w.Write(data)
+		}))
+	}
+
+	smallDataHandler := makeCompressHandler(smallData)
+	largeDataHandler := makeCompressHandler(largeData)
+
+	t.Run("Client not support compress", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		largeDataHandler.ServeHTTP(w, r)
+		assert.EqualValues(t, largeData, w.Body.Bytes())
+	})
+
+	t.Run("Response too small", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		r.Header.Set("Accept-Encoding", "gzip, br, zstd")
+		smallDataHandler.ServeHTTP(w, r)
+		assert.EqualValues(t, smallData, w.Body.Bytes())
+	})
+
+	t.Run("Must compress", func(t *testing.T) {
+		r := httptest.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		r.Header.Set("Accept-Encoding", "gzip, br, zstd")
+		largeDataHandler.ServeHTTP(w, r)
+
+		if !assert.Equal(t, "zstd", w.Header().Get("Content-Encoding")) {
+			return
+		}
+
+		ww, _ := zstd.NewReader(w.Body)
+		defer ww.Close()
+		var decompress bytes.Buffer
+		io.Copy(&decompress, ww)
+		assert.EqualValues(t, largeData, decompress.Bytes())
+	})
+}
+
+// benchmarkCompress drives requests through the given compress middleware,
+// reporting throughput and the achieved compression ratio.
+func benchmarkCompress(b *testing.B, c *compress.Compress, data []byte) {
+	b.Helper()
+
+	h := c.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 		w.Write(data)
 	}))
 
+	var compressedLen int
+	b.SetBytes(int64(len(data)))
+	b.ReportAllocs()
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r := httptest.NewRequest("GET", "/", nil)
+		r.Header.Set("Accept-Encoding", c.Encoding)
 		w := httptest.NewRecorder()
-
-		r.Header.Set("Accept-Encoding", "gzip, br")
 		h.ServeHTTP(w, r)
+		compressedLen = w.Body.Len()
+	}
+	b.StopTimer()
+
+	if compressedLen > 0 {
+		b.ReportMetric(float64(len(data))/float64(compressedLen), "ratio")
+	}
+}
+
+func BenchmarkCompress(b *testing.B) {
+	data := make([]byte, 5000)
+	rand.Read(data)
+
+	// random data barely compresses; also exercise repetitive text which is
+	// closer to real-world responses and shows the encoders' ratio differences.
+	text := bytes.Repeat([]byte("the quick brown fox jumps over the lazy dog. "), 256)
+
+	cases := []struct {
+		name string
+		new  func() *compress.Compress
+	}{
+		{"Gzip", compress.Gzip},
+		{"Deflate", compress.Deflate},
+		{"Zstd", compress.Zstd},
+	}
+
+	for _, c := range cases {
+		b.Run(c.name, func(b *testing.B) {
+			b.Run("Random", func(b *testing.B) { benchmarkCompress(b, c.new(), data) })
+			b.Run("Text", func(b *testing.B) { benchmarkCompress(b, c.new(), text) })
+		})
 	}
 }

--- a/pkg/compress/zstd.go
+++ b/pkg/compress/zstd.go
@@ -1,0 +1,28 @@
+package compress
+
+import (
+	"io"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// Zstd creates new zstd compress middleware
+func Zstd() *Compress {
+	return ZstdWithLevel(zstd.SpeedDefault)
+}
+
+func ZstdWithLevel(level zstd.EncoderLevel) *Compress {
+	return &Compress{
+		New: func() Compressor {
+			g, err := zstd.NewWriter(io.Discard, zstd.WithEncoderLevel(level))
+			if err != nil {
+				panic(err)
+			}
+			return g
+		},
+		Encoding:  "zstd",
+		Vary:      defaultCompressVary,
+		Types:     defaultCompressTypes,
+		MinLength: defaultCompressMinLength,
+	}
+}


### PR DESCRIPTION
## Summary

- Add a **zstd** compress middleware (`compress.Zstd()` / `compress.ZstdWithLevel(level)`), backed by `klauspost/compress` — which was already in the module graph. It's pure Go, so unlike brotli it needs no cgo or build tag and is always available.
- The `zstd.Encoder` already satisfies the existing `Compressor` interface (`Write`/`Close`/`Reset(io.Writer)`/`Flush`), so it plugs straight into the package's `sync.Pool` reuse with no wrapper type.
- Promote `github.com/klauspost/compress` from indirect to a direct dependency in `go.mod`.

## Tests & benchmarks

- Added `TestZstd` mirroring the existing gzip test (client-unsupported, too-small, must-compress round-trip).
- Replaced the single Gzip benchmark with a table-driven `BenchmarkCompress` reporting **throughput (MB/s)** and a custom **compression ratio** metric for gzip, deflate, and zstd, over both incompressible random data and repetitive text.
- Added `BenchmarkCompressBr` behind `//go:build cbrotli` (since `Br()` is only a real compressor under that tag).

Sample results (Apple M1 Ultra):

```
Gzip/Text       210.50 MB/s   100.2  ratio   27 allocs/op
Deflate/Text    209.87 MB/s   118.8  ratio   27 allocs/op
Zstd/Text       850.86 MB/s   167.0  ratio   27 allocs/op
```

## Test plan

- [x] `go test -race ./pkg/compress/...`
- [x] `go vet ./pkg/compress/...`
- [x] `golangci-lint run ./pkg/compress/...` (0 issues)
- [x] `go test -run '^$' -bench BenchmarkCompress ./pkg/compress/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)