### PR TITLE
fix(cache): repair build — Age tests use post-#185 decide signature

### DIFF
--- a/pkg/cache/policy_test.go
+++ b/pkg/cache/policy_test.go
@@ -134,10 +134,10 @@ func TestFreshness_SubtractsResponseAge(t *testing.T) {
 // response aged past its lifetime is not cached at all.
 func TestDecide_AgeReducesFreshness(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), maxFile, now)
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), false, maxFile, now)
 	assert.True(t, d.cacheable)
 	assert.Equal(t, now.Add(5*time.Second), d.freshUntil, "freshUntil reflects the ~5s remaining after Age")
 
-	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), maxFile, now).cacheable,
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), false, maxFile, now).cacheable,
 		"Age >= max-age: already stale, not cached")
 }


### PR DESCRIPTION
**Merge this first — `master` currently does not compile.**

`#186` (Age-aware freshness) was branched from `master` *before* `#185` (the Authorization gate) merged. `#185` changed `decide()` to take a `reqAuthorized bool`; `#186`'s `TestDecide_AgeReducesFreshness` still called the old 5-arg form. The two PRs touched different regions of `policy_test.go`, so git auto-merged them with no conflict — but the result doesn't build:

```
vet: pkg/cache/policy_test.go:137: not enough arguments in call to decide
	have (string, int, http.Header, int64, time.Time)
	want (string, int, http.Header, bool, int64, time.Time)
```

This passes the `reqAuthorized` argument (`false`) at the two affected call sites. No production code changes.

`go vet` and `go test -race ./pkg/cache/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)