### PR TITLE
fix(cache): make the fill-lock timeout configurable (Options.LockTimeout)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -16,9 +16,10 @@ import (
 // Cache is a parapet.Middleware.
 var _ parapet.Middleware = (*Cache)(nil)
 
-// cacheLockTimeout bounds how long a concurrent miss waits for the in-flight fill
-// (the "leader") to populate the cache before fetching on its own.
-const cacheLockTimeout = 2 * time.Second
+// defaultLockTimeout bounds how long a concurrent miss waits for the in-flight
+// fill (the "leader") to populate the cache before fetching on its own. Used when
+// Options.LockTimeout <= 0.
+const defaultLockTimeout = 2 * time.Second
 
 // defaultMaxFileSize is the per-object cap when Options.MaxFileSize <= 0.
 const defaultMaxFileSize = 8 << 20 // 8 MiB
@@ -45,6 +46,16 @@ type Options struct {
 	// this (by Content-Length, or mid-stream) is not cached but still served in
 	// full. Defaults to 8 MiB when <= 0.
 	MaxFileSize int64
+
+	// LockTimeout bounds how long a concurrent miss (a "follower") waits for the
+	// in-flight leader to populate the cache before giving up and fetching the
+	// origin itself. The leader holds the fill lock for the WHOLE time it streams
+	// the response to its own client and (on the disk backend) fsyncs the committed
+	// entry, so a slow leader client or a saturated disk can hold followers for up
+	// to this long before they fall back to the origin. Raise it to wait through a
+	// slow fill (fewer origin fetches, higher follower latency); lower it to fail
+	// fast (more origin fetches under load). Defaults to 2s when <= 0.
+	LockTimeout time.Duration
 }
 
 // Cache is the HTTP response-cache middleware. It implements parapet.Middleware
@@ -54,6 +65,7 @@ type Options struct {
 type Cache struct {
 	storage          Storage
 	maxFileSize      int64
+	lockTimeout      time.Duration
 	invalidatedAfter func(r *http.Request, m Meta) int64
 
 	pvMu        sync.RWMutex
@@ -76,9 +88,14 @@ func New(storage Storage, opts Options) *Cache {
 	if mfs <= 0 {
 		mfs = defaultMaxFileSize
 	}
+	lt := opts.LockTimeout
+	if lt <= 0 {
+		lt = defaultLockTimeout
+	}
 	return &Cache{
 		storage:          storage,
 		maxFileSize:      mfs,
+		lockTimeout:      lt,
 		invalidatedAfter: opts.InvalidatedAfter,
 		primaryVary:      map[string][]string{},
 		locks:            map[string]*fillLock{},
@@ -153,7 +170,7 @@ func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.H
 		}
 		select {
 		case <-lock.done:
-		case <-time.After(cacheLockTimeout):
+		case <-time.After(c.lockTimeout):
 		}
 		// Leader finished (or we timed out). Re-read: it may have just learned this
 		// primary's Vary, so our key now matches the stored entry IF our varied

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -266,6 +266,34 @@ func TestCache_SingleFlightCollapsesCrossVariant(t *testing.T) {
 	})
 }
 
+// A short Options.LockTimeout makes followers give up on a slow leader and fetch
+// the origin themselves rather than wait (the default 2s would collapse them).
+func TestCache_LockTimeoutConfigurable(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024, LockTimeout: 20 * time.Millisecond})
+	var calls int32
+	h := origin(originSpec{body: []byte("slow"), header: hdr("Cache-Control", "max-age=60"), sleep: 200 * time.Millisecond}, &calls)
+	mw := c.ServeHandler(h)
+
+	const n = 4
+	var wg, start sync.WaitGroup
+	start.Add(1)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start.Wait()
+			rec := httptest.NewRecorder()
+			mw.ServeHTTP(rec, httptest.NewRequest("GET", "http://acme.com/s", nil))
+			assert.Equal(t, "slow", rec.Body.String())
+		}()
+	}
+	start.Done()
+	wg.Wait()
+	// The leader's 200ms fill far exceeds the 20ms timeout, so followers don't wait
+	// for it — they each contact the origin.
+	assert.Greater(t, atomic.LoadInt32(&calls), int32(1), "short LockTimeout: followers fetch the origin instead of waiting")
+}
+
 func TestCache_ExpiredEntryIsMiss(t *testing.T) {
 	eachBackend(t, func(t *testing.T, c *Cache) {
 		var calls int32


### PR DESCRIPTION
> **Stacked on #187** (the build repair). Merge #187 first. Also touches `fillAndServe`, so it overlaps with #189 (M2) — whichever merges second needs a trivial rebase of the `time.After(...)` line.

## Problem (M3 / review finding F8)

The follower wait before falling back to the origin was a hard-coded `cacheLockTimeout = 2 * time.Second`. The leader closes the fill lock (`release`) only *after* `next.ServeHTTP(tw, r)` (streaming the body to its **own** client) **and** `tw.finish()` (on disk, two synchronous fsyncs). So a slow/throttled leader client or a saturated disk holds every waiting follower for up to that fixed 2s before they each stampede the origin — and there was no knob to tune it.

## Fix (scoped)

- `Options.LockTimeout time.Duration` overrides the wait (default 2s via `defaultLockTimeout`). Raise it to wait through a slow fill (fewer origin fetches, higher follower latency); lower it to fail fast.
- Its doc spells out the leader-hold coupling (client streaming + disk fsync) so operators can size it to their slowest expected fill.

## Out of scope (deliberately)

Fully decoupling cache population from client delivery — so a slow leader *client* can't hold followers at all — is an architectural change to the streaming fill model (the `teeWriter` writes to client and storage in lockstep, so origin→storage is throttled to client speed). That's a larger, riskier change than a focused fix should carry; happy to follow up with a design if wanted. The disk fsync-under-lock is already documented as intentional.

## Tests

`TestCache_LockTimeoutConfigurable`: with `LockTimeout: 20ms` and a 200ms leader fill, followers stop waiting and contact the origin themselves (the default 2s would collapse them to one fetch). Ran `-race -count=10` — stable.

`go vet`, `go test -race ./pkg/cache/...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)