### PR TITLE
fix(cache): collapse cross-variant stampedes and cache follower variants

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -100,12 +100,10 @@ func (c *Cache) serve(w http.ResponseWriter, r *http.Request, next http.Handler)
 		return
 	}
 	primaryHex := c.primaryHash(r)
-	variantHex := c.variantHash(primaryHex, r)
-
-	if c.tryServeHit(w, r, variantHex) {
+	if c.tryServeHit(w, r, c.variantHash(primaryHex, r)) {
 		return
 	}
-	c.fillAndServe(w, r, next, primaryHex, variantHex)
+	c.fillAndServe(w, r, next, primaryHex)
 }
 
 // tryServeHit serves key from storage if present and fresh, returning true. An
@@ -132,31 +130,53 @@ func (c *Cache) tryServeHit(w http.ResponseWriter, r *http.Request, key string) 
 	return true
 }
 
-// fillAndServe handles a miss. The first arrival becomes the leader and fills the
-// cache while streaming to its own client; concurrent arrivals wait for the
-// leader (then re-read from cache) or time out and fetch on their own. Each tags
-// X-Cache accurately (HIT when served from the just-filled cache, MISS when it
-// contacted the origin).
-func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex, variantHex string) {
-	lock, leader := c.acquire(variantHex)
-	if !leader {
+// fillAndServe handles a miss with single-flight. The first arrival for a variant
+// becomes the leader and fills the cache while streaming to its own client;
+// concurrent arrivals wait for it (then re-read from cache) or time out and fetch
+// on their own. Each tags X-Cache accurately (HIT when served from the just-filled
+// cache, MISS when it contacted the origin).
+//
+// A primary's Vary is learned lazily, so before the first fill every variant of a
+// URL shares one lock key. A follower whose varied-header values differ from the
+// leader's therefore wakes to a miss; it then re-enters once to lead (or join) the
+// single-flight for ITS OWN variant key — so each variant collapses to a single
+// origin fetch and is cached, instead of every differing follower fetching
+// uncached. The loop runs at most twice: once on the pre-Vary key, once on the
+// learned-Vary key (which is stable thereafter).
+func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex string) {
+	for attempt := 0; attempt < 2; attempt++ {
+		variantHex := c.variantHash(primaryHex, r)
+		lock, leader := c.acquire(variantHex)
+		if leader {
+			c.fill(w, r, next, primaryHex, variantHex, lock)
+			return
+		}
 		select {
 		case <-lock.done:
 		case <-time.After(cacheLockTimeout):
 		}
-		// The leader has finished (or we timed out). Recompute our variant key:
-		// the leader may have just learned this primary's Vary, so our key now
-		// matches the stored entry IF our varied-header values match the leader's
-		// (otherwise we correctly miss and fetch our own variant — never serving a
-		// wrong Vary variant). A miss here falls through to our own origin fetch.
+		// Leader finished (or we timed out). Re-read: it may have just learned this
+		// primary's Vary, so our key now matches the stored entry IF our varied
+		// values match the leader's. A wrong-Vary variant is never served.
 		if c.tryServeHit(w, r, c.variantHash(primaryHex, r)) {
 			return
 		}
-		w.Header().Set("X-Cache", "MISS")
-		next.ServeHTTP(w, r)
-		return
+		// Still a miss. If the leader learned a Vary we differ on, our key changed —
+		// loop to lead/join the fill for our own variant. If the key is unchanged
+		// (the leader didn't cache it, or we timed out before any Vary was learned),
+		// fall through to our own uncached fetch.
+		if c.variantHash(primaryHex, r) == variantHex {
+			break
+		}
 	}
+	w.Header().Set("X-Cache", "MISS")
+	next.ServeHTTP(w, r)
+}
 
+// fill is the leader path: stream the response to the client through a teeWriter
+// that also writes the cacheable body to storage, commit on completion, then
+// release the fill lock so waiting followers find the committed entry.
+func (c *Cache) fill(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex, variantHex string, lock *fillLock) {
 	defer c.release(variantHex, lock)
 	tw := &teeWriter{rw: w, r: r, c: c, method: r.Method, primaryHex: primaryHex}
 	defer tw.cleanup() // panic-safe: abort an uncommitted entry if finish never ran

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -221,6 +221,51 @@ func TestCache_SingleFlightVaryFirstFill(t *testing.T) {
 	})
 }
 
+// A cold-key stampede spanning multiple Vary variants collapses to one origin
+// fetch PER VARIANT (not one per follower), and every variant is cached. Each
+// requester still receives its own variant's body.
+func TestCache_SingleFlightCollapsesCrossVariant(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&calls, 1)
+			enc := r.Header.Get("Accept-Encoding")
+			time.Sleep(60 * time.Millisecond) // hold the lock so a stampede forms
+			body := []byte("body-" + enc)
+			w.Header().Set("Cache-Control", "max-age=60")
+			w.Header().Set("Vary", "Accept-Encoding")
+			w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+			w.WriteHeader(200)
+			_, _ = w.Write(body)
+		})
+		mw := c.ServeHandler(h)
+
+		var wg, start sync.WaitGroup
+		start.Add(1)
+		for _, enc := range []string{"gzip", "br", "br", "br", "br", "br"} {
+			wg.Add(1)
+			go func(enc string) {
+				defer wg.Done()
+				start.Wait()
+				req := httptest.NewRequest("GET", "http://acme.com/v", nil)
+				req.Header.Set("Accept-Encoding", enc)
+				rec := httptest.NewRecorder()
+				mw.ServeHTTP(rec, req)
+				assert.Equal(t, "body-"+enc, rec.Body.String(), "each variant gets its own body")
+			}(enc)
+		}
+		start.Done()
+		wg.Wait()
+
+		// Two distinct variants (gzip, br) => exactly two origin fetches, regardless
+		// of how many followers each had.
+		assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "one fetch per variant, not per follower")
+		// Both variants ended up cached.
+		assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/v", hdr("Accept-Encoding", "gzip")).Header().Get("X-Cache"))
+		assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/v", hdr("Accept-Encoding", "br")).Header().Get("X-Cache"))
+	})
+}
+
 func TestCache_ExpiredEntryIsMiss(t *testing.T) {
 	eachBackend(t, func(t *testing.T, c *Cache) {
 		var calls int32

--- a/pkg/cache/policy_test.go
+++ b/pkg/cache/policy_test.go
@@ -134,10 +134,10 @@ func TestFreshness_SubtractsResponseAge(t *testing.T) {
 // response aged past its lifetime is not cached at all.
 func TestDecide_AgeReducesFreshness(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), maxFile, now)
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), false, maxFile, now)
 	assert.True(t, d.cacheable)
 	assert.Equal(t, now.Add(5*time.Second), d.freshUntil, "freshUntil reflects the ~5s remaining after Age")
 
-	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), maxFile, now).cacheable,
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), false, maxFile, now).cacheable,
 		"Age >= max-age: already stale, not cached")
 }


### PR DESCRIPTION
> **Stacked on #187** (the build repair). Merge #187 first.

## Problem (M2 / review finding F7)

A primary's `Vary` is learned lazily, so on a cold key **every** variant of a URL computes the same (pre-Vary) lock key. The leader fills exactly one variant and learns the `Vary`. A follower whose varied-header value differs from the leader's then wakes, recomputes a *different* key, misses, and falls through to:

```go
w.Header().Set("X-Cache", "MISS")
next.ServeHTTP(w, r)   // RAW writer — no single-flight, no teeWriter
```

So for that variant there is **no stampede protection** (N differing followers ⇒ N origin fetches) and the response is **never cached** (no `teeWriter`), so the next request for that variant misses again. Reproduced: a gzip leader + 10 concurrent `br` followers ⇒ 1 + 10 origin fetches, `br` uncached afterward. This contradicts the package's "concurrent misses for one key collapse into a single origin fetch."

## Fix

`fillAndServe` now loops at most twice. After a follower wakes and misses, if the leader learned a `Vary` it differs on (its variant key changed), it **re-enters** `acquire` for its own variant key — becoming that variant's leader (filling + caching via `teeWriter`) or joining other same-variant followers. The loop is bounded: pass 1 uses the pre-Vary key, pass 2 the learned-Vary key (stable thereafter); a same-key miss (leader didn't cache, or a timeout before any `Vary` was learned) still falls back to an uncached fetch.

Behavior preserved:
- A wrong-`Vary` variant is **never** served (the re-read still keys on the recomputed variant).
- `X-Cache` stays accurate; same-variant collapse and the 2s timeout fallback are unchanged.
- Leader body extracted into `fill()` — no semantic change (same `release`/`cleanup` defer order).

## Tests

`TestCache_SingleFlightCollapsesCrossVariant` (both backends): a cold-key `gzip`+`br×5` stampede yields **exactly two** origin fetches (one per variant, not one per follower), each requester receives its own variant's body, and both variants are cached afterward. Ran `-race -count=20` on the single-flight suite — no flakiness.

`go vet`, `go test -race ./pkg/cache/...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)