### PR TITLE
fix(cache): don't share Authorization-bearing responses across users

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -366,3 +366,33 @@ func TestCache_PanicDuringFillIsSafe(t *testing.T) {
 		assert.Equal(t, "MISS", do(c, ok, "GET", "http://acme.com/after", nil).Header().Get("X-Cache"))
 	})
 }
+
+// A response to an Authorization-bearing request must not be served to other
+// users from a shared cache unless the origin explicitly opted in (RFC 9111 §3.5).
+func TestCache_AuthorizationNotSharedAcrossUsers(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		// Bare max-age (no public/s-maxage/must-revalidate) on an authenticated request.
+		h := origin(originSpec{body: []byte("user-A-private"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+
+		// User A (authenticated): not shared-cacheable, so nothing is stored.
+		rA := do(c, h, "GET", "http://acme.com/account", hdr("Authorization", "Bearer tokenA"))
+		assert.Equal(t, "MISS", rA.Header().Get("X-Cache"))
+
+		// User B (no credentials) must not receive A's body from the cache.
+		rB := do(c, h, "GET", "http://acme.com/account", nil)
+		assert.Equal(t, "MISS", rB.Header().Get("X-Cache"), "authorized response must not be shared with other users")
+		assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "each request reaches the origin; A's response is never shared")
+	})
+}
+
+// public opt-in makes an authorized response shared-cacheable (RFC 9111 §3.5).
+func TestCache_AuthorizationCachedWithExplicitSharedOptIn(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("shared"), header: hdr("Cache-Control", "public, max-age=60")}, &calls)
+		assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/pub", hdr("Authorization", "Bearer t")).Header().Get("X-Cache"))
+		assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/pub", nil).Header().Get("X-Cache"))
+		assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
+	})
+}

--- a/pkg/cache/policy.go
+++ b/pkg/cache/policy.go
@@ -52,7 +52,8 @@ type decision struct {
 }
 
 // decide applies the honor-origin policy to an origin response. method is the
-// request method; status/h are the response status + headers; maxFileSize caps a
+// request method; status/h are the response status + headers; reqAuthorized
+// reports whether the request carried an Authorization header; maxFileSize caps a
 // GET's Content-Length; now is the reference time for freshness. Returns
 // cacheable=false unless the origin explicitly opted in with freshness and the
 // response isn't refused for any reason.
@@ -61,7 +62,7 @@ type decision struct {
 // commits a body only once written bytes == Content-Length, guaranteeing a
 // truncated response is never stored. A chunked (no Content-Length) GET passes
 // through uncached. HEAD has no body and is unaffected.
-func decide(method string, status int, h http.Header, maxFileSize int64, now time.Time) decision {
+func decide(method string, status int, h http.Header, reqAuthorized bool, maxFileSize int64, now time.Time) decision {
 	no := decision{}
 	if !cacheableStatus(status) {
 		return no
@@ -76,6 +77,15 @@ func decide(method string, status int, h http.Header, maxFileSize int64, now tim
 	}
 	cc := parseCacheControl(h)
 	if cc.private || cc.noStore || cc.noCache {
+		return no
+	}
+	// RFC 9111 §3.5: a shared cache MUST NOT store/reuse a response to an
+	// Authorization-bearing request unless the response explicitly opts in via
+	// public, s-maxage, or must-revalidate. The honor-origin policy otherwise keys
+	// without Authorization, so without this gate a bare max-age response to an
+	// authenticated request would be served to other users — a cross-user leak.
+	sharedOptIn := cc.public || cc.hasSMax || cc.mustRevalidate
+	if reqAuthorized && !sharedOptIn {
 		return no
 	}
 	ttl := freshness(cc, h, now)
@@ -120,13 +130,15 @@ func parseVary(h http.Header) (names []string, star bool) {
 
 //nolint:govet
 type cacheControl struct {
-	private bool
-	noStore bool
-	noCache bool
-	maxAge  int64
-	sMaxAge int64
-	hasMax  bool
-	hasSMax bool
+	private        bool
+	noStore        bool
+	noCache        bool
+	public         bool
+	mustRevalidate bool
+	maxAge         int64
+	sMaxAge        int64
+	hasMax         bool
+	hasSMax        bool
 }
 
 // parseCacheControl parses the response Cache-Control directives the policy
@@ -149,6 +161,10 @@ func parseCacheControl(h http.Header) cacheControl {
 				cc.noStore = true
 			case "no-cache":
 				cc.noCache = true
+			case "public":
+				cc.public = true
+			case "must-revalidate":
+				cc.mustRevalidate = true
 			case "max-age":
 				if n, err := strconv.ParseInt(val, 10, 64); err == nil {
 					cc.maxAge = n

--- a/pkg/cache/policy_test.go
+++ b/pkg/cache/policy_test.go
@@ -23,7 +23,7 @@ func cacheableGET(t *testing.T, h http.Header) bool {
 	if h.Get("Content-Length") == "" {
 		h.Set("Content-Length", "10")
 	}
-	return decide(http.MethodGet, 200, h, maxFile, time.Unix(1_000_000, 0)).cacheable
+	return decide(http.MethodGet, 200, h, false, maxFile, time.Unix(1_000_000, 0)).cacheable
 }
 
 func TestDecide_HonorsOriginFreshnessOnly(t *testing.T) {
@@ -42,41 +42,61 @@ func TestDecide_RefusesPrivateNoStoreNoCacheSetCookieVaryStar(t *testing.T) {
 	assert.False(t, cacheableGET(t, hdr("Cache-Control", "public, max-age=60", "Vary", "*")))
 }
 
+// An Authorization-bearing request's response is only shared-cacheable when the
+// origin explicitly opts in via public, s-maxage, or must-revalidate (RFC 9111
+// §3.5). A bare max-age is refused so it can't be served to other users.
+func TestDecide_AuthorizationRequiresExplicitSharedOptIn(t *testing.T) {
+	cl := func(cc string) http.Header { return hdr("Cache-Control", cc, "Content-Length", "1") }
+	now := time.Now()
+
+	// Authorized request: bare max-age (or Expires) is NOT shared-cacheable.
+	assert.False(t, decide(http.MethodGet, 200, cl("max-age=60"), true, maxFile, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", now.Add(time.Hour).UTC().Format(http.TimeFormat), "Content-Length", "1"), true, maxFile, now).cacheable)
+
+	// Explicit shared opt-in re-enables caching for an authorized request.
+	assert.True(t, decide(http.MethodGet, 200, cl("public, max-age=60"), true, maxFile, now).cacheable)
+	assert.True(t, decide(http.MethodGet, 200, cl("s-maxage=60"), true, maxFile, now).cacheable)
+	assert.True(t, decide(http.MethodGet, 200, cl("must-revalidate, max-age=60"), true, maxFile, now).cacheable)
+
+	// An unauthenticated request is unaffected: bare max-age still caches.
+	assert.True(t, decide(http.MethodGet, 200, cl("max-age=60"), false, maxFile, now).cacheable)
+}
+
 func TestDecide_VaryNamedHeaderStillCacheable(t *testing.T) {
-	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "5", "Vary", "Accept-Encoding"), maxFile, time.Now())
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "5", "Vary", "Accept-Encoding"), false, maxFile, time.Now())
 	assert.True(t, d.cacheable)
 	assert.Equal(t, []string{"accept-encoding"}, d.vary)
 }
 
 func TestDecide_StatusCodes(t *testing.T) {
 	for _, code := range []int{200, 203, 204, 300, 301, 308, 404, 410} {
-		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), maxFile, time.Now())
+		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), false, maxFile, time.Now())
 		assert.True(t, d.cacheable, "status %d should be cacheable with freshness", code)
 	}
 	for _, code := range []int{201, 302, 401, 403, 500, 502, 206} {
-		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), maxFile, time.Now())
+		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), false, maxFile, time.Now())
 		assert.False(t, d.cacheable, "status %d should not be cached", code)
 	}
 }
 
 func TestDecide_ContentLengthCapAndPresence(t *testing.T) {
-	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60"), maxFile, time.Now()).cacheable)
-	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "9000000"), maxFile, time.Now()).cacheable)
-	assert.True(t, decide(http.MethodHead, 200, hdr("Cache-Control", "max-age=60"), maxFile, time.Now()).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60"), false, maxFile, time.Now()).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "9000000"), false, maxFile, time.Now()).cacheable)
+	assert.True(t, decide(http.MethodHead, 200, hdr("Cache-Control", "max-age=60"), false, maxFile, time.Now()).cacheable)
 }
 
 func TestDecide_Expires(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	future := now.Add(time.Hour).UTC().Format(http.TimeFormat)
 	past := now.Add(-time.Hour).UTC().Format(http.TimeFormat)
-	assert.True(t, decide(http.MethodGet, 200, hdr("Expires", future, "Content-Length", "1"), maxFile, now).cacheable)
-	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", past, "Content-Length", "1"), maxFile, now).cacheable)
-	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", "0", "Content-Length", "1"), maxFile, now).cacheable)
+	assert.True(t, decide(http.MethodGet, 200, hdr("Expires", future, "Content-Length", "1"), false, maxFile, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", past, "Content-Length", "1"), false, maxFile, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", "0", "Content-Length", "1"), false, maxFile, now).cacheable)
 }
 
 func TestDecide_FarFutureTTLClamped(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=7445000000", "Content-Length", "1"), maxFile, now) // ~236y
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=7445000000", "Content-Length", "1"), false, maxFile, now) // ~236y
 	assert.True(t, d.cacheable)
 	// clamped well within UnixNano range (year < 2262)
 	assert.True(t, d.freshUntil.Before(time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)))

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -18,8 +18,11 @@
 //	m := cache.New(store, cache.Options{MaxFileSize: 8 << 20})
 //	srv.Use(m) // mount it ahead of the upstream/handler it should cache
 //
-// Only origin-opted-in (public, fresh) content is cached, so per-user or
-// authorization-sensitive responses must be marked uncacheable by the origin.
+// Only origin-opted-in (public, fresh) content is cached, so per-user responses
+// must be marked uncacheable by the origin. As a shared cache it additionally
+// follows RFC 9111 §3.5: a response to a request bearing an Authorization header
+// is cached only when the origin explicitly opts in via public, s-maxage, or
+// must-revalidate.
 package cache
 
 import (

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -58,7 +58,8 @@ func (tw *teeWriter) WriteHeader(code int) {
 	tw.status = code
 
 	h := tw.rw.Header()
-	dec := decide(tw.method, code, h, tw.c.maxFileSize, time.Now())
+	reqAuthorized := tw.r.Header.Get("Authorization") != ""
+	dec := decide(tw.method, code, h, reqAuthorized, tw.c.maxFileSize, time.Now())
 	if dec.cacheable {
 		vary := append([]string(nil), dec.vary...)
 		sort.Strings(vary)


### PR DESCRIPTION
## Problem

The new `pkg/cache` is a **shared** response cache, but it keyed entries on `host+method+scheme+uri` with no per-user component and decided cacheability from the **response only**. So a response to a request carrying `Authorization` was stored and served — verbatim, as `X-Cache: HIT` — to *other* users (including unauthenticated ones) for the same URL.

Reproduced before the fix:

```
A (auth):    GET /dashboard  Authorization: Bearer tokenA  → origin 200, Cache-Control: max-age=60
             X-Cache: MISS
B (no auth): GET /dashboard  (no credentials)              → X-Cache: HIT, body = user A's private body
             origin contacted exactly once
```

RFC 9111 §3.5 (RFC 7234 §3.2) requires a shared cache to **not** reuse a response to an `Authorization`-bearing request unless the response explicitly allows it via `public`, `s-maxage`, or `must-revalidate`. None of `public`/`must-revalidate` were parsed, and the request was never consulted.

## Fix

- `decide()` now receives whether the request carried an `Authorization` header and refuses to cache absent an explicit shared opt-in (`public` / `s-maxage` / `must-revalidate`).
- `parseCacheControl` learns `public` and `must-revalidate`.
- `teeWriter.WriteHeader` passes `r.Header.Get("Authorization") != ""`.
- Package doc updated to state the RFC 9111 §3.5 behavior.

Behavior summary:

| Request | Response `Cache-Control` | Before | After |
|---|---|---|---|
| `Authorization: …` | `max-age=60` | cached + shared | **not cached** |
| `Authorization: …` | `public, max-age=60` | cached + shared | cached + shared |
| `Authorization: …` | `s-maxage=60` | cached + shared | cached + shared |
| `Authorization: …` | `must-revalidate, max-age=60` | cached + shared | cached + shared |
| *(no auth)* | `max-age=60` | cached | cached *(unchanged)* |

## Tests

- `TestDecide_AuthorizationRequiresExplicitSharedOptIn` — unit coverage of the refusal + the three opt-in directives + the unauthenticated path.
- `TestCache_AuthorizationNotSharedAcrossUsers` — end-to-end (both backends): an authed bare-`max-age` response is never served to a second user.
- `TestCache_AuthorizationCachedWithExplicitSharedOptIn` — end-to-end: `public` re-enables sharing.

`go vet`, `go test -race ./pkg/cache/...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)