### PR TITLE
fix(cache): account for response Age in freshness (RFC 9111 §4.2.3)

### DIFF
--- a/pkg/cache/policy.go
+++ b/pkg/cache/policy.go
@@ -165,30 +165,71 @@ func parseCacheControl(h http.Header) cacheControl {
 	return cc
 }
 
-// freshness returns the cacheable lifetime: s-maxage wins (shared-cache
-// directive), then max-age, then Expires (relative to Date if present, else
-// now). Returns 0 (not fresh) when the origin gave no explicit freshness.
+// freshness returns the remaining cacheable lifetime from now: the origin's
+// declared freshness lifetime minus the age the response already had when it was
+// received. Accounting for that age (RFC 9111 §4.2.3) keeps the cache from
+// over-serving a response that was already aged upstream — e.g. max-age=60 on a
+// response carrying Age: 55 is fresh for ~5s, not a full 60s. Returns <= 0
+// (treated as not cacheable) when the origin gave no explicit freshness or the
+// response is already stale on arrival.
 func freshness(cc cacheControl, h http.Header, now time.Time) time.Duration {
+	lifetime := freshnessLifetime(cc, h, now)
+	if lifetime <= 0 {
+		return lifetime // no explicit freshness, or already-expired
+	}
+	return lifetime - responseAge(h, now)
+}
+
+// freshnessLifetime returns the origin's declared freshness lifetime: s-maxage
+// wins (shared-cache directive), then max-age, then Expires (relative to Date if
+// present, else now). Returns 0 when the origin gave no explicit freshness.
+func freshnessLifetime(cc cacheControl, h http.Header, now time.Time) time.Duration {
 	if cc.hasSMax {
 		return time.Duration(cc.sMaxAge) * time.Second
 	}
 	if cc.hasMax {
 		return time.Duration(cc.maxAge) * time.Second
 	}
-	if exp := h.Get("Expires"); exp != "" {
-		expTime, err := http.ParseTime(exp)
-		if err != nil {
-			return 0 // an unparseable Expires (e.g. "0") means already-expired
+	exp := h.Get("Expires")
+	if exp == "" {
+		return 0
+	}
+	expTime, err := http.ParseTime(exp)
+	if err != nil {
+		return 0 // an unparseable Expires (e.g. "0") means already-expired
+	}
+	ref := now
+	if d := h.Get("Date"); d != "" {
+		if dt, derr := http.ParseTime(d); derr == nil {
+			ref = dt
 		}
-		ref := now
-		if d := h.Get("Date"); d != "" {
-			if dt, derr := http.ParseTime(d); derr == nil {
-				ref = dt
+	}
+	return expTime.Sub(ref)
+}
+
+// responseAge estimates how old the response already was when received: the larger
+// of the Age header value and the apparent age (now - Date). Per RFC 9111 §4.2.3
+// this is the corrected initial age at receipt; resident time afterwards is
+// tracked by the stored FreshUntil clock. Never negative.
+func responseAge(h http.Header, now time.Time) time.Duration {
+	var apparent time.Duration
+	if d := h.Get("Date"); d != "" {
+		if dt, err := http.ParseTime(d); err == nil {
+			if a := now.Sub(dt); a > apparent {
+				apparent = a
 			}
 		}
-		return expTime.Sub(ref)
 	}
-	return 0
+	var ageVal time.Duration
+	if v := h.Get("Age"); v != "" {
+		if n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64); err == nil && n > 0 {
+			ageVal = time.Duration(n) * time.Second
+		}
+	}
+	if ageVal > apparent {
+		return ageVal
+	}
+	return apparent
 }
 
 // contentLength parses the Content-Length header.

--- a/pkg/cache/policy_test.go
+++ b/pkg/cache/policy_test.go
@@ -95,3 +95,29 @@ func TestFreshness_SMaxAgeWins(t *testing.T) {
 	cc := parseCacheControl(hdr("Cache-Control", "max-age=10, s-maxage=99"))
 	assert.Equal(t, 99*time.Second, freshness(cc, http.Header{}, time.Now()))
 }
+
+// The remaining lifetime is reduced by the response's age (RFC 9111 §4.2.3): the
+// larger of the Age header and the apparent age (now - Date).
+func TestFreshness_SubtractsResponseAge(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	cc := parseCacheControl(hdr("Cache-Control", "max-age=60"))
+	date50 := now.Add(-50 * time.Second).UTC().Format(http.TimeFormat)
+
+	assert.Equal(t, 60*time.Second, freshness(cc, http.Header{}, now), "no Age/Date: full lifetime")
+	assert.Equal(t, 5*time.Second, freshness(cc, hdr("Age", "55"), now), "Age header subtracted")
+	assert.Equal(t, 10*time.Second, freshness(cc, hdr("Date", date50), now), "apparent age (now-Date) subtracted")
+	assert.Equal(t, 5*time.Second, freshness(cc, hdr("Age", "55", "Date", date50), now), "larger of Age and apparent age wins")
+	assert.LessOrEqual(t, freshness(cc, hdr("Age", "120"), now), time.Duration(0), "age beyond lifetime: not fresh")
+}
+
+// An already-aged response stays cacheable only for its remaining lifetime, and a
+// response aged past its lifetime is not cached at all.
+func TestDecide_AgeReducesFreshness(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), maxFile, now)
+	assert.True(t, d.cacheable)
+	assert.Equal(t, now.Add(5*time.Second), d.freshUntil, "freshUntil reflects the ~5s remaining after Age")
+
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), maxFile, now).cacheable,
+		"Age >= max-age: already stale, not cached")
+}


### PR DESCRIPTION
## Problem

`freshness()` derived the cacheable lifetime purely from `s-maxage`/`max-age` relative to **receipt time** and never looked at how old the response already was. So a response that was already aged upstream is served fresh for its *full* declared lifetime.

Reproduced before the fix:

```
decide(GET, 200, {Cache-Control: max-age=60, Age: 55}, now)
  → cacheable=true, freshUntil = now + 60s
  RFC-correct remaining lifetime with Age:55 = ~5s   (over-served by ~55s)
```

RFC 9111 §4.2.3 defines `usable_lifetime = freshness_lifetime − current_age`, where `current_age` incorporates the `Age` header and the time elapsed since `Date`. This matters most for the normal reverse-proxy deployment — a parapet cache sitting behind another CDN/cache tier — where the error compounds at each hop. (The `Expires` path already referenced `Date`; this fixes the common `max-age`/`s-maxage` path and folds `Age` in everywhere.)

## Fix

`freshness()` now subtracts the response's age from the declared lifetime:

- `freshnessLifetime()` — the origin's declared lifetime (`s-maxage` → `max-age` → `Expires`), factored out unchanged.
- `responseAge()` — the larger of the `Age` header and the apparent age (`now − Date`), never negative.
- A response that arrives already past its lifetime clamps to `≤ 0` and is not cached (existing `decide()` gate).

No public API change; behavior with no `Age`/`Date` headers is identical to before (`responseAge == 0`).

## Tests

- `TestFreshness_SubtractsResponseAge` — `Age` header, apparent age from `Date`, the max-of-the-two rule, and age-beyond-lifetime.
- `TestDecide_AgeReducesFreshness` — `freshUntil` reflects the reduced remaining lifetime, and `Age ≥ max-age` is not cached.

`go vet`, `go test -race ./...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)