### PR TITLE
feat(cache): InvalidatedAfter hook for out-of-band purge

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -35,6 +35,16 @@ type Options struct {
 	// this (by Content-Length, or mid-stream) is not cached but still served in
 	// full. Defaults to 8 MiB when <= 0.
 	MaxFileSize int64
+
+	// InvalidatedAfter, when non-nil, is consulted on every cache hit to support
+	// out-of-band invalidation (cache purge). It receives the request and the
+	// stored entry's Meta and returns an invalidation epoch in unix nanos: a hit
+	// whose Meta.Created is <= the returned epoch is treated as stale (reaped and
+	// served as a miss), exactly like a passed FreshUntil. Return 0 (or any value
+	// below the entry's Created) to keep the entry. It runs only on a hit, so it
+	// costs nothing while the cache is idle; nil disables the check entirely (zero
+	// overhead). The callee owns its own concurrency.
+	InvalidatedAfter func(r *http.Request, m Meta) int64
 }
 
 // Cache is the HTTP response-cache middleware. It implements parapet.Middleware
@@ -42,8 +52,9 @@ type Options struct {
 //
 //nolint:govet
 type Cache struct {
-	storage     Storage
-	maxFileSize int64
+	storage          Storage
+	maxFileSize      int64
+	invalidatedAfter func(r *http.Request, m Meta) int64
 
 	pvMu        sync.RWMutex
 	primaryVary map[string][]string // primaryHex -> Vary header names learned from a stored response
@@ -66,10 +77,11 @@ func New(storage Storage, opts Options) *Cache {
 		mfs = defaultMaxFileSize
 	}
 	return &Cache{
-		storage:     storage,
-		maxFileSize: mfs,
-		primaryVary: map[string][]string{},
-		locks:       map[string]*fillLock{},
+		storage:          storage,
+		maxFileSize:      mfs,
+		invalidatedAfter: opts.InvalidatedAfter,
+		primaryVary:      map[string][]string{},
+		locks:            map[string]*fillLock{},
 	}
 }
 
@@ -105,6 +117,14 @@ func (c *Cache) tryServeHit(w http.ResponseWriter, r *http.Request, key string) 
 		return false
 	}
 	if time.Now().After(time.Unix(0, m.FreshUntil)) {
+		c.storage.Delete(key)
+		return false
+	}
+	// Out-of-band invalidation (cache purge): an entry created at or before the
+	// invalidation epoch is reaped and served as a miss, just like a passed
+	// FreshUntil. Checked after freshness so the common (no-purge) path is one nil
+	// compare.
+	if c.invalidatedAfter != nil && m.Created <= c.invalidatedAfter(r, m) {
 		c.storage.Delete(key)
 		return false
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -31,11 +31,6 @@ const maxPrimaryVary = 1 << 16
 
 // Options configures the cache middleware.
 type Options struct {
-	// MaxFileSize caps a cacheable response's body. A GET response larger than
-	// this (by Content-Length, or mid-stream) is not cached but still served in
-	// full. Defaults to 8 MiB when <= 0.
-	MaxFileSize int64
-
 	// InvalidatedAfter, when non-nil, is consulted on every cache hit to support
 	// out-of-band invalidation (cache purge). It receives the request and the
 	// stored entry's Meta and returns an invalidation epoch in unix nanos: a hit
@@ -45,6 +40,11 @@ type Options struct {
 	// costs nothing while the cache is idle; nil disables the check entirely (zero
 	// overhead). The callee owns its own concurrency.
 	InvalidatedAfter func(r *http.Request, m Meta) int64
+
+	// MaxFileSize caps a cacheable response's body. A GET response larger than
+	// this (by Content-Length, or mid-stream) is not cached but still served in
+	// full. Defaults to 8 MiB when <= 0.
+	MaxFileSize int64
 }
 
 // Cache is the HTTP response-cache middleware. It implements parapet.Middleware

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -239,6 +239,49 @@ func TestCache_ExpiredEntryIsMiss(t *testing.T) {
 	})
 }
 
+func TestCache_InvalidatedAfterPurgesHit(t *testing.T) {
+	backends := []struct {
+		name string
+		new  func() Storage
+	}{
+		{"memory", func() Storage { return NewMemory(1 << 20) }},
+		{"disk", func() Storage {
+			d, err := NewDisk(t.TempDir(), 1<<20)
+			require.NoError(t, err)
+			return d
+		}},
+	}
+	for _, bk := range backends {
+		t.Run(bk.name, func(t *testing.T) {
+			var epoch atomic.Int64 // invalidation epoch (unix nanos); 0 = nothing purged
+			c := New(bk.new(), Options{
+				MaxFileSize:      1024,
+				InvalidatedAfter: func(_ *http.Request, _ Meta) int64 { return epoch.Load() },
+			})
+			var calls int32
+			h := origin(originSpec{body: []byte("p"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+
+			// epoch 0: the hook is present but purges nothing (Created > 0), so the
+			// entry fills then hits — the no-purge fast path stays a hit.
+			assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/p", nil).Header().Get("X-Cache"))
+			assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/p", nil).Header().Get("X-Cache"))
+			assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+
+			// Purge: bump the epoch to now. The cached entry was created before this,
+			// so its next lookup is reaped and served as a miss (re-fetch).
+			epoch.Store(time.Now().UnixNano())
+			r := do(c, h, "GET", "http://acme.com/p", nil)
+			assert.Equal(t, "MISS", r.Header().Get("X-Cache"), "entry created at/before the epoch is purged")
+			assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+
+			// The re-fill was created after the epoch, so it hits again (a purge
+			// invalidates only what existed when it was issued).
+			assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/p", nil).Header().Get("X-Cache"))
+			assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+		})
+	}
+}
+
 func TestCache_PanicDuringFillIsSafe(t *testing.T) {
 	// Buffering (no temp file) makes a fill panic-safe: nothing is persisted, and
 	// the cache stays usable afterward.


### PR DESCRIPTION
## What

Adds an optional `Options.InvalidatedAfter func(r *http.Request, m Meta) int64` hook to the response-cache middleware. It is consulted on every cache **hit**: an entry whose `Meta.Created` is `<=` the returned epoch (unix nanos) is reaped and served as a miss — exactly mirroring the existing `FreshUntil` staleness path.

## Why

This gives a caller a lookup-time gate to implement **out-of-band invalidation (cache purge)** with full access to the request and the stored `Meta`. Because the gate sees the live request (host/uri) it can support **global**, **per-host**, and **per-URL** purge scopes, keyed however the caller likes — none of which is expressible from the `Storage` interface alone (it never sees the raw host/uri).

The immediate consumer is the parapet-ingress-controller edge proxy's cache-purge feature (EDGE.md Phase 5), which owns an epoch table fed from its control plane and supplies the closure.

## Safety / compatibility

- `nil` (the default) disables the check entirely — **existing users are unaffected** and an idle cache pays nothing.
- The check runs only on a hit and is **one nil-compare on the common no-purge path** (placed after the `FreshUntil` check).
- Return `0` (or any value below the entry's `Created`) to keep an entry.

## Tests

`TestCache_InvalidatedAfterPurgesHit` covers both memory and disk backends: epoch-0 still hits, a bumped epoch purges the older entry and re-fetches, and a post-epoch re-fill hits again. `gofmt`/`go vet` clean; full module test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)