### PR TITLE
fix(cache): reject objects larger than the LRU cap

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -587,3 +587,12 @@ func TestCache_PrimaryVaryBoundedEviction(t *testing.T) {
 	assert.Equal(t, 3, n, "map stays at the cap (one evicted), not wiped")
 	assert.True(t, hasE, "the most recent entry is retained")
 }
+
+func TestCache_ObjectLargerThanCapNotCached(t *testing.T) {
+	c := New(NewMemory(500), Options{MaxFileSize: 1 << 20}) // per-object cap > storage cap
+	var calls int32
+	h := origin(originSpec{body: make([]byte, 800), header: hdr("Cache-Control", "max-age=60")}, &calls)
+	assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/big", nil).Header().Get("X-Cache"))
+	assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/big", nil).Header().Get("X-Cache"), "object larger than the storage cap is not cached")
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
+}

--- a/pkg/cache/lru.go
+++ b/pkg/cache/lru.go
@@ -30,10 +30,24 @@ func newLRU(max int64) *lru {
 
 // admit inserts or updates key with size and returns the keys evicted to stay
 // within the cap (most-recently-used kept). The caller deletes the evicted
-// entries' data.
+// entries' data. An object larger than the whole cap is refused outright (returned
+// as its own victim) so the byte bound is never exceeded.
 func (l *lru) admit(key string, size int64) []string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+
+	if size > l.max {
+		// Can never fit; refuse it (and drop any prior in-cap version). The
+		// per-object cap normally prevents this — it guards a misconfiguration where
+		// MaxFileSize exceeds the storage cap.
+		if el, ok := l.items[key]; ok {
+			it := el.Value.(*lruItem)
+			l.ll.Remove(el)
+			delete(l.items, key)
+			l.cur -= it.size
+		}
+		return []string{key}
+	}
 
 	if el, ok := l.items[key]; ok {
 		it := el.Value.(*lruItem)
@@ -52,12 +66,6 @@ func (l *lru) admit(key string, size int64) []string {
 			break
 		}
 		it := back.Value.(*lruItem)
-		if it.key == key {
-			// Never evict the entry we just admitted to satisfy its own admission
-			// (a single object larger than the cap); the per-object cap prevents
-			// this in practice. Stop to avoid an infinite loop.
-			break
-		}
 		l.ll.Remove(back)
 		delete(l.items, it.key)
 		l.cur -= it.size

--- a/pkg/cache/lru_test.go
+++ b/pkg/cache/lru_test.go
@@ -38,3 +38,12 @@ func TestLRU_Remove(t *testing.T) {
 	assert.EqualValues(t, 0, l.size())
 	l.remove("missing")
 }
+
+func TestLRU_RejectsOverCap(t *testing.T) {
+	l := newLRU(100)
+	assert.Equal(t, []string{"big"}, l.admit("big", 5000))
+	assert.EqualValues(t, 0, l.size())
+	l.admit("k", 40)
+	assert.Equal(t, []string{"k"}, l.admit("k", 5000), "prior in-cap version dropped when updated over-cap")
+	assert.EqualValues(t, 0, l.size())
+}


### PR DESCRIPTION
**Finding L2 (F5).** `admit`'s self-break left `cur > max` for an object larger than the whole cap (reachable when `MaxFileSize` exceeds the storage cap), exceeding the configured byte bound.

**Fix:** `admit` refuses an over-cap object — dropping any prior version and returning the key as its own victim, so the backend's Commit deletes the just-written data and the object isn't cached. The now-unreachable self-break in the eviction loop is removed.

Tests: `TestLRU_RejectsOverCap`; `TestCache_ObjectLargerThanCapNotCached` (per-object cap > storage cap ⇒ not cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)