### PR TITLE
feat(cache): Storage.Range + raw Host/URI in Meta for out-of-band reaping

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -196,13 +196,21 @@ func (c *Cache) primaryHash(r *http.Request) string {
 			scheme = "http"
 		}
 	}
-	host := strings.ToLower(r.Host)
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h // drop :port (SplitHostPort errors when there is none)
-	}
+	host := normalizeHost(r.Host)
 	uri := r.URL.RequestURI()
 	sum := sha256.Sum256([]byte(host + "\n" + r.Method + "\n" + scheme + "\n" + uri))
 	return hex.EncodeToString(sum[:16])
+}
+
+// normalizeHost lowercases a host and strips any port, matching the form used in
+// the primary key. It is also stamped into Meta.Host so out-of-band Range
+// maintenance can key on the same value.
+func normalizeHost(host string) string {
+	host = strings.ToLower(host)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h // drop :port (SplitHostPort errors when there is none)
+	}
+	return host
 }
 
 // variantHash mixes the primary hash with the request's values for the Vary

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -282,6 +282,69 @@ func TestCache_InvalidatedAfterPurgesHit(t *testing.T) {
 	}
 }
 
+func TestStorage_RangeVisitsEntriesAndAllowsDelete(t *testing.T) {
+	backends := []struct {
+		name string
+		new  func() Storage
+	}{
+		{"memory", func() Storage { return NewMemory(1 << 20) }},
+		{"disk", func() Storage {
+			d, err := NewDisk(t.TempDir(), 1<<20)
+			require.NoError(t, err)
+			return d
+		}},
+	}
+	for _, bk := range backends {
+		t.Run(bk.name, func(t *testing.T) {
+			s := bk.new()
+			fresh := time.Now().Add(time.Hour).UnixNano()
+			for _, k := range []string{"aa01", "bb02", "cc03"} {
+				storePut(t, s, k, Meta{PrimaryHex: k, Host: "acme.com", URI: "/" + k, Created: 1, FreshUntil: fresh, Size: 3}, []byte("xyz"))
+			}
+
+			// Range sees all three and exposes Meta; delete one from inside fn.
+			seen := map[string]Meta{}
+			s.Range(func(key string, m Meta) bool {
+				seen[key] = m
+				if key == "bb02" {
+					s.Delete(key)
+				}
+				return true
+			})
+			assert.Len(t, seen, 3)
+			assert.Equal(t, "acme.com", seen["aa01"].Host)
+			assert.Equal(t, "/aa01", seen["aa01"].URI)
+
+			_, _, ok := s.Get("bb02")
+			assert.False(t, ok, "deleted from within Range")
+			cnt := 0
+			s.Range(func(string, Meta) bool { cnt++; return true })
+			assert.Equal(t, 2, cnt)
+
+			// Early stop: returning false halts iteration.
+			visited := 0
+			s.Range(func(string, Meta) bool { visited++; return false })
+			assert.Equal(t, 1, visited)
+		})
+	}
+}
+
+func TestCache_MetaCarriesHostURIForRange(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("x"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+		do(c, h, "GET", "http://Acme.COM:8443/p?q=1", nil) // fill (mixed case + port)
+
+		got := map[string]Meta{}
+		c.storage.Range(func(k string, m Meta) bool { got[k] = m; return true })
+		require.Len(t, got, 1)
+		for _, m := range got {
+			assert.Equal(t, "acme.com", m.Host, "host normalized (lowercased, port-stripped) for Range maintenance")
+			assert.Equal(t, "/p?q=1", m.URI)
+		}
+	})
+}
+
 func TestCache_PanicDuringFillIsSafe(t *testing.T) {
 	// Buffering (no temp file) makes a fill panic-safe: nothing is persisted, and
 	// the cache stays usable afterward.

--- a/pkg/cache/disk.go
+++ b/pkg/cache/disk.go
@@ -123,6 +123,46 @@ func (s *DiskStorage) removeFiles(key string) {
 	os.Remove(s.bodyPath(key))
 }
 
+// Range walks the shard dirs reading each entry's .meta sidecar and calls fn(key,
+// Meta), stopping early if fn returns false. It holds no lock, so fn may Delete the
+// entry it is visiting (the keys come from a directory snapshot taken before fn
+// runs). Unreadable/corrupt sidecars are skipped. For maintenance only, off the
+// serving path.
+func (s *DiskStorage) Range(fn func(key string, m Meta) bool) {
+	shards, err := os.ReadDir(s.dir)
+	if err != nil {
+		return
+	}
+	for _, sh := range shards {
+		if !sh.IsDir() || sh.Name() == "tmp" {
+			continue
+		}
+		shardPath := filepath.Join(s.dir, sh.Name())
+		ents, err := os.ReadDir(shardPath)
+		if err != nil {
+			continue
+		}
+		for _, e := range ents {
+			name := e.Name()
+			if !strings.HasSuffix(name, ".meta") {
+				continue
+			}
+			key := strings.TrimSuffix(name, ".meta")
+			mb, err := os.ReadFile(filepath.Join(shardPath, name))
+			if err != nil {
+				continue
+			}
+			var m Meta
+			if err := json.Unmarshal(mb, &m); err != nil {
+				continue
+			}
+			if !fn(key, m) {
+				return
+			}
+		}
+	}
+}
+
 //nolint:govet
 type diskWriter struct {
 	s    *DiskStorage

--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -53,6 +53,27 @@ func (s *MemoryStorage) Delete(key string) {
 	s.lru.remove(key)
 }
 
+// Range snapshots the current (key, Meta) pairs under the read lock, then calls fn
+// for each WITHOUT holding the lock — so fn may Delete entries (which takes the
+// write lock) without deadlocking. The snapshot copies only metadata, not bodies.
+func (s *MemoryStorage) Range(fn func(key string, m Meta) bool) {
+	s.mu.RLock()
+	type kv struct {
+		key string
+		m   Meta
+	}
+	snap := make([]kv, 0, len(s.m))
+	for k, e := range s.m {
+		snap = append(snap, kv{k, e.meta})
+	}
+	s.mu.RUnlock()
+	for _, e := range snap {
+		if !fn(e.key, e.m) {
+			return
+		}
+	}
+}
+
 //nolint:govet
 type memWriter struct {
 	s    *MemoryStorage

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -51,6 +51,16 @@ type Storage interface {
 
 	// Delete removes the entry under key (e.g. when the middleware finds it stale).
 	Delete(key string)
+
+	// Range calls fn for each currently-stored entry (key + its Meta), stopping
+	// early if fn returns false. It is for out-of-band maintenance — e.g. a purge
+	// reaper that physically deletes entries matching an external predicate — not
+	// the serving path. Iteration order is unspecified, and the snapshot is
+	// best-effort: fn may observe an entry that is concurrently deleted, and an
+	// entry written during the walk may or may not be visited. fn MAY call
+	// Delete(key) on this storage (a backend must not hold a lock across fn that
+	// Delete would need). fn MUST NOT call Writer.
+	Range(fn func(key string, m Meta) bool)
 }
 
 // EntryWriter streams one cached body and finalizes it. Exactly one of Commit or
@@ -73,9 +83,11 @@ type EntryWriter interface {
 type Meta struct {
 	Status     int         `json:"status"`
 	Header     http.Header `json:"header"`
-	PrimaryHex string      `json:"primary"` // primary key hash (host+method+scheme+uri)
-	Vary       []string    `json:"vary"`    // lowercased Vary header names
-	Created    int64       `json:"created"` // unix nanos
-	FreshUntil int64       `json:"fresh"`   // unix nanos; entry is stale after this
-	Size       int64       `json:"size"`    // body bytes (== eviction weight)
+	PrimaryHex string      `json:"primary"`        // primary key hash (host+method+scheme+uri)
+	Host       string      `json:"host,omitempty"` // normalized host (lowercased, port-stripped); for out-of-band Range maintenance
+	URI        string      `json:"uri,omitempty"`  // request-uri (path+query); for out-of-band Range maintenance
+	Vary       []string    `json:"vary"`           // lowercased Vary header names
+	Created    int64       `json:"created"`        // unix nanos
+	FreshUntil int64       `json:"fresh"`          // unix nanos; entry is stale after this
+	Size       int64       `json:"size"`           // body bytes (== eviction weight)
 }

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -126,6 +126,8 @@ func (tw *teeWriter) finish() {
 		Status:     tw.status,
 		Header:     tw.metaHeader,
 		PrimaryHex: tw.primaryHex,
+		Host:       normalizeHost(tw.r.Host),
+		URI:        tw.r.URL.RequestURI(),
 		Vary:       tw.vary,
 		Created:    time.Now().UnixNano(),
 		FreshUntil: tw.freshUntil.UnixNano(),


### PR DESCRIPTION
## What

Two additive changes to `pkg/cache` that enable an **out-of-band cache reaper**:

1. **`Storage.Range(fn func(key string, m Meta) bool)`** — a new interface method (implemented by both the memory and disk backends) that enumerates stored entries with their `Meta`, stopping early if `fn` returns false. It holds no lock across `fn`, so `fn` may `Delete(key)` the entry it is visiting (memory snapshots metadata under the read lock first; disk walks the shard dirs).
2. **`Meta.Host` + `Meta.URI`** — the normalized request host (lowercased, port-stripped) and request-uri, stamped at store time (`teeWriter.finish`). `Meta` already keeps only the opaque `PrimaryHex` hash, so a maintenance loop couldn't tell which host/url a stored entry belonged to; these let it match entries against a per-host / per-url predicate without the original request.

## Why

The `InvalidatedAfter` hook (added in v0.17.0, #183) reaps invalidated entries **lazily** — only on the next lookup of each entry. After a broad purge (e.g. flush-all) with little subsequent traffic, the now-dead bytes linger on disk until LRU pressure or a future request evicts them. A reaper needs to (a) enumerate entries and (b) know each entry's host/url to apply the purge predicate off the serving path. These two additions provide exactly that.

The consumer is the parapet-ingress-controller edge proxy's purge reaper.

## Compatibility

Both changes are additive:
- `Meta` gains `Host`/`URI` (`omitempty`); old on-disk entries deserialize with them empty, and a reaper can still match those by the global (flush-all) scope.
- `Range` is a new interface method — a **custom `Storage` implementation must add it** (the two shipped backends do).

## Tests

`TestStorage_RangeVisitsEntriesAndAllowsDelete` (both backends: enumeration, delete-from-within-fn, early stop) and `TestCache_MetaCarriesHostURIForRange` (host normalized + uri populated through the middleware). `gofmt`/`go vet` clean (govet/fieldalignment is config-excluded on `_test.go`; `teeWriter` keeps its existing `//nolint:govet`), full module builds and all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)