### PR TITLE
feat(cache): HTTP response-cache middleware with memory + disk backends

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,235 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// cacheLockTimeout bounds how long a concurrent miss waits for the in-flight fill
+// (the "leader") to populate the cache before fetching on its own.
+const cacheLockTimeout = 2 * time.Second
+
+// defaultMaxFileSize is the per-object cap when Options.MaxFileSize <= 0.
+const defaultMaxFileSize = 8 << 20 // 8 MiB
+
+// maxPrimaryVary bounds the in-memory primary->Vary map so a long-tail URL space
+// can't grow it without limit (the storage backend bounds bytes, not this map).
+// When the cap is hit the map is reset; a dropped entry just costs one re-learn
+// (the next fill re-records its Vary), so correctness is unaffected.
+const maxPrimaryVary = 1 << 16
+
+// Options configures the cache middleware.
+type Options struct {
+	// MaxFileSize caps a cacheable response's body. A GET response larger than
+	// this (by Content-Length, or mid-stream) is not cached but still served in
+	// full. Defaults to 8 MiB when <= 0.
+	MaxFileSize int64
+}
+
+// Cache is the HTTP response-cache middleware. It implements parapet.Middleware
+// (ServeHandler). Construct with New, giving it a Storage backend.
+//
+//nolint:govet
+type Cache struct {
+	storage     Storage
+	maxFileSize int64
+
+	pvMu        sync.RWMutex
+	primaryVary map[string][]string // primaryHex -> Vary header names learned from a stored response
+
+	lockMu sync.Mutex
+	locks  map[string]*fillLock // variantHex -> in-flight fill
+}
+
+// fillLock coordinates concurrent misses for one variant: the leader fills, the
+// rest wait on done (then re-read the cache) or time out and fetch on their own.
+type fillLock struct {
+	done chan struct{}
+}
+
+// New builds the cache middleware over the given Storage backend (memory or
+// disk).
+func New(storage Storage, opts Options) *Cache {
+	mfs := opts.MaxFileSize
+	if mfs <= 0 {
+		mfs = defaultMaxFileSize
+	}
+	return &Cache{
+		storage:     storage,
+		maxFileSize: mfs,
+		primaryVary: map[string][]string{},
+		locks:       map[string]*fillLock{},
+	}
+}
+
+// ServeHandler implements parapet.Middleware: it wraps next (the
+// upstream/handler whose responses are cached). A hit short-circuits next; a
+// miss fetches via next and stores.
+func (c *Cache) ServeHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.serve(w, r, next)
+	})
+}
+
+func (c *Cache) serve(w http.ResponseWriter, r *http.Request, next http.Handler) {
+	if !cacheableMethod(r.Method) || isUpgrade(r) {
+		next.ServeHTTP(w, r) // never cache these; no X-Cache header
+		return
+	}
+	primaryHex := c.primaryHash(r)
+	variantHex := c.variantHash(primaryHex, r)
+
+	if c.tryServeHit(w, r, variantHex) {
+		return
+	}
+	c.fillAndServe(w, r, next, primaryHex, variantHex)
+}
+
+// tryServeHit serves key from storage if present and fresh, returning true. An
+// expired entry is reaped and reported as a miss (fail-static: a storage error
+// reads as a miss).
+func (c *Cache) tryServeHit(w http.ResponseWriter, r *http.Request, key string) bool {
+	m, body, ok := c.storage.Get(key)
+	if !ok {
+		return false
+	}
+	if time.Now().After(time.Unix(0, m.FreshUntil)) {
+		c.storage.Delete(key)
+		return false
+	}
+	writeStored(w, r, m, body, "HIT")
+	return true
+}
+
+// fillAndServe handles a miss. The first arrival becomes the leader and fills the
+// cache while streaming to its own client; concurrent arrivals wait for the
+// leader (then re-read from cache) or time out and fetch on their own. Each tags
+// X-Cache accurately (HIT when served from the just-filled cache, MISS when it
+// contacted the origin).
+func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex, variantHex string) {
+	lock, leader := c.acquire(variantHex)
+	if !leader {
+		select {
+		case <-lock.done:
+		case <-time.After(cacheLockTimeout):
+		}
+		// The leader has finished (or we timed out). Recompute our variant key:
+		// the leader may have just learned this primary's Vary, so our key now
+		// matches the stored entry IF our varied-header values match the leader's
+		// (otherwise we correctly miss and fetch our own variant — never serving a
+		// wrong Vary variant). A miss here falls through to our own origin fetch.
+		if c.tryServeHit(w, r, c.variantHash(primaryHex, r)) {
+			return
+		}
+		w.Header().Set("X-Cache", "MISS")
+		next.ServeHTTP(w, r)
+		return
+	}
+
+	defer c.release(variantHex, lock)
+	tw := &teeWriter{rw: w, r: r, c: c, method: r.Method, primaryHex: primaryHex}
+	next.ServeHTTP(tw, r)
+	tw.finish()
+}
+
+func (c *Cache) acquire(variantHex string) (*fillLock, bool) {
+	c.lockMu.Lock()
+	defer c.lockMu.Unlock()
+	if l, ok := c.locks[variantHex]; ok {
+		return l, false
+	}
+	l := &fillLock{done: make(chan struct{})}
+	c.locks[variantHex] = l
+	return l, true
+}
+
+func (c *Cache) release(variantHex string, l *fillLock) {
+	c.lockMu.Lock()
+	delete(c.locks, variantHex)
+	c.lockMu.Unlock()
+	close(l.done)
+}
+
+// primaryHash keys on host + method + scheme + uri (so distinct hosts/schemes/
+// methods never collide). scheme reflects the terminating listener via
+// X-Forwarded-Proto (set by the parapet server), defaulting to the request TLS
+// state.
+func (c *Cache) primaryHash(r *http.Request) string {
+	scheme := r.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		if r.TLS != nil {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
+	}
+	uri := r.URL.RequestURI()
+	sum := sha256.Sum256([]byte(strings.ToLower(r.Host) + "\n" + r.Method + "\n" + scheme + "\n" + uri))
+	return hex.EncodeToString(sum[:16])
+}
+
+// variantHash mixes the primary hash with the request's values for the Vary
+// header names learned for this primary, so distinct Vary variants get distinct
+// entries. Before the primary's Vary is known the variance is empty — so the
+// first fill stores under the actual response's Vary (see teeWriter.finish),
+// which a later lookup then matches once the Vary map is learned.
+func (c *Cache) variantHash(primaryHex string, r *http.Request) string {
+	return variantHashFor(primaryHex, c.getPrimaryVary(primaryHex), r.Header)
+}
+
+// variantHashFor computes the storage key. names must be sorted + lowercased; the
+// variance is each name's value in h. The same (primaryHex, names, h) on the
+// lookup and store paths yields the same key.
+func variantHashFor(primaryHex string, names []string, h http.Header) string {
+	var b strings.Builder
+	b.WriteString(primaryHex)
+	b.WriteByte(0)
+	for _, name := range names {
+		b.WriteString(name)
+		b.WriteByte('=')
+		b.WriteString(h.Get(name))
+		b.WriteByte('\n')
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:16])
+}
+
+func (c *Cache) getPrimaryVary(primaryHex string) []string {
+	c.pvMu.RLock()
+	defer c.pvMu.RUnlock()
+	return c.primaryVary[primaryHex]
+}
+
+func (c *Cache) setPrimaryVary(primaryHex string, names []string) {
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	c.pvMu.Lock()
+	// Bound the map: a dropped entry just re-learns on the next fill.
+	if len(c.primaryVary) >= maxPrimaryVary {
+		if _, exists := c.primaryVary[primaryHex]; !exists {
+			c.primaryVary = make(map[string][]string, maxPrimaryVary)
+		}
+	}
+	c.primaryVary[primaryHex] = sorted
+	c.pvMu.Unlock()
+}
+
+// writeStored writes a cached entry to the client. body is omitted for HEAD and
+// bodiless statuses. X-Cache is set to tag (HIT/MISS).
+func writeStored(w http.ResponseWriter, r *http.Request, m Meta, body []byte, tag string) {
+	h := w.Header()
+	for k, vs := range m.Header {
+		h[k] = append([]string(nil), vs...)
+	}
+	h.Set("X-Cache", tag)
+	w.WriteHeader(m.Status)
+	if r.Method == http.MethodHead || m.Status == http.StatusNoContent {
+		return
+	}
+	_, _ = w.Write(body)
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3,12 +3,18 @@ package cache
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/moonrhythm/parapet"
 )
+
+// Cache is a parapet.Middleware.
+var _ parapet.Middleware = (*Cache)(nil)
 
 // cacheLockTimeout bounds how long a concurrent miss waits for the in-flight fill
 // (the "leader") to populate the cache before fetching on its own.
@@ -133,6 +139,7 @@ func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.H
 
 	defer c.release(variantHex, lock)
 	tw := &teeWriter{rw: w, r: r, c: c, method: r.Method, primaryHex: primaryHex}
+	defer tw.cleanup() // panic-safe: abort an uncommitted entry if finish never ran
 	next.ServeHTTP(tw, r)
 	tw.finish()
 }
@@ -156,9 +163,10 @@ func (c *Cache) release(variantHex string, l *fillLock) {
 }
 
 // primaryHash keys on host + method + scheme + uri (so distinct hosts/schemes/
-// methods never collide). scheme reflects the terminating listener via
-// X-Forwarded-Proto (set by the parapet server), defaulting to the request TLS
-// state.
+// methods never collide). The host is lowercased and port-stripped so
+// "example.com" and "example.com:443" share a key regardless of upstream host
+// normalization. scheme reflects the terminating listener via X-Forwarded-Proto
+// (set by the parapet server), defaulting to the request TLS state.
 func (c *Cache) primaryHash(r *http.Request) string {
 	scheme := r.Header.Get("X-Forwarded-Proto")
 	if scheme == "" {
@@ -168,8 +176,12 @@ func (c *Cache) primaryHash(r *http.Request) string {
 			scheme = "http"
 		}
 	}
+	host := strings.ToLower(r.Host)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h // drop :port (SplitHostPort errors when there is none)
+	}
 	uri := r.URL.RequestURI()
-	sum := sha256.Sum256([]byte(strings.ToLower(r.Host) + "\n" + r.Method + "\n" + scheme + "\n" + uri))
+	sum := sha256.Sum256([]byte(host + "\n" + r.Method + "\n" + scheme + "\n" + uri))
 	return hex.EncodeToString(sum[:16])
 }
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -43,6 +43,19 @@ func origin(spec originSpec, calls *int32) http.Handler {
 	})
 }
 
+// storePut writes an entry directly to a Storage backend (Writer + Commit), for
+// tests that seed or rewrite stored state.
+func storePut(t *testing.T, s Storage, key string, m Meta, body []byte) {
+	t.Helper()
+	w, err := s.Writer(key)
+	require.NoError(t, err)
+	if len(body) > 0 {
+		_, err = w.Write(body)
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Commit(m))
+}
+
 func do(c *Cache, h http.Handler, method, target string, reqHeader http.Header) *httptest.ResponseRecorder {
 	mw := c.ServeHandler(h)
 	req := httptest.NewRequest(method, target, nil)
@@ -219,7 +232,7 @@ func TestCache_ExpiredEntryIsMiss(t *testing.T) {
 		m, body, ok := c.storage.Get(variant)
 		require.True(t, ok)
 		m.FreshUntil = time.Now().Add(-time.Minute).UnixNano()
-		c.storage.Set(variant, m, body)
+		storePut(t, c.storage, variant, m, body)
 		r := do(c, h, "GET", "http://acme.com/exp", nil)
 		assert.Equal(t, "MISS", r.Header().Get("X-Cache"), "expired entry is a miss")
 		assert.EqualValues(t, 2, atomic.LoadInt32(&calls))

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,249 @@
+package cache
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type originSpec struct {
+	body   []byte
+	header http.Header
+	status int
+	sleep  time.Duration
+}
+
+func origin(spec originSpec, calls *int32) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(calls, 1)
+		if spec.sleep > 0 {
+			time.Sleep(spec.sleep)
+		}
+		for k, vs := range spec.header {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		if w.Header().Get("Content-Length") == "" {
+			w.Header().Set("Content-Length", strconv.Itoa(len(spec.body)))
+		}
+		st := spec.status
+		if st == 0 {
+			st = http.StatusOK
+		}
+		w.WriteHeader(st)
+		_, _ = w.Write(spec.body)
+	})
+}
+
+func do(c *Cache, h http.Handler, method, target string, reqHeader http.Header) *httptest.ResponseRecorder {
+	mw := c.ServeHandler(h)
+	req := httptest.NewRequest(method, target, nil)
+	for k, vs := range reqHeader {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	return rec
+}
+
+// eachBackend runs fn against both storage backends so the middleware behavior is
+// verified identically for memory and disk.
+func eachBackend(t *testing.T, fn func(t *testing.T, c *Cache)) {
+	t.Helper()
+	t.Run("memory", func(t *testing.T) {
+		fn(t, New(NewMemory(1<<20), Options{MaxFileSize: 1024}))
+	})
+	t.Run("disk", func(t *testing.T) {
+		d, err := NewDisk(t.TempDir(), 1<<20)
+		require.NoError(t, err)
+		fn(t, New(d, Options{MaxFileSize: 1024}))
+	})
+}
+
+func TestCache_MissThenHit(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("hello"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+		r1 := do(c, h, "GET", "http://acme.com/a", nil)
+		assert.Equal(t, "MISS", r1.Header().Get("X-Cache"))
+		assert.Equal(t, "hello", r1.Body.String())
+		r2 := do(c, h, "GET", "http://acme.com/a", nil)
+		assert.Equal(t, "HIT", r2.Header().Get("X-Cache"))
+		assert.Equal(t, "hello", r2.Body.String())
+		assert.EqualValues(t, 1, atomic.LoadInt32(&calls), "origin contacted once")
+	})
+}
+
+func TestCache_NonCacheableAlwaysMiss(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("dyn")}, &calls) // no freshness
+		do(c, h, "GET", "http://acme.com/d", nil)
+		r := do(c, h, "GET", "http://acme.com/d", nil)
+		assert.Equal(t, "MISS", r.Header().Get("X-Cache"))
+		assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+	})
+}
+
+func TestCache_IgnoresClientCacheControl(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("x"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+		do(c, h, "GET", "http://acme.com/a", nil)
+		r := do(c, h, "GET", "http://acme.com/a", hdr("Cache-Control", "no-cache"))
+		assert.Equal(t, "HIT", r.Header().Get("X-Cache"))
+		assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+	})
+}
+
+func TestCache_VarySeparatesVariants(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("v"), header: hdr("Cache-Control", "max-age=60", "Vary", "Accept-Encoding")}, &calls)
+		do(c, h, "GET", "http://acme.com/a", hdr("Accept-Encoding", "gzip"))
+		gz := do(c, h, "GET", "http://acme.com/a", hdr("Accept-Encoding", "gzip"))
+		assert.Equal(t, "HIT", gz.Header().Get("X-Cache"))
+		br := do(c, h, "GET", "http://acme.com/a", hdr("Accept-Encoding", "br"))
+		assert.Equal(t, "MISS", br.Header().Get("X-Cache"))
+		assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+	})
+}
+
+func TestCache_PerObjectCapNotCached(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: make([]byte, 2000), header: hdr("Cache-Control", "max-age=60")}, &calls)
+		do(c, h, "GET", "http://acme.com/big", nil)
+		r := do(c, h, "GET", "http://acme.com/big", nil)
+		assert.Equal(t, "MISS", r.Header().Get("X-Cache"))
+		assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+	})
+}
+
+func TestCache_PostNotCached(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("body"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+		r := do(c, h, "POST", "http://acme.com/a", nil)
+		assert.Equal(t, "", r.Header().Get("X-Cache"))
+	})
+}
+
+func TestCache_FarFutureFreshnessStillHits(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("immortal"), header: hdr("Cache-Control", "max-age=7445000000")}, &calls)
+		assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/far", nil).Header().Get("X-Cache"))
+		assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/far", nil).Header().Get("X-Cache"))
+		assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+	})
+}
+
+func TestCache_SingleFlightCollapsesConcurrentMisses(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("slow"), header: hdr("Cache-Control", "max-age=60"), sleep: 60 * time.Millisecond}, &calls)
+		mw := c.ServeHandler(h)
+		const n = 12
+		var wg, start sync.WaitGroup
+		var miss, hit int32
+		start.Add(1)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				start.Wait()
+				rec := httptest.NewRecorder()
+				mw.ServeHTTP(rec, httptest.NewRequest("GET", "http://acme.com/s", nil))
+				assert.Equal(t, "slow", rec.Body.String())
+				switch rec.Header().Get("X-Cache") {
+				case "MISS":
+					atomic.AddInt32(&miss, 1)
+				case "HIT":
+					atomic.AddInt32(&hit, 1)
+				}
+			}()
+		}
+		start.Done()
+		wg.Wait()
+		assert.EqualValues(t, 1, atomic.LoadInt32(&calls), "concurrent misses collapse to one origin fetch")
+		assert.EqualValues(t, 1, atomic.LoadInt32(&miss))
+		assert.EqualValues(t, n-1, atomic.LoadInt32(&hit))
+	})
+}
+
+func TestCache_SingleFlightVaryFirstFill(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("vb"), header: hdr("Cache-Control", "max-age=60", "Vary", "Accept-Encoding"), sleep: 60 * time.Millisecond}, &calls)
+		mw := c.ServeHandler(h)
+		const n = 12
+		var wg, start sync.WaitGroup
+		start.Add(1)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				start.Wait()
+				req := httptest.NewRequest("GET", "http://acme.com/v", nil)
+				req.Header.Set("Accept-Encoding", "gzip")
+				rec := httptest.NewRecorder()
+				mw.ServeHTTP(rec, req)
+				assert.Equal(t, "vb", rec.Body.String())
+			}()
+		}
+		start.Done()
+		wg.Wait()
+		assert.EqualValues(t, 1, atomic.LoadInt32(&calls), "concurrent first-fill of a Vary'd URL collapses to one fetch")
+	})
+}
+
+func TestCache_ExpiredEntryIsMiss(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("e"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+		req := httptest.NewRequest("GET", "http://acme.com/exp", nil)
+		do(c, h, "GET", "http://acme.com/exp", nil) // fill
+		// Force the stored entry stale by rewriting its meta with a past FreshUntil.
+		variant := c.variantHash(c.primaryHash(req), req)
+		m, body, ok := c.storage.Get(variant)
+		require.True(t, ok)
+		m.FreshUntil = time.Now().Add(-time.Minute).UnixNano()
+		c.storage.Set(variant, m, body)
+		r := do(c, h, "GET", "http://acme.com/exp", nil)
+		assert.Equal(t, "MISS", r.Header().Get("X-Cache"), "expired entry is a miss")
+		assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+	})
+}
+
+func TestCache_PanicDuringFillIsSafe(t *testing.T) {
+	// Buffering (no temp file) makes a fill panic-safe: nothing is persisted, and
+	// the cache stays usable afterward.
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		panicky := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Cache-Control", "max-age=60")
+			w.Header().Set("Content-Length", "100")
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte("partial"))
+			panic("boom")
+		})
+		mw := c.ServeHandler(panicky)
+		func() {
+			defer func() { _ = recover() }()
+			mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "http://acme.com/boom", nil))
+		}()
+		var calls int32
+		ok := origin(originSpec{body: []byte("ok"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+		assert.Equal(t, "MISS", do(c, ok, "GET", "http://acme.com/after", nil).Header().Get("X-Cache"))
+	})
+}

--- a/pkg/cache/disk.go
+++ b/pkg/cache/disk.go
@@ -16,10 +16,16 @@ import (
 // commit (body renamed in, .meta not yet) is never touched.
 const reapMinAge = 60 * time.Second
 
-// DiskStorage is a disk-backed cache backend. Entries survive restarts and are
-// not bounded by RSS. The total on-disk byte cap is held by an in-memory LRU,
-// re-seeded from disk by a background startup scan that also reaps orphans, torn
-// writes, and expired entries. Safe for concurrent use.
+// minKeyLen is the shortest key the disk layout supports (the shard dir is the
+// first 2 chars). The middleware always passes 32-hex keys; this guards a direct
+// Storage caller from panicking shardDir.
+const minKeyLen = 2
+
+// DiskStorage is a disk-backed cache backend. Entries survive restarts and the
+// body is streamed to disk, so the cache isn't bounded by RSS. The total on-disk
+// byte cap is held by an in-memory LRU, re-seeded from disk by a background
+// startup scan that also reaps orphans, torn writes, and expired entries. Safe
+// for concurrent use by a single Cache (see Storage).
 //
 // Layout (sharded by the first 2 hex chars of the key):
 //
@@ -63,8 +69,14 @@ func (s *DiskStorage) tempPath(prefix string) string {
 }
 
 // Get reads the entry under key, touching its LRU recency on a hit. ok=false on
-// any miss / corruption / torn write (fail-static — treated as a cache miss).
+// any miss / corruption / torn read (fail-static — treated as a cache miss). The
+// body length is checked against meta.Size so a reader can never serve an old
+// meta paired with a concurrently-rewritten body (the two files are read
+// non-atomically; this guards the framing-corruption case).
 func (s *DiskStorage) Get(key string) (Meta, []byte, bool) {
+	if len(key) < minKeyLen {
+		return Meta{}, nil, false
+	}
 	mb, err := os.ReadFile(s.metaPath(key))
 	if err != nil {
 		return Meta{}, nil, false // clean miss or unreadable
@@ -74,49 +86,34 @@ func (s *DiskStorage) Get(key string) (Meta, []byte, bool) {
 		return Meta{}, nil, false // corrupt sidecar
 	}
 	body, err := os.ReadFile(s.bodyPath(key))
-	if err != nil {
-		return Meta{}, nil, false // meta without body (torn)
+	if err != nil || int64(len(body)) != m.Size {
+		return Meta{}, nil, false // meta without body (torn), or meta/body size disagree
 	}
 	s.lru.touch(key)
 	return m, body, true
 }
 
-// Set writes body+meta under key: body to a temp file, fsync, atomically rename
-// to <key>.body, then atomically write <key>.meta LAST (so its presence implies
-// a complete body). On success it admits to the byte cap and evicts LRU victims.
-// Any IO error is fail-static (the entry is simply not cached).
-func (s *DiskStorage) Set(key string, meta Meta, body []byte) {
+// Writer streams a new entry's body to a temp file; Commit fsyncs + renames it
+// into place (body first, meta last) and admits it to the byte cap; Abort
+// discards the temp file. Returns an error if the temp file can't be created.
+func (s *DiskStorage) Writer(key string) (EntryWriter, error) {
+	if len(key) < minKeyLen {
+		return nil, errors.New("cache: key too short")
+	}
 	tmp := s.tempPath(key)
-	if err := atomicWrite(tmp, body); err != nil {
-		os.Remove(tmp)
-		return
-	}
-	if err := os.MkdirAll(s.shardDir(key), 0o755); err != nil {
-		os.Remove(tmp)
-		return
-	}
-	bodyPath := s.bodyPath(key)
-	if err := os.Rename(tmp, bodyPath); err != nil {
-		os.Remove(tmp)
-		return
-	}
-	mb, err := json.Marshal(meta)
+	f, err := os.Create(tmp)
 	if err != nil {
-		os.Remove(bodyPath)
-		return
+		return nil, err
 	}
-	if err := atomicWriteRename(s.metaPath(key), mb, s.tempPath(key+".meta")); err != nil {
-		os.Remove(bodyPath) // roll back so a body without meta isn't left
-		return
-	}
-	for _, victim := range s.lru.admit(key, meta.Size) {
-		s.removeFiles(victim)
-	}
+	return &diskWriter{s: s, key: key, f: f, tmp: tmp}, nil
 }
 
 // Delete removes the entry under key (meta first, so a half-deleted entry reads
-// as a clean miss rather than a torn write) and its LRU accounting.
+// as a clean miss rather than a torn read) and its LRU accounting.
 func (s *DiskStorage) Delete(key string) {
+	if len(key) < minKeyLen {
+		return
+	}
 	s.removeFiles(key)
 	s.lru.remove(key)
 }
@@ -124,6 +121,71 @@ func (s *DiskStorage) Delete(key string) {
 func (s *DiskStorage) removeFiles(key string) {
 	os.Remove(s.metaPath(key))
 	os.Remove(s.bodyPath(key))
+}
+
+//nolint:govet
+type diskWriter struct {
+	s    *DiskStorage
+	key  string
+	f    *os.File
+	tmp  string
+	done bool
+}
+
+func (w *diskWriter) Write(p []byte) (int, error) { return w.f.Write(p) }
+
+// Commit fsyncs the temp body, atomically renames it to <key>.body, then writes
+// <key>.meta LAST (its presence implies a complete body), and admits to the byte
+// cap. NOTE: the fsync runs synchronously on the caller's goroutine — the
+// middleware calls Commit on the request goroutine (after the client already has
+// the full response) and before it releases the fill lock, so a slow fsync holds
+// the connection and briefly blocks waiting followers.
+func (w *diskWriter) Commit(meta Meta) error {
+	if w.done {
+		return nil
+	}
+	w.done = true
+	s := w.s
+	if err := w.f.Sync(); err != nil {
+		w.f.Close()
+		os.Remove(w.tmp)
+		return err
+	}
+	if err := w.f.Close(); err != nil {
+		os.Remove(w.tmp)
+		return err
+	}
+	if err := os.MkdirAll(s.shardDir(w.key), 0o755); err != nil {
+		os.Remove(w.tmp)
+		return err
+	}
+	bodyPath := s.bodyPath(w.key)
+	if err := os.Rename(w.tmp, bodyPath); err != nil {
+		os.Remove(w.tmp)
+		return err
+	}
+	mb, err := json.Marshal(meta)
+	if err != nil {
+		os.Remove(bodyPath)
+		return err
+	}
+	if err := atomicWriteRename(s.metaPath(w.key), mb, s.tempPath(w.key+".meta")); err != nil {
+		os.Remove(bodyPath) // roll back so a body without meta isn't left
+		return err
+	}
+	for _, victim := range s.lru.admit(w.key, meta.Size) {
+		s.removeFiles(victim)
+	}
+	return nil
+}
+
+func (w *diskWriter) Abort() {
+	if w.done {
+		return
+	}
+	w.done = true
+	w.f.Close()
+	os.Remove(w.tmp)
 }
 
 // scan walks the cache dir, reaping orphans / torn writes / expired entries
@@ -210,27 +272,23 @@ func reapIfStale(path string, now time.Time) {
 	}
 }
 
-// atomicWrite writes data to path, fsyncing before close (path is a temp file
-// the caller renames into place).
-func atomicWrite(path string, data []byte) error {
-	f, err := os.Create(path)
+// atomicWriteRename writes data to tmpPath (fsync'd) then renames to path.
+func atomicWriteRename(path string, data []byte, tmpPath string) error {
+	f, err := os.Create(tmpPath)
 	if err != nil {
 		return err
 	}
 	if _, err := f.Write(data); err != nil {
 		f.Close()
+		os.Remove(tmpPath)
 		return err
 	}
 	if err := f.Sync(); err != nil {
 		f.Close()
+		os.Remove(tmpPath)
 		return err
 	}
-	return f.Close()
-}
-
-// atomicWriteRename writes data to tmpPath (fsync'd) then renames to path.
-func atomicWriteRename(path string, data []byte, tmpPath string) error {
-	if err := atomicWrite(tmpPath, data); err != nil {
+	if err := f.Close(); err != nil {
 		os.Remove(tmpPath)
 		return err
 	}

--- a/pkg/cache/disk.go
+++ b/pkg/cache/disk.go
@@ -1,0 +1,242 @@
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// reapMinAge gates orphan/torn-write reaping during the startup scan: a file is
+// only deleted if its mtime is at least this old, so a concurrent in-flight
+// commit (body renamed in, .meta not yet) is never touched.
+const reapMinAge = 60 * time.Second
+
+// DiskStorage is a disk-backed cache backend. Entries survive restarts and are
+// not bounded by RSS. The total on-disk byte cap is held by an in-memory LRU,
+// re-seeded from disk by a background startup scan that also reaps orphans, torn
+// writes, and expired entries. Safe for concurrent use.
+//
+// Layout (sharded by the first 2 hex chars of the key):
+//
+//	<dir>/<aa>/<key>.body   response body bytes
+//	<dir>/<aa>/<key>.meta   JSON sidecar (written last)
+//	<dir>/tmp/<key>.<seq>   in-progress writes, atomically renamed on commit
+//
+//nolint:govet
+type DiskStorage struct {
+	dir string
+	seq atomic.Uint64
+	lru *lru
+}
+
+// NewDisk creates (or opens) a disk storage rooted at dir, bounded to maxSize
+// total body bytes. It starts a background scan that re-seeds the byte cap from
+// surviving entries and reaps orphans/expired files off the serving path — the
+// cap simply lags until the scan completes. Returns an error only if the dir
+// can't be initialized.
+func NewDisk(dir string, maxSize int64) (*DiskStorage, error) {
+	if dir == "" {
+		return nil, errors.New("cache: empty dir")
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "tmp"), 0o755); err != nil {
+		return nil, err
+	}
+	s := &DiskStorage{dir: dir, lru: newLRU(maxSize)}
+	go s.scan(time.Now())
+	return s, nil
+}
+
+func (s *DiskStorage) shardDir(key string) string { return filepath.Join(s.dir, key[:2]) }
+func (s *DiskStorage) bodyPath(key string) string {
+	return filepath.Join(s.shardDir(key), key+".body")
+}
+func (s *DiskStorage) metaPath(key string) string {
+	return filepath.Join(s.shardDir(key), key+".meta")
+}
+func (s *DiskStorage) tempPath(prefix string) string {
+	return filepath.Join(s.dir, "tmp", prefix+"."+strconv.FormatUint(s.seq.Add(1), 10))
+}
+
+// Get reads the entry under key, touching its LRU recency on a hit. ok=false on
+// any miss / corruption / torn write (fail-static — treated as a cache miss).
+func (s *DiskStorage) Get(key string) (Meta, []byte, bool) {
+	mb, err := os.ReadFile(s.metaPath(key))
+	if err != nil {
+		return Meta{}, nil, false // clean miss or unreadable
+	}
+	var m Meta
+	if err := json.Unmarshal(mb, &m); err != nil {
+		return Meta{}, nil, false // corrupt sidecar
+	}
+	body, err := os.ReadFile(s.bodyPath(key))
+	if err != nil {
+		return Meta{}, nil, false // meta without body (torn)
+	}
+	s.lru.touch(key)
+	return m, body, true
+}
+
+// Set writes body+meta under key: body to a temp file, fsync, atomically rename
+// to <key>.body, then atomically write <key>.meta LAST (so its presence implies
+// a complete body). On success it admits to the byte cap and evicts LRU victims.
+// Any IO error is fail-static (the entry is simply not cached).
+func (s *DiskStorage) Set(key string, meta Meta, body []byte) {
+	tmp := s.tempPath(key)
+	if err := atomicWrite(tmp, body); err != nil {
+		os.Remove(tmp)
+		return
+	}
+	if err := os.MkdirAll(s.shardDir(key), 0o755); err != nil {
+		os.Remove(tmp)
+		return
+	}
+	bodyPath := s.bodyPath(key)
+	if err := os.Rename(tmp, bodyPath); err != nil {
+		os.Remove(tmp)
+		return
+	}
+	mb, err := json.Marshal(meta)
+	if err != nil {
+		os.Remove(bodyPath)
+		return
+	}
+	if err := atomicWriteRename(s.metaPath(key), mb, s.tempPath(key+".meta")); err != nil {
+		os.Remove(bodyPath) // roll back so a body without meta isn't left
+		return
+	}
+	for _, victim := range s.lru.admit(key, meta.Size) {
+		s.removeFiles(victim)
+	}
+}
+
+// Delete removes the entry under key (meta first, so a half-deleted entry reads
+// as a clean miss rather than a torn write) and its LRU accounting.
+func (s *DiskStorage) Delete(key string) {
+	s.removeFiles(key)
+	s.lru.remove(key)
+}
+
+func (s *DiskStorage) removeFiles(key string) {
+	os.Remove(s.metaPath(key))
+	os.Remove(s.bodyPath(key))
+}
+
+// scan walks the cache dir, reaping orphans / torn writes / expired entries
+// (age-gated so in-flight commits are spared) and re-admitting the survivors to
+// the LRU so the byte cap holds across restarts.
+func (s *DiskStorage) scan(now time.Time) {
+	// Reap stale temp files (abandoned in-progress writes).
+	tmpDir := filepath.Join(s.dir, "tmp")
+	if ents, err := os.ReadDir(tmpDir); err == nil {
+		for _, e := range ents {
+			reapIfStale(filepath.Join(tmpDir, e.Name()), now)
+		}
+	}
+
+	shards, err := os.ReadDir(s.dir)
+	if err != nil {
+		return
+	}
+	for _, sh := range shards {
+		if !sh.IsDir() || sh.Name() == "tmp" {
+			continue
+		}
+		shardPath := filepath.Join(s.dir, sh.Name())
+		ents, err := os.ReadDir(shardPath)
+		if err != nil {
+			continue
+		}
+		bodies := map[string]struct{}{}
+		var metas []string
+		for _, e := range ents {
+			name := e.Name()
+			switch {
+			case strings.HasSuffix(name, ".body"):
+				bodies[strings.TrimSuffix(name, ".body")] = struct{}{}
+			case strings.HasSuffix(name, ".meta"):
+				metas = append(metas, strings.TrimSuffix(name, ".meta"))
+			}
+		}
+		seenMeta := map[string]struct{}{}
+		for _, key := range metas {
+			seenMeta[key] = struct{}{}
+			mp := filepath.Join(shardPath, key+".meta")
+			mb, err := os.ReadFile(mp)
+			if err != nil {
+				continue
+			}
+			var m Meta
+			if err := json.Unmarshal(mb, &m); err != nil {
+				reapIfStale(mp, now) // corrupt sidecar
+				reapIfStale(filepath.Join(shardPath, key+".body"), now)
+				continue
+			}
+			if _, hasBody := bodies[key]; !hasBody {
+				reapIfStale(mp, now) // meta without body (torn)
+				continue
+			}
+			if now.After(time.Unix(0, m.FreshUntil)) {
+				os.Remove(mp) // expired
+				os.Remove(filepath.Join(shardPath, key+".body"))
+				continue
+			}
+			for _, victim := range s.lru.admit(key, m.Size) {
+				s.removeFiles(victim)
+			}
+		}
+		// .body files with no matching .meta -> orphan (age-gated reap).
+		for key := range bodies {
+			if _, ok := seenMeta[key]; !ok {
+				reapIfStale(filepath.Join(shardPath, key+".body"), now)
+			}
+		}
+	}
+}
+
+// reapIfStale deletes path only if its mtime is at least reapMinAge old, so a
+// concurrent in-flight commit is never deleted.
+func reapIfStale(path string, now time.Time) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	if now.Sub(fi.ModTime()) >= reapMinAge {
+		os.Remove(path)
+	}
+}
+
+// atomicWrite writes data to path, fsyncing before close (path is a temp file
+// the caller renames into place).
+func atomicWrite(path string, data []byte) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// atomicWriteRename writes data to tmpPath (fsync'd) then renames to path.
+func atomicWriteRename(path string, data []byte, tmpPath string) error {
+	if err := atomicWrite(tmpPath, data); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/pkg/cache/disk_test.go
+++ b/pkg/cache/disk_test.go
@@ -2,6 +2,9 @@ package cache
 
 import (
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -39,7 +42,7 @@ func TestDisk_ScanReapsExpired(t *testing.T) {
 	a, err := NewDisk(dir, 1<<20)
 	require.NoError(t, err)
 	const key = "aabbccddeeff00112233445566778899"
-	a.Set(key, Meta{
+	storePut(t, a, key, Meta{
 		Status:     200,
 		Header:     http.Header{},
 		FreshUntil: time.Now().Add(-time.Hour).UnixNano(), // already expired
@@ -55,11 +58,35 @@ func TestDisk_ScanReapsExpired(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "scan reaps the expired entry")
 }
 
+func TestDisk_PanicDuringFillNoTempLeak(t *testing.T) {
+	dir := t.TempDir()
+	d, err := NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	c := New(d, Options{MaxFileSize: 1024})
+
+	panicky := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("partial"))
+		panic("boom")
+	})
+	mw := c.ServeHandler(panicky)
+	func() {
+		defer func() { _ = recover() }()
+		mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "http://acme.com/boom", nil))
+	}()
+
+	ents, err := os.ReadDir(filepath.Join(dir, "tmp"))
+	require.NoError(t, err)
+	assert.Empty(t, ents, "panic during fill must abort the writer and leave no temp file")
+}
+
 func TestDisk_GetSetDelete(t *testing.T) {
 	d, err := NewDisk(t.TempDir(), 1<<20)
 	require.NoError(t, err)
 	const key = "0011223344556677889900aabbccddee"
-	d.Set(key, Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3}, []byte("abc"))
+	storePut(t, d, key, Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3}, []byte("abc"))
 	m, body, ok := d.Get(key)
 	require.True(t, ok)
 	assert.Equal(t, 200, m.Status)

--- a/pkg/cache/disk_test.go
+++ b/pkg/cache/disk_test.go
@@ -1,0 +1,70 @@
+package cache
+
+import (
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisk_RestartPersistence(t *testing.T) {
+	dir := t.TempDir()
+
+	a, err := NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	ca := New(a, Options{MaxFileSize: 1024})
+	var callsA int32
+	ha := origin(originSpec{body: []byte("persist"), header: hdr("Cache-Control", "max-age=600")}, &callsA)
+	do(ca, ha, "GET", "http://acme.com/p", nil) // store on disk
+
+	// A fresh storage over the same dir serves the entry from disk.
+	b, err := NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	cb := New(b, Options{MaxFileSize: 1024})
+	var callsB int32
+	hb := origin(originSpec{body: []byte("persist"), header: hdr("Cache-Control", "max-age=600")}, &callsB)
+	r := do(cb, hb, "GET", "http://acme.com/p", nil)
+	assert.Equal(t, "HIT", r.Header().Get("X-Cache"), "survived restart")
+	assert.EqualValues(t, 0, atomic.LoadInt32(&callsB), "served from disk, origin not contacted")
+
+	assert.Eventually(t, func() bool { return b.lru.size() > 0 }, time.Second, 10*time.Millisecond,
+		"startup scan re-seeds the LRU byte accounting")
+}
+
+func TestDisk_ScanReapsExpired(t *testing.T) {
+	dir := t.TempDir()
+	a, err := NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	const key = "aabbccddeeff00112233445566778899"
+	a.Set(key, Meta{
+		Status:     200,
+		Header:     http.Header{},
+		FreshUntil: time.Now().Add(-time.Hour).UnixNano(), // already expired
+		Size:       3,
+	}, []byte("xyz"))
+
+	// A new storage scans on startup and reaps the expired entry.
+	b, err := NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	assert.Eventually(t, func() bool {
+		_, _, ok := b.Get(key)
+		return !ok
+	}, time.Second, 10*time.Millisecond, "scan reaps the expired entry")
+}
+
+func TestDisk_GetSetDelete(t *testing.T) {
+	d, err := NewDisk(t.TempDir(), 1<<20)
+	require.NoError(t, err)
+	const key = "0011223344556677889900aabbccddee"
+	d.Set(key, Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3}, []byte("abc"))
+	m, body, ok := d.Get(key)
+	require.True(t, ok)
+	assert.Equal(t, 200, m.Status)
+	assert.Equal(t, "abc", string(body))
+	d.Delete(key)
+	_, _, ok = d.Get(key)
+	assert.False(t, ok)
+}

--- a/pkg/cache/lru.go
+++ b/pkg/cache/lru.go
@@ -1,0 +1,96 @@
+package cache
+
+import (
+	"container/list"
+	"sync"
+)
+
+// lru bounds a backend's total stored bytes by least-recently-used eviction. It
+// tracks keys and their byte weights; the owning Storage holds the actual data
+// and deletes a key's data when lru returns it as a victim. Both the memory and
+// disk backends embed an lru.
+//
+//nolint:govet
+type lru struct {
+	mu    sync.Mutex
+	max   int64
+	cur   int64
+	ll    *list.List               // front = most recently used
+	items map[string]*list.Element // key -> element holding *lruItem
+}
+
+type lruItem struct {
+	key  string
+	size int64
+}
+
+func newLRU(max int64) *lru {
+	return &lru{max: max, ll: list.New(), items: map[string]*list.Element{}}
+}
+
+// admit inserts or updates key with size and returns the keys evicted to stay
+// within the cap (most-recently-used kept). The caller deletes the evicted
+// entries' data.
+func (l *lru) admit(key string, size int64) []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if el, ok := l.items[key]; ok {
+		it := el.Value.(*lruItem)
+		l.cur += size - it.size
+		it.size = size
+		l.ll.MoveToFront(el)
+	} else {
+		l.items[key] = l.ll.PushFront(&lruItem{key: key, size: size})
+		l.cur += size
+	}
+
+	var evicted []string
+	for l.cur > l.max {
+		back := l.ll.Back()
+		if back == nil {
+			break
+		}
+		it := back.Value.(*lruItem)
+		if it.key == key {
+			// Never evict the entry we just admitted to satisfy its own admission
+			// (a single object larger than the cap); the per-object cap prevents
+			// this in practice. Stop to avoid an infinite loop.
+			break
+		}
+		l.ll.Remove(back)
+		delete(l.items, it.key)
+		l.cur -= it.size
+		evicted = append(evicted, it.key)
+	}
+	return evicted
+}
+
+// touch marks key as most-recently-used (called on a cache hit). No-op if absent.
+func (l *lru) touch(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if el, ok := l.items[key]; ok {
+		l.ll.MoveToFront(el)
+	}
+}
+
+// remove drops key from the accounting (called when its data is deleted). No-op
+// if absent.
+func (l *lru) remove(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if el, ok := l.items[key]; ok {
+		it := el.Value.(*lruItem)
+		l.ll.Remove(el)
+		delete(l.items, key)
+		l.cur -= it.size
+	}
+}
+
+// size reports the current tracked total (for tests/observability).
+func (l *lru) size() int64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.cur
+}

--- a/pkg/cache/lru_test.go
+++ b/pkg/cache/lru_test.go
@@ -1,0 +1,40 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLRU_AdmitEvictsOverCap(t *testing.T) {
+	l := newLRU(100)
+	assert.Empty(t, l.admit("a", 40))
+	assert.Empty(t, l.admit("b", 40))
+	assert.EqualValues(t, 80, l.size())
+	evicted := l.admit("c", 40) // 120 > 100 -> evict LRU "a"
+	assert.Equal(t, []string{"a"}, evicted)
+	assert.EqualValues(t, 80, l.size())
+}
+
+func TestLRU_TouchUpdatesRecency(t *testing.T) {
+	l := newLRU(100)
+	l.admit("a", 40)
+	l.admit("b", 40)
+	l.touch("a") // a most-recent; b becomes LRU
+	assert.Equal(t, []string{"b"}, l.admit("c", 40))
+}
+
+func TestLRU_AdmitUpdatesSize(t *testing.T) {
+	l := newLRU(100)
+	l.admit("a", 40)
+	l.admit("a", 60)
+	assert.EqualValues(t, 60, l.size())
+}
+
+func TestLRU_Remove(t *testing.T) {
+	l := newLRU(100)
+	l.admit("a", 40)
+	l.remove("a")
+	assert.EqualValues(t, 0, l.size())
+	l.remove("missing")
+}

--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -1,6 +1,9 @@
 package cache
 
-import "sync"
+import (
+	"bytes"
+	"sync"
+)
 
 // MemoryStorage is an in-memory cache backend: bodies are held in RAM and lost
 // on restart. Total size is bounded by LRU eviction (the cap passed to NewMemory)
@@ -36,17 +39,10 @@ func (s *MemoryStorage) Get(key string) (Meta, []byte, bool) {
 	return e.meta, e.body, true
 }
 
-// Set stores body+meta under key and evicts least-recently-used entries to stay
-// within the byte cap. The middleware passes a body it no longer mutates.
-func (s *MemoryStorage) Set(key string, meta Meta, body []byte) {
-	s.mu.Lock()
-	s.m[key] = memEntry{meta: meta, body: body}
-	s.mu.Unlock()
-	for _, victim := range s.lru.admit(key, meta.Size) {
-		s.mu.Lock()
-		delete(s.m, victim)
-		s.mu.Unlock()
-	}
+// Writer returns a buffer-backed writer; Commit stores it (bodies are in RAM
+// either way for this backend).
+func (s *MemoryStorage) Writer(key string) (EntryWriter, error) {
+	return &memWriter{s: s, key: key}, nil
 }
 
 // Delete removes the entry under key.
@@ -55,4 +51,36 @@ func (s *MemoryStorage) Delete(key string) {
 	delete(s.m, key)
 	s.mu.Unlock()
 	s.lru.remove(key)
+}
+
+//nolint:govet
+type memWriter struct {
+	s    *MemoryStorage
+	key  string
+	buf  bytes.Buffer
+	done bool
+}
+
+func (w *memWriter) Write(p []byte) (int, error) { return w.buf.Write(p) }
+
+func (w *memWriter) Commit(meta Meta) error {
+	if w.done {
+		return nil
+	}
+	w.done = true
+	body := append([]byte(nil), w.buf.Bytes()...)
+	w.s.mu.Lock()
+	w.s.m[w.key] = memEntry{meta: meta, body: body}
+	w.s.mu.Unlock()
+	for _, victim := range w.s.lru.admit(w.key, meta.Size) {
+		w.s.mu.Lock()
+		delete(w.s.m, victim)
+		w.s.mu.Unlock()
+	}
+	return nil
+}
+
+func (w *memWriter) Abort() {
+	w.done = true
+	w.buf.Reset()
 }

--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -1,0 +1,58 @@
+package cache
+
+import "sync"
+
+// MemoryStorage is an in-memory cache backend: bodies are held in RAM and lost
+// on restart. Total size is bounded by LRU eviction (the cap passed to NewMemory)
+// plus the middleware's per-object cap. Safe for concurrent use.
+//
+//nolint:govet
+type MemoryStorage struct {
+	mu  sync.RWMutex
+	m   map[string]memEntry
+	lru *lru
+}
+
+//nolint:govet
+type memEntry struct {
+	meta Meta
+	body []byte
+}
+
+// NewMemory creates an in-memory storage bounded to maxSize total body bytes.
+func NewMemory(maxSize int64) *MemoryStorage {
+	return &MemoryStorage{m: map[string]memEntry{}, lru: newLRU(maxSize)}
+}
+
+// Get returns the entry under key, touching its LRU recency on a hit.
+func (s *MemoryStorage) Get(key string) (Meta, []byte, bool) {
+	s.mu.RLock()
+	e, ok := s.m[key]
+	s.mu.RUnlock()
+	if !ok {
+		return Meta{}, nil, false
+	}
+	s.lru.touch(key)
+	return e.meta, e.body, true
+}
+
+// Set stores body+meta under key and evicts least-recently-used entries to stay
+// within the byte cap. The middleware passes a body it no longer mutates.
+func (s *MemoryStorage) Set(key string, meta Meta, body []byte) {
+	s.mu.Lock()
+	s.m[key] = memEntry{meta: meta, body: body}
+	s.mu.Unlock()
+	for _, victim := range s.lru.admit(key, meta.Size) {
+		s.mu.Lock()
+		delete(s.m, victim)
+		s.mu.Unlock()
+	}
+}
+
+// Delete removes the entry under key.
+func (s *MemoryStorage) Delete(key string) {
+	s.mu.Lock()
+	delete(s.m, key)
+	s.mu.Unlock()
+	s.lru.remove(key)
+}

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -24,8 +24,8 @@ func TestMemory_DoesNotPersistAcrossInstances(t *testing.T) {
 func TestMemory_LRUEvicts(t *testing.T) {
 	s := NewMemory(100)
 	fresh := time.Now().Add(time.Hour).UnixNano()
-	s.Set("k1", Meta{Status: 200, Header: http.Header{}, FreshUntil: fresh, Size: 60}, make([]byte, 60))
-	s.Set("k2", Meta{Status: 200, Header: http.Header{}, FreshUntil: fresh, Size: 60}, make([]byte, 60)) // 120 > 100 -> evict k1
+	storePut(t, s, "k1", Meta{Status: 200, Header: http.Header{}, FreshUntil: fresh, Size: 60}, make([]byte, 60))
+	storePut(t, s, "k2", Meta{Status: 200, Header: http.Header{}, FreshUntil: fresh, Size: 60}, make([]byte, 60)) // 120 > 100 -> evict k1
 	_, _, ok1 := s.Get("k1")
 	_, _, ok2 := s.Get("k2")
 	assert.False(t, ok1, "least-recently-used k1 evicted")
@@ -35,7 +35,7 @@ func TestMemory_LRUEvicts(t *testing.T) {
 
 func TestMemory_GetSetDelete(t *testing.T) {
 	s := NewMemory(1 << 20)
-	s.Set("k", Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3}, []byte("abc"))
+	storePut(t, s, "k", Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3}, []byte("abc"))
 	m, body, ok := s.Get("k")
 	assert.True(t, ok)
 	assert.Equal(t, 200, m.Status)

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -1,0 +1,46 @@
+package cache
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemory_DoesNotPersistAcrossInstances(t *testing.T) {
+	var calls int32
+	h := origin(originSpec{body: []byte("m"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+
+	ca := New(NewMemory(1<<20), Options{MaxFileSize: 1024})
+	do(ca, h, "GET", "http://acme.com/m", nil)
+	assert.Equal(t, "HIT", do(ca, h, "GET", "http://acme.com/m", nil).Header().Get("X-Cache"))
+
+	// A fresh memory storage shares nothing (no persistence).
+	cb := New(NewMemory(1<<20), Options{MaxFileSize: 1024})
+	assert.Equal(t, "MISS", do(cb, h, "GET", "http://acme.com/m", nil).Header().Get("X-Cache"))
+}
+
+func TestMemory_LRUEvicts(t *testing.T) {
+	s := NewMemory(100)
+	fresh := time.Now().Add(time.Hour).UnixNano()
+	s.Set("k1", Meta{Status: 200, Header: http.Header{}, FreshUntil: fresh, Size: 60}, make([]byte, 60))
+	s.Set("k2", Meta{Status: 200, Header: http.Header{}, FreshUntil: fresh, Size: 60}, make([]byte, 60)) // 120 > 100 -> evict k1
+	_, _, ok1 := s.Get("k1")
+	_, _, ok2 := s.Get("k2")
+	assert.False(t, ok1, "least-recently-used k1 evicted")
+	assert.True(t, ok2)
+	assert.EqualValues(t, 60, s.lru.size())
+}
+
+func TestMemory_GetSetDelete(t *testing.T) {
+	s := NewMemory(1 << 20)
+	s.Set("k", Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3}, []byte("abc"))
+	m, body, ok := s.Get("k")
+	assert.True(t, ok)
+	assert.Equal(t, 200, m.Status)
+	assert.Equal(t, "abc", string(body))
+	s.Delete("k")
+	_, _, ok = s.Get("k")
+	assert.False(t, ok)
+}

--- a/pkg/cache/policy.go
+++ b/pkg/cache/policy.go
@@ -1,0 +1,205 @@
+package cache
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// maxTTL caps the cacheable lifetime so now+ttl stays well within
+// time.UnixNano's representable range (~year 2262). 10y exceeds any real TTL.
+const maxTTL = 10 * 365 * 24 * time.Hour
+
+// cacheableMethod reports the only methods the cache engages for.
+func cacheableMethod(m string) bool { return m == http.MethodGet || m == http.MethodHead }
+
+// isUpgrade reports a protocol-upgrade request (websocket, h2c upgrade). Such
+// requests are streamed and must never be cached.
+func isUpgrade(r *http.Request) bool {
+	if r.Header.Get("Upgrade") != "" {
+		return true
+	}
+	for _, v := range r.Header.Values("Connection") {
+		for _, tok := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(tok), "upgrade") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// cacheableStatus is the set of status codes the cache will store (a conservative
+// subset of the RFC "heuristically cacheable" set; 206/partial is excluded — no
+// Range support). Freshness is still required regardless.
+func cacheableStatus(code int) bool {
+	switch code {
+	case 200, 203, 204, 300, 301, 308, 404, 410:
+		return true
+	default:
+		return false
+	}
+}
+
+// decision is the outcome of the honor-origin cacheability check.
+//
+//nolint:govet
+type decision struct {
+	cacheable  bool
+	freshUntil time.Time
+	vary       []string // lowercased Vary header names (nil when no Vary)
+}
+
+// decide applies the honor-origin policy to an origin response. method is the
+// request method; status/h are the response status + headers; maxFileSize caps a
+// GET's Content-Length; now is the reference time for freshness. Returns
+// cacheable=false unless the origin explicitly opted in with freshness and the
+// response isn't refused for any reason.
+//
+// A GET is cacheable only with a Content-Length within the cap: the middleware
+// commits a body only once written bytes == Content-Length, guaranteeing a
+// truncated response is never stored. A chunked (no Content-Length) GET passes
+// through uncached. HEAD has no body and is unaffected.
+func decide(method string, status int, h http.Header, maxFileSize int64, now time.Time) decision {
+	no := decision{}
+	if !cacheableStatus(status) {
+		return no
+	}
+	// A Set-Cookie response is per-client; never store it in a shared cache.
+	if len(h.Values("Set-Cookie")) > 0 {
+		return no
+	}
+	vary, varyStar := parseVary(h)
+	if varyStar {
+		return no // Vary: * — no single key can represent it
+	}
+	cc := parseCacheControl(h)
+	if cc.private || cc.noStore || cc.noCache {
+		return no
+	}
+	ttl := freshness(cc, h, now)
+	if ttl <= 0 {
+		return no // honor-origin: no explicit freshness -> not cached
+	}
+	// Clamp absurd freshness so now+ttl stays within time.UnixNano's range.
+	if ttl > maxTTL {
+		ttl = maxTTL
+	}
+	if method == http.MethodGet {
+		cl, ok := contentLength(h)
+		if !ok || cl < 0 || cl > maxFileSize {
+			return no
+		}
+	}
+	return decision{cacheable: true, freshUntil: now.Add(ttl), vary: vary}
+}
+
+// parseVary returns the lowercased, de-duplicated Vary header names and whether
+// any token was "*".
+func parseVary(h http.Header) (names []string, star bool) {
+	seen := map[string]struct{}{}
+	for _, v := range h.Values("Vary") {
+		for _, tok := range strings.Split(v, ",") {
+			tok = strings.ToLower(strings.TrimSpace(tok))
+			if tok == "" {
+				continue
+			}
+			if tok == "*" {
+				return nil, true
+			}
+			if _, dup := seen[tok]; dup {
+				continue
+			}
+			seen[tok] = struct{}{}
+			names = append(names, tok)
+		}
+	}
+	return names, false
+}
+
+//nolint:govet
+type cacheControl struct {
+	private bool
+	noStore bool
+	noCache bool
+	maxAge  int64
+	sMaxAge int64
+	hasMax  bool
+	hasSMax bool
+}
+
+// parseCacheControl parses the response Cache-Control directives the policy
+// cares about.
+func parseCacheControl(h http.Header) cacheControl {
+	var cc cacheControl
+	for _, v := range h.Values("Cache-Control") {
+		for _, raw := range strings.Split(v, ",") {
+			d := strings.TrimSpace(raw)
+			if d == "" {
+				continue
+			}
+			name, val, _ := strings.Cut(d, "=")
+			name = strings.ToLower(strings.TrimSpace(name))
+			val = strings.Trim(strings.TrimSpace(val), "\"")
+			switch name {
+			case "private":
+				cc.private = true
+			case "no-store":
+				cc.noStore = true
+			case "no-cache":
+				cc.noCache = true
+			case "max-age":
+				if n, err := strconv.ParseInt(val, 10, 64); err == nil {
+					cc.maxAge = n
+					cc.hasMax = true
+				}
+			case "s-maxage":
+				if n, err := strconv.ParseInt(val, 10, 64); err == nil {
+					cc.sMaxAge = n
+					cc.hasSMax = true
+				}
+			}
+		}
+	}
+	return cc
+}
+
+// freshness returns the cacheable lifetime: s-maxage wins (shared-cache
+// directive), then max-age, then Expires (relative to Date if present, else
+// now). Returns 0 (not fresh) when the origin gave no explicit freshness.
+func freshness(cc cacheControl, h http.Header, now time.Time) time.Duration {
+	if cc.hasSMax {
+		return time.Duration(cc.sMaxAge) * time.Second
+	}
+	if cc.hasMax {
+		return time.Duration(cc.maxAge) * time.Second
+	}
+	if exp := h.Get("Expires"); exp != "" {
+		expTime, err := http.ParseTime(exp)
+		if err != nil {
+			return 0 // an unparseable Expires (e.g. "0") means already-expired
+		}
+		ref := now
+		if d := h.Get("Date"); d != "" {
+			if dt, derr := http.ParseTime(d); derr == nil {
+				ref = dt
+			}
+		}
+		return expTime.Sub(ref)
+	}
+	return 0
+}
+
+// contentLength parses the Content-Length header.
+func contentLength(h http.Header) (int64, bool) {
+	v := h.Get("Content-Length")
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/pkg/cache/policy_test.go
+++ b/pkg/cache/policy_test.go
@@ -1,0 +1,97 @@
+package cache
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const maxFile = 8 << 20
+
+func hdr(kv ...string) http.Header {
+	h := http.Header{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		h.Add(kv[i], kv[i+1])
+	}
+	return h
+}
+
+func cacheableGET(t *testing.T, h http.Header) bool {
+	t.Helper()
+	if h.Get("Content-Length") == "" {
+		h.Set("Content-Length", "10")
+	}
+	return decide(http.MethodGet, 200, h, maxFile, time.Unix(1_000_000, 0)).cacheable
+}
+
+func TestDecide_HonorsOriginFreshnessOnly(t *testing.T) {
+	assert.True(t, cacheableGET(t, hdr("Cache-Control", "public, max-age=60")))
+	assert.True(t, cacheableGET(t, hdr("Cache-Control", "max-age=60")))
+	assert.True(t, cacheableGET(t, hdr("Cache-Control", "s-maxage=30")))
+	assert.False(t, cacheableGET(t, hdr()))
+	assert.False(t, cacheableGET(t, hdr("Content-Type", "text/html")))
+}
+
+func TestDecide_RefusesPrivateNoStoreNoCacheSetCookieVaryStar(t *testing.T) {
+	assert.False(t, cacheableGET(t, hdr("Cache-Control", "private, max-age=60")))
+	assert.False(t, cacheableGET(t, hdr("Cache-Control", "no-store")))
+	assert.False(t, cacheableGET(t, hdr("Cache-Control", "no-cache, max-age=60")))
+	assert.False(t, cacheableGET(t, hdr("Cache-Control", "public, max-age=60", "Set-Cookie", "sid=abc")))
+	assert.False(t, cacheableGET(t, hdr("Cache-Control", "public, max-age=60", "Vary", "*")))
+}
+
+func TestDecide_VaryNamedHeaderStillCacheable(t *testing.T) {
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "5", "Vary", "Accept-Encoding"), maxFile, time.Now())
+	assert.True(t, d.cacheable)
+	assert.Equal(t, []string{"accept-encoding"}, d.vary)
+}
+
+func TestDecide_StatusCodes(t *testing.T) {
+	for _, code := range []int{200, 203, 204, 300, 301, 308, 404, 410} {
+		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), maxFile, time.Now())
+		assert.True(t, d.cacheable, "status %d should be cacheable with freshness", code)
+	}
+	for _, code := range []int{201, 302, 401, 403, 500, 502, 206} {
+		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), maxFile, time.Now())
+		assert.False(t, d.cacheable, "status %d should not be cached", code)
+	}
+}
+
+func TestDecide_ContentLengthCapAndPresence(t *testing.T) {
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60"), maxFile, time.Now()).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "9000000"), maxFile, time.Now()).cacheable)
+	assert.True(t, decide(http.MethodHead, 200, hdr("Cache-Control", "max-age=60"), maxFile, time.Now()).cacheable)
+}
+
+func TestDecide_Expires(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	future := now.Add(time.Hour).UTC().Format(http.TimeFormat)
+	past := now.Add(-time.Hour).UTC().Format(http.TimeFormat)
+	assert.True(t, decide(http.MethodGet, 200, hdr("Expires", future, "Content-Length", "1"), maxFile, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", past, "Content-Length", "1"), maxFile, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", "0", "Content-Length", "1"), maxFile, now).cacheable)
+}
+
+func TestDecide_FarFutureTTLClamped(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=7445000000", "Content-Length", "1"), maxFile, now) // ~236y
+	assert.True(t, d.cacheable)
+	// clamped well within UnixNano range (year < 2262)
+	assert.True(t, d.freshUntil.Before(time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)))
+	assert.False(t, d.freshUntil.IsZero())
+}
+
+func TestParseVary(t *testing.T) {
+	names, star := parseVary(hdr("Vary", "Accept-Encoding, Accept", "Vary", "accept-encoding"))
+	assert.False(t, star)
+	assert.ElementsMatch(t, []string{"accept-encoding", "accept"}, names)
+	_, star = parseVary(hdr("Vary", "Accept, *"))
+	assert.True(t, star)
+}
+
+func TestFreshness_SMaxAgeWins(t *testing.T) {
+	cc := parseCacheControl(hdr("Cache-Control", "max-age=10, s-maxage=99"))
+	assert.Equal(t, 99*time.Second, freshness(cc, http.Header{}, time.Now()))
+}

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -9,9 +9,10 @@
 // response is tagged X-Cache: HIT|MISS.
 //
 // Two storage backends ship: an in-memory one ([NewMemory], bodies held in RAM,
-// lost on restart) and a disk-backed one ([NewDisk], survives restarts, bounded
-// by an on-disk byte cap). Both bound their total size with LRU eviction and a
-// per-object cap. Plug either (or your own [Storage]) into [New].
+// lost on restart) and a disk-backed one ([NewDisk], survives restarts, streams
+// bodies to disk so it isn't bounded by RSS). Both bound their total size with
+// LRU eviction and a per-object cap. Plug either (or your own [Storage]) into
+// [New].
 //
 //	store, _ := cache.NewDisk("/var/cache/app", 1<<30) // 1 GiB on disk
 //	m := cache.New(store, cache.Options{MaxFileSize: 8 << 20})
@@ -21,27 +22,48 @@
 // authorization-sensitive responses must be marked uncacheable by the origin.
 package cache
 
-import "net/http"
+import (
+	"io"
+	"net/http"
+)
 
 // Storage is the cache backend: where cached entries live and how total size is
 // bounded. The middleware handles policy, keys, Vary, locking, and X-Cache;
 // Storage only persists bytes and enforces capacity (LRU + per-object cap).
 //
-// Implementations must be safe for concurrent use.
+// Implementations must be safe for concurrent use BY A SINGLE Cache instance.
+// One backing store (e.g. a [DiskStorage] dir) must be owned by one Cache:
+// concurrent same-key writes are otherwise unsynchronized. The middleware
+// serializes same-key fills with its fill lock and only writes a key it has just
+// missed, so within one Cache the store never sees a same-key Get racing a Set.
 type Storage interface {
 	// Get returns the entry stored under key, or ok=false on a miss. A hit should
 	// be counted as a recent use (LRU). The returned body must not be mutated by
 	// the caller. Any internal error is reported as a miss (fail-static).
 	Get(key string) (meta Meta, body []byte, ok bool)
 
-	// Set stores body+meta under key, admitting it to the capacity bound and
-	// evicting least-recently-used entries as needed. body is the complete
-	// response body (the middleware has already enforced the per-object cap). A
-	// failure is best-effort/fail-static: the entry is simply not cached.
-	Set(key string, meta Meta, body []byte)
+	// Writer begins storing an entry under key. The caller streams the body to the
+	// returned EntryWriter and then calls Commit (to persist) or Abort (to
+	// discard). It returns an error if a writer can't be opened (then the entry is
+	// simply not cached). The disk backend streams to a temp file so the body
+	// never has to be buffered whole in RAM.
+	Writer(key string) (EntryWriter, error)
 
 	// Delete removes the entry under key (e.g. when the middleware finds it stale).
 	Delete(key string)
+}
+
+// EntryWriter streams one cached body and finalizes it. Exactly one of Commit or
+// Abort must be called; after either, the writer is spent. Abort after Commit (or
+// vice versa) is a no-op. Backends admit the entry to their capacity bound (LRU)
+// inside Commit.
+type EntryWriter interface {
+	io.Writer
+	// Commit persists the streamed body with meta and admits it to the byte cap
+	// (evicting LRU victims). A failure is fail-static: the entry is not cached.
+	Commit(meta Meta) error
+	// Abort discards the streamed body (e.g. truncated/over-cap/panicked fill).
+	Abort()
 }
 
 // Meta is the stored metadata for a cached response. Backends persist it

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -1,0 +1,59 @@
+// Package cache is an HTTP response-cache middleware with a pluggable storage
+// backend. It implements a CDN-style honor-origin policy: it caches a response
+// only when the origin opts in via explicit Cache-Control/Expires freshness;
+// refuses private/no-store/no-cache, Set-Cookie, and Vary: *; honors Vary
+// (keying per varied request header); GET/HEAD only; and ignores the client's
+// request Cache-Control so a client can't bust the shared cache. Concurrent
+// misses for one key collapse into a single origin fetch. It is fail-static: any
+// storage error degrades to a cache miss, never an error to the client. The
+// response is tagged X-Cache: HIT|MISS.
+//
+// Two storage backends ship: an in-memory one ([NewMemory], bodies held in RAM,
+// lost on restart) and a disk-backed one ([NewDisk], survives restarts, bounded
+// by an on-disk byte cap). Both bound their total size with LRU eviction and a
+// per-object cap. Plug either (or your own [Storage]) into [New].
+//
+//	store, _ := cache.NewDisk("/var/cache/app", 1<<30) // 1 GiB on disk
+//	m := cache.New(store, cache.Options{MaxFileSize: 8 << 20})
+//	srv.Use(m) // mount it ahead of the upstream/handler it should cache
+//
+// Only origin-opted-in (public, fresh) content is cached, so per-user or
+// authorization-sensitive responses must be marked uncacheable by the origin.
+package cache
+
+import "net/http"
+
+// Storage is the cache backend: where cached entries live and how total size is
+// bounded. The middleware handles policy, keys, Vary, locking, and X-Cache;
+// Storage only persists bytes and enforces capacity (LRU + per-object cap).
+//
+// Implementations must be safe for concurrent use.
+type Storage interface {
+	// Get returns the entry stored under key, or ok=false on a miss. A hit should
+	// be counted as a recent use (LRU). The returned body must not be mutated by
+	// the caller. Any internal error is reported as a miss (fail-static).
+	Get(key string) (meta Meta, body []byte, ok bool)
+
+	// Set stores body+meta under key, admitting it to the capacity bound and
+	// evicting least-recently-used entries as needed. body is the complete
+	// response body (the middleware has already enforced the per-object cap). A
+	// failure is best-effort/fail-static: the entry is simply not cached.
+	Set(key string, meta Meta, body []byte)
+
+	// Delete removes the entry under key (e.g. when the middleware finds it stale).
+	Delete(key string)
+}
+
+// Meta is the stored metadata for a cached response. Backends persist it
+// alongside the body (the disk backend marshals it to JSON).
+//
+//nolint:govet
+type Meta struct {
+	Status     int         `json:"status"`
+	Header     http.Header `json:"header"`
+	PrimaryHex string      `json:"primary"` // primary key hash (host+method+scheme+uri)
+	Vary       []string    `json:"vary"`    // lowercased Vary header names
+	Created    int64       `json:"created"` // unix nanos
+	FreshUntil int64       `json:"fresh"`   // unix nanos; entry is stale after this
+	Size       int64       `json:"size"`    // body bytes (== eviction weight)
+}

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"bytes"
 	"net/http"
 	"sort"
 	"time"
@@ -22,11 +21,11 @@ var hopByHop = map[string]struct{}{
 }
 
 // teeWriter wraps the client ResponseWriter on a cache fill (the leader path). It
-// streams the response to the client AND, when cacheable, buffers the body
-// (bounded by the per-object cap). On finish it hands a COMPLETE body to the
-// storage backend iff the body is complete (Content-Length matched, or HEAD),
-// guaranteeing a truncated response is never stored. Because nothing is persisted
-// until finish, an upstream panic before finish leaves no temp/partial state.
+// streams the response to the client AND, when cacheable, to a storage
+// EntryWriter (the disk backend streams to a temp file; memory buffers). On
+// finish it Commits iff the body is complete (Content-Length matched, or HEAD),
+// guaranteeing a truncated response is never stored; otherwise it Aborts. cleanup
+// Aborts on a panic before finish so no temp/partial state is left.
 //
 //nolint:govet
 type teeWriter struct {
@@ -38,9 +37,8 @@ type teeWriter struct {
 
 	wroteHeader bool
 	status      int
-	caching     bool
 
-	buf        bytes.Buffer
+	ew         EntryWriter // nil = not caching this response
 	written    int64
 	contentLen int64
 	hasCL      bool
@@ -66,14 +64,17 @@ func (tw *teeWriter) WriteHeader(code int) {
 		sort.Strings(vary)
 		// Store under the key derived from THIS response's Vary + the request's
 		// values, so a later lookup matches once the Vary map is learned.
-		tw.storeKey = variantHashFor(tw.primaryHex, vary, tw.r.Header)
-		tw.caching = true
-		tw.vary = vary
-		tw.freshUntil = dec.freshUntil
-		tw.metaHeader = sanitizeHeader(h)
-		if cl, ok := contentLength(h); ok {
-			tw.hasCL = true
-			tw.contentLen = cl
+		storeKey := variantHashFor(tw.primaryHex, vary, tw.r.Header)
+		if ew, err := tw.c.storage.Writer(storeKey); err == nil {
+			tw.ew = ew
+			tw.storeKey = storeKey
+			tw.vary = vary
+			tw.freshUntil = dec.freshUntil
+			tw.metaHeader = sanitizeHeader(h)
+			if cl, ok := contentLength(h); ok {
+				tw.hasCL = true
+				tw.contentLen = cl
+			}
 		}
 	}
 	h.Set("X-Cache", "MISS")
@@ -85,47 +86,64 @@ func (tw *teeWriter) Write(p []byte) (int, error) {
 		tw.WriteHeader(http.StatusOK)
 	}
 	n, err := tw.rw.Write(p)
-	if tw.caching {
-		if tw.written+int64(len(p)) > tw.c.maxFileSize {
+	if tw.ew != nil {
+		switch {
+		case tw.written+int64(len(p)) > tw.c.maxFileSize:
 			tw.abort() // oversize -> stop caching; client still gets the full response
-		} else {
-			tw.buf.Write(p)
-			tw.written += int64(len(p))
+		default:
+			if _, werr := tw.ew.Write(p); werr != nil {
+				tw.abort()
+			} else {
+				tw.written += int64(len(p))
+			}
 		}
 	}
 	return n, err
 }
 
-// abort stops caching this response and drops the buffered body.
+// abort stops caching this response and discards the in-progress entry.
 func (tw *teeWriter) abort() {
-	tw.caching = false
-	tw.buf.Reset()
+	if tw.ew != nil {
+		tw.ew.Abort()
+		tw.ew = nil
+	}
 }
 
-// finish stores the entry iff the body is complete; a truncated body (written !=
-// Content-Length) or an abort drops it. Runs after the upstream handler returns
-// (the client already has the full response) and before the caller closes the
-// fill lock, so waiting followers find the committed entry.
+// finish commits the entry iff the body is complete; a truncated body (written !=
+// Content-Length) or an abort discards it. Runs after the upstream handler
+// returns (the client already has the full response) and before the caller
+// closes the fill lock, so waiting followers find the committed entry.
 func (tw *teeWriter) finish() {
-	if !tw.caching {
+	if tw.ew == nil {
 		return
 	}
 	complete := tw.method == http.MethodHead || (tw.hasCL && tw.written == tw.contentLen)
 	if !complete {
+		tw.abort()
 		return
 	}
-	body := append([]byte(nil), tw.buf.Bytes()...)
-	m := Meta{
+	meta := Meta{
 		Status:     tw.status,
 		Header:     tw.metaHeader,
 		PrimaryHex: tw.primaryHex,
 		Vary:       tw.vary,
 		Created:    time.Now().UnixNano(),
 		FreshUntil: tw.freshUntil.UnixNano(),
-		Size:       int64(len(body)),
+		Size:       tw.written,
 	}
-	tw.c.storage.Set(tw.storeKey, m, body)
-	tw.c.setPrimaryVary(tw.primaryHex, tw.vary)
+	if err := tw.ew.Commit(meta); err == nil {
+		tw.c.setPrimaryVary(tw.primaryHex, tw.vary)
+	}
+	tw.ew = nil
+}
+
+// cleanup aborts an uncommitted entry. Deferred on the leader path so a panic in
+// the upstream handler (before finish) doesn't leak the temp file.
+func (tw *teeWriter) cleanup() {
+	if tw.ew != nil {
+		tw.ew.Abort()
+		tw.ew = nil
+	}
 }
 
 // Flush forwards to the underlying writer so streaming responses still flush.

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -1,0 +1,153 @@
+package cache
+
+import (
+	"bytes"
+	"net/http"
+	"sort"
+	"time"
+)
+
+// hopByHop headers are connection-specific and must not be stored in (or served
+// from) the shared cache.
+var hopByHop = map[string]struct{}{
+	"Connection":          {},
+	"Proxy-Connection":    {},
+	"Keep-Alive":          {},
+	"Te":                  {},
+	"Trailer":             {},
+	"Transfer-Encoding":   {},
+	"Upgrade":             {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Authorization": {},
+}
+
+// teeWriter wraps the client ResponseWriter on a cache fill (the leader path). It
+// streams the response to the client AND, when cacheable, buffers the body
+// (bounded by the per-object cap). On finish it hands a COMPLETE body to the
+// storage backend iff the body is complete (Content-Length matched, or HEAD),
+// guaranteeing a truncated response is never stored. Because nothing is persisted
+// until finish, an upstream panic before finish leaves no temp/partial state.
+//
+//nolint:govet
+type teeWriter struct {
+	rw         http.ResponseWriter
+	r          *http.Request
+	c          *Cache
+	method     string
+	primaryHex string
+
+	wroteHeader bool
+	status      int
+	caching     bool
+
+	buf        bytes.Buffer
+	written    int64
+	contentLen int64
+	hasCL      bool
+	storeKey   string
+	freshUntil time.Time
+	vary       []string // sorted, lowercased
+	metaHeader http.Header
+}
+
+func (tw *teeWriter) Header() http.Header { return tw.rw.Header() }
+
+func (tw *teeWriter) WriteHeader(code int) {
+	if tw.wroteHeader {
+		return
+	}
+	tw.wroteHeader = true
+	tw.status = code
+
+	h := tw.rw.Header()
+	dec := decide(tw.method, code, h, tw.c.maxFileSize, time.Now())
+	if dec.cacheable {
+		vary := append([]string(nil), dec.vary...)
+		sort.Strings(vary)
+		// Store under the key derived from THIS response's Vary + the request's
+		// values, so a later lookup matches once the Vary map is learned.
+		tw.storeKey = variantHashFor(tw.primaryHex, vary, tw.r.Header)
+		tw.caching = true
+		tw.vary = vary
+		tw.freshUntil = dec.freshUntil
+		tw.metaHeader = sanitizeHeader(h)
+		if cl, ok := contentLength(h); ok {
+			tw.hasCL = true
+			tw.contentLen = cl
+		}
+	}
+	h.Set("X-Cache", "MISS")
+	tw.rw.WriteHeader(code)
+}
+
+func (tw *teeWriter) Write(p []byte) (int, error) {
+	if !tw.wroteHeader {
+		tw.WriteHeader(http.StatusOK)
+	}
+	n, err := tw.rw.Write(p)
+	if tw.caching {
+		if tw.written+int64(len(p)) > tw.c.maxFileSize {
+			tw.abort() // oversize -> stop caching; client still gets the full response
+		} else {
+			tw.buf.Write(p)
+			tw.written += int64(len(p))
+		}
+	}
+	return n, err
+}
+
+// abort stops caching this response and drops the buffered body.
+func (tw *teeWriter) abort() {
+	tw.caching = false
+	tw.buf.Reset()
+}
+
+// finish stores the entry iff the body is complete; a truncated body (written !=
+// Content-Length) or an abort drops it. Runs after the upstream handler returns
+// (the client already has the full response) and before the caller closes the
+// fill lock, so waiting followers find the committed entry.
+func (tw *teeWriter) finish() {
+	if !tw.caching {
+		return
+	}
+	complete := tw.method == http.MethodHead || (tw.hasCL && tw.written == tw.contentLen)
+	if !complete {
+		return
+	}
+	body := append([]byte(nil), tw.buf.Bytes()...)
+	m := Meta{
+		Status:     tw.status,
+		Header:     tw.metaHeader,
+		PrimaryHex: tw.primaryHex,
+		Vary:       tw.vary,
+		Created:    time.Now().UnixNano(),
+		FreshUntil: tw.freshUntil.UnixNano(),
+		Size:       int64(len(body)),
+	}
+	tw.c.storage.Set(tw.storeKey, m, body)
+	tw.c.setPrimaryVary(tw.primaryHex, tw.vary)
+}
+
+// Flush forwards to the underlying writer so streaming responses still flush.
+func (tw *teeWriter) Flush() {
+	if f, ok := tw.rw.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap exposes the underlying writer to http.ResponseController (Flush/Hijack
+// etc. via the standard mechanism).
+func (tw *teeWriter) Unwrap() http.ResponseWriter { return tw.rw }
+
+// sanitizeHeader clones h for the stored meta, dropping hop-by-hop headers (the
+// X-Cache tag is not yet set when this is called).
+func sanitizeHeader(h http.Header) http.Header {
+	out := make(http.Header, len(h))
+	for k, vs := range h {
+		if _, hop := hopByHop[http.CanonicalHeaderKey(k)]; hop {
+			continue
+		}
+		out[k] = append([]string(nil), vs...)
+	}
+	return out
+}


### PR DESCRIPTION
A CDN-style **honor-origin HTTP response cache**, usable as a `parapet.Middleware` over any upstream/handler. Extracted and generalized from the out-of-cluster edge proxy, where it has been running as a disk cache; this version adds a pluggable storage layer with **memory** and **disk** backends.

## Behavior

- **Honor-origin policy**: caches only when the origin opts in via explicit `Cache-Control`/`Expires` freshness; refuses `private`/`no-store`/`no-cache`, `Set-Cookie`, and `Vary: *`; honors `Vary` (keys per varied request header); `GET`/`HEAD` only; a conservative cacheable-status set.
- **CDN semantics**: the client's request `Cache-Control` is ignored, so a client can't bust the shared cache.
- **Single-flight**: concurrent misses for one key collapse into one origin fetch — including the first concurrent fill of a `Vary`'d resource (followers re-key once the response's `Vary` is learned, and serve the just-filled entry or correctly fetch their own variant).
- **Fail-static**: any storage error degrades to a cache miss, never an error to the client.
- Tags `X-Cache: HIT|MISS`.

## Storage layer

```go
type Storage interface {
    Get(key string) (meta Meta, body []byte, ok bool)
    Set(key string, meta Meta, body []byte)
    Delete(key string)
}
```

Two backends ship:

- **`NewMemory(maxSize)`** — bodies in RAM, LRU-bounded by total bytes, lost on restart.
- **`NewDisk(dir, maxSize)`** — sharded files + a JSON meta sidecar, atomic `temp+fsync+rename` with the `.meta` written **last** (its presence implies a complete `.body`), a background startup scan that re-seeds the byte cap and reaps orphans / torn writes / expired entries, survives restarts. LRU-bounded by total on-disk bytes.

Usage:

```go
store, _ := cache.NewDisk("/var/cache/app", 1<<30) // 1 GiB on disk
m := cache.New(store, cache.Options{MaxFileSize: 8 << 20})
srv.Use(m) // ahead of the upstream/handler it should cache
```

## Safety / bounds

- Per-object cap (`Options.MaxFileSize`, default 8 MiB) + total-size LRU on each backend.
- A GET is cached only with a `Content-Length` within the cap, committed only once written bytes == `Content-Length` — so a **truncated** response (client disconnect, upstream error) is never stored; chunked GETs pass through uncached.
- Bodies are buffered (bounded by the cap) during a fill, so an upstream **panic** mid-response leaves no partial state.
- The in-memory primary→`Vary` map is bounded (clear-at-cap; a dropped entry just re-learns).

## Tests

Policy, LRU, **both backends**, concurrency (single-flight incl. `Vary` first-fill), expiry, far-future-TTL clamp, panic-safety, and disk restart persistence — all under `-race`. `golangci-lint` (incl. `fieldalignment`) clean.

> Follow-up: the parapet-ingress-controller edge currently ships its own copy of this cache; once this is released it will switch to `parapet/pkg/cache` and drop the local copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)