### PR TITLE
fix(cache): guard removeFiles against short keys

### DIFF
--- a/pkg/cache/disk.go
+++ b/pkg/cache/disk.go
@@ -119,6 +119,9 @@ func (s *DiskStorage) Delete(key string) {
 }
 
 func (s *DiskStorage) removeFiles(key string) {
+	if len(key) < minKeyLen {
+		return // guard shardDir(key[:2]) against a malformed key
+	}
 	os.Remove(s.metaPath(key))
 	os.Remove(s.bodyPath(key))
 }

--- a/pkg/cache/disk_test.go
+++ b/pkg/cache/disk_test.go
@@ -95,3 +95,10 @@ func TestDisk_GetSetDelete(t *testing.T) {
 	_, _, ok = d.Get(key)
 	assert.False(t, ok)
 }
+
+func TestDisk_RemoveFilesShortKeyNoPanic(t *testing.T) {
+	d, err := NewDisk(t.TempDir(), 1<<20)
+	require.NoError(t, err)
+	assert.NotPanics(t, func() { d.removeFiles("x") })
+	assert.NotPanics(t, func() { d.removeFiles("") })
+}


### PR DESCRIPTION
**Finding L7 (F17).** `removeFiles` (used by the Commit/scan eviction loops and Delete) called `shardDir(key[:2])` without the `minKeyLen` guard `Get`/`Writer`/`Delete` have — a malformed key would panic with a slice-bounds error. Not reachable via the middleware (LRU victims are always valid keys), but a defense-in-depth gap.

**Fix:** `removeFiles` returns early for keys shorter than `minKeyLen`.

Test: `TestDisk_RemoveFilesShortKeyNoPanic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)