### PR TITLE
fix(cache): deep-copy Meta in the memory backend (Get and Range)

### DIFF
--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"bytes"
+	"net/http"
 	"sync"
 )
 
@@ -27,7 +28,10 @@ func NewMemory(maxSize int64) *MemoryStorage {
 	return &MemoryStorage{m: map[string]memEntry{}, lru: newLRU(maxSize)}
 }
 
-// Get returns the entry under key, touching its LRU recency on a hit.
+// Get returns the entry under key, touching its LRU recency on a hit. The Meta is
+// deep-copied so a caller (e.g. the InvalidatedAfter hook) can't mutate the live
+// stored entry; the body is returned by reference and must not be mutated (see
+// Storage). This matches the disk backend, which returns a fresh Meta per call.
 func (s *MemoryStorage) Get(key string) (Meta, []byte, bool) {
 	s.mu.RLock()
 	e, ok := s.m[key]
@@ -36,7 +40,25 @@ func (s *MemoryStorage) Get(key string) (Meta, []byte, bool) {
 		return Meta{}, nil, false
 	}
 	s.lru.touch(key)
-	return e.meta, e.body, true
+	return cloneMeta(e.meta), e.body, true
+}
+
+// cloneMeta returns m with its Header map and Vary slice deep-copied, so a caller
+// can't mutate (or data-race) the live stored entry's metadata. The body is not
+// copied (it is large and read-only by contract). The disk backend gets this for
+// free by unmarshaling a fresh Meta per call.
+func cloneMeta(m Meta) Meta {
+	if m.Header != nil {
+		h := make(http.Header, len(m.Header))
+		for k, vs := range m.Header {
+			h[k] = append([]string(nil), vs...)
+		}
+		m.Header = h
+	}
+	if m.Vary != nil {
+		m.Vary = append([]string(nil), m.Vary...)
+	}
+	return m
 }
 
 // Writer returns a buffer-backed writer; Commit stores it (bodies are in RAM
@@ -55,7 +77,9 @@ func (s *MemoryStorage) Delete(key string) {
 
 // Range snapshots the current (key, Meta) pairs under the read lock, then calls fn
 // for each WITHOUT holding the lock — so fn may Delete entries (which takes the
-// write lock) without deadlocking. The snapshot copies only metadata, not bodies.
+// write lock) without deadlocking. The snapshot deep-copies each Meta (header map
+// and Vary slice included), so a fn that mutates the Meta it receives can neither
+// corrupt the live cached entry nor data-race concurrent serving of it.
 func (s *MemoryStorage) Range(fn func(key string, m Meta) bool) {
 	s.mu.RLock()
 	type kv struct {
@@ -64,7 +88,7 @@ func (s *MemoryStorage) Range(fn func(key string, m Meta) bool) {
 	}
 	snap := make([]kv, 0, len(s.m))
 	for k, e := range s.m {
-		snap = append(snap, kv{k, e.meta})
+		snap = append(snap, kv{k, cloneMeta(e.meta)})
 	}
 	s.mu.RUnlock()
 	for _, e := range snap {

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMemory_DoesNotPersistAcrossInstances(t *testing.T) {
@@ -43,4 +44,40 @@ func TestMemory_GetSetDelete(t *testing.T) {
 	s.Delete("k")
 	_, _, ok = s.Get("k")
 	assert.False(t, ok)
+}
+
+// The Meta returned by Get is a deep copy: mutating its Header/Vary must not touch
+// the live stored entry that future hits serve.
+func TestMemory_GetReturnsMetaCopy(t *testing.T) {
+	s := NewMemory(1 << 20)
+	fresh := time.Now().Add(time.Hour).UnixNano()
+	storePut(t, s, "k", Meta{Status: 200, Header: http.Header{"X-Orig": {"1"}}, Vary: []string{"accept-encoding"}, FreshUntil: fresh, Size: 3}, []byte("abc"))
+
+	m, _, ok := s.Get("k")
+	require.True(t, ok)
+	m.Header.Set("X-Injected", "pwned")
+	m.Header.Set("X-Orig", "tampered")
+	m.Vary[0] = "tampered"
+
+	m2, _, ok := s.Get("k")
+	require.True(t, ok)
+	assert.Equal(t, "", m2.Header.Get("X-Injected"), "stored header must be unaffected by a caller's mutation")
+	assert.Equal(t, "1", m2.Header.Get("X-Orig"))
+	assert.Equal(t, []string{"accept-encoding"}, m2.Vary, "stored Vary must be unaffected")
+}
+
+// A Range fn that mutates the Meta it receives must not corrupt the live entry.
+func TestMemory_RangeMetaMutationDoesNotCorrupt(t *testing.T) {
+	s := NewMemory(1 << 20)
+	fresh := time.Now().Add(time.Hour).UnixNano()
+	storePut(t, s, "k", Meta{Status: 200, Header: http.Header{"X-Orig": {"1"}}, FreshUntil: fresh, Size: 3}, []byte("abc"))
+
+	s.Range(func(_ string, m Meta) bool {
+		m.Header.Set("X-Injected", "pwned") // a reaper that tags headers, say
+		return true
+	})
+
+	m, _, ok := s.Get("k")
+	require.True(t, ok)
+	assert.Equal(t, "", m.Header.Get("X-Injected"), "Range fn mutation must not poison the cached entry")
 }

--- a/pkg/cache/policy_test.go
+++ b/pkg/cache/policy_test.go
@@ -134,10 +134,10 @@ func TestFreshness_SubtractsResponseAge(t *testing.T) {
 // response aged past its lifetime is not cached at all.
 func TestDecide_AgeReducesFreshness(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), maxFile, now)
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), false, maxFile, now)
 	assert.True(t, d.cacheable)
 	assert.Equal(t, now.Add(5*time.Second), d.freshUntil, "freshUntil reflects the ~5s remaining after Age")
 
-	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), maxFile, now).cacheable,
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), false, maxFile, now).cacheable,
 		"Age >= max-age: already stale, not cached")
 }

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -41,8 +41,10 @@ import (
 // missed, so within one Cache the store never sees a same-key Get racing a Set.
 type Storage interface {
 	// Get returns the entry stored under key, or ok=false on a miss. A hit should
-	// be counted as a recent use (LRU). The returned body must not be mutated by
-	// the caller. Any internal error is reported as a miss (fail-static).
+	// be counted as a recent use (LRU). The returned Meta (including its Header map
+	// and Vary slice) must be independent of stored state — safe for the caller to
+	// read or modify without affecting the cache; the returned body must not be
+	// mutated. Any internal error is reported as a miss (fail-static).
 	Get(key string) (meta Meta, body []byte, ok bool)
 
 	// Writer begins storing an entry under key. The caller streams the body to the
@@ -60,9 +62,10 @@ type Storage interface {
 	// reaper that physically deletes entries matching an external predicate — not
 	// the serving path. Iteration order is unspecified, and the snapshot is
 	// best-effort: fn may observe an entry that is concurrently deleted, and an
-	// entry written during the walk may or may not be visited. fn MAY call
-	// Delete(key) on this storage (a backend must not hold a lock across fn that
-	// Delete would need). fn MUST NOT call Writer.
+	// entry written during the walk may or may not be visited. The Meta passed to
+	// fn is independent of stored state (see Get), so fn may freely read or modify
+	// it. fn MAY call Delete(key) on this storage (a backend must not hold a lock
+	// across fn that Delete would need). fn MUST NOT call Writer.
 	Range(fn func(key string, m Meta) bool)
 }
 


### PR DESCRIPTION
> **Stacked on #187** (the build repair). Merge #187 first; this PR's diff will then show only its own changes.

## Problem (M1 / review finding F6)

`MemoryStorage.Get` returned the stored `Meta` *by value*, and `Range` snapshotted it by value — but `Meta.Header` is a `map` and `Meta.Vary` a slice, so both **aliased the live stored entry**. The disk backend doesn't alias (it `json.Unmarshal`s a fresh `Meta` per call), so this was a silent backend divergence.

Consequences on the memory backend:
- A `Range` `fn` (the documented out-of-band maintenance API from #184) that normalizes/tags headers — rather than only inspecting + deleting — **poisons every future HIT** of that entry.
- Because `Range` runs `fn` *without* the read lock, such a mutation also **data-races** the `http.Header` map against concurrent `writeStored` serving the same entry (undefined behavior).
- The `InvalidatedAfter` hook likewise received the live map (latent footgun).

## Fix

- `cloneMeta` deep-copies `Meta.Header` and `Meta.Vary`; `Get` and `Range` now return/snapshot a clone. The **body is still shared** (large, read-only by contract).
- The `Storage` interface doc now states the Meta-independence contract for `Get` and `Range`, which both backends uphold (disk via unmarshal, memory via `cloneMeta`).

The per-hit clone is a small header-map copy — far cheaper than the disk backend's existing per-`Get` JSON unmarshal — and brings the two backends to identical, safe semantics.

## Tests

- `TestMemory_GetReturnsMetaCopy` — mutating the returned `Meta.Header`/`Vary` doesn't affect a later `Get`.
- `TestMemory_RangeMetaMutationDoesNotCorrupt` — a `Range` `fn` that writes a header doesn't poison the cached entry.

`go vet`, `go test -race ./pkg/cache/...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)