### PR TITLE
fix(cache): evict one primaryVary entry at cap instead of wiping the map

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -28,7 +28,7 @@ const defaultMaxFileSize = 8 << 20 // 8 MiB
 // can't grow it without limit (the storage backend bounds bytes, not this map).
 // When the cap is hit the map is reset; a dropped entry just costs one re-learn
 // (the next fill re-records its Vary), so correctness is unaffected.
-const maxPrimaryVary = 1 << 16
+var maxPrimaryVary = 1 << 16
 
 // Options configures the cache middleware.
 type Options struct {
@@ -286,10 +286,12 @@ func (c *Cache) setPrimaryVary(primaryHex string, names []string) {
 	sorted := append([]string(nil), names...)
 	sort.Strings(sorted)
 	c.pvMu.Lock()
-	// Bound the map: a dropped entry just re-learns on the next fill.
-	if len(c.primaryVary) >= maxPrimaryVary {
-		if _, exists := c.primaryVary[primaryHex]; !exists {
-			c.primaryVary = make(map[string][]string, maxPrimaryVary)
+	// Bound the map by evicting one arbitrary entry when full — an O(1) re-learn,
+	// rather than wiping the whole map (which would re-fill every varied URL at once).
+	if _, exists := c.primaryVary[primaryHex]; !exists && len(c.primaryVary) >= maxPrimaryVary {
+		for k := range c.primaryVary {
+			delete(c.primaryVary, k)
+			break
 		}
 	}
 	c.primaryVary[primaryHex] = sorted

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -572,3 +572,18 @@ func TestCache_NoContent204Cached(t *testing.T) {
 		assert.EqualValues(t, 1, atomic.LoadInt32(&calls))
 	})
 }
+
+func TestCache_PrimaryVaryBoundedEviction(t *testing.T) {
+	defer func(orig int) { maxPrimaryVary = orig }(maxPrimaryVary)
+	maxPrimaryVary = 3
+	c := New(NewMemory(1<<20), Options{})
+	for _, k := range []string{"a", "b", "c", "d", "e"} {
+		c.setPrimaryVary(k, []string{"accept-encoding"})
+	}
+	c.pvMu.RLock()
+	n := len(c.primaryVary)
+	_, hasE := c.primaryVary["e"]
+	c.pvMu.RUnlock()
+	assert.Equal(t, 3, n, "map stays at the cap (one evicted), not wiped")
+	assert.True(t, hasE, "the most recent entry is retained")
+}


### PR DESCRIPTION
**Finding L3 (F13).** At `maxPrimaryVary` (65536) entries, `setPrimaryVary` wiped the *whole* map, so every previously Vary-keyed URL recomputed an empty-Vary key and missed until re-learning — a cache-wide cold cliff.

**Fix:** evict one arbitrary entry when full (O(1) re-learn) instead of clearing all. `maxPrimaryVary` is now a package `var` so the bounded eviction is testable at a small cap. Correctness is unchanged — a wrong-Vary variant is still never served.

Test: `TestCache_PrimaryVaryBoundedEviction` (map stays at cap, isn't wiped, retains the newest entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)