### PR TITLE
fix(cache): age-gate the disk startup expired-reap

### DIFF
--- a/pkg/cache/disk.go
+++ b/pkg/cache/disk.go
@@ -286,8 +286,11 @@ func (s *DiskStorage) scan(now time.Time) {
 				continue
 			}
 			if now.After(time.Unix(0, m.FreshUntil)) {
-				os.Remove(mp) // expired
-				os.Remove(filepath.Join(shardPath, key+".body"))
+				// Age-gated like the other reap paths so a concurrent in-flight commit
+				// (mtime ~now) is never destroyed; a genuinely expired-on-disk entry is
+				// older than reapMinAge, and any expired entry is reaped on access too.
+				reapIfStale(mp, now)
+				reapIfStale(filepath.Join(shardPath, key+".body"), now)
 				continue
 			}
 			for _, victim := range s.lru.admit(key, m.Size) {

--- a/pkg/cache/disk_test.go
+++ b/pkg/cache/disk_test.go
@@ -42,20 +42,30 @@ func TestDisk_ScanReapsExpired(t *testing.T) {
 	a, err := NewDisk(dir, 1<<20)
 	require.NoError(t, err)
 	const key = "aabbccddeeff00112233445566778899"
-	storePut(t, a, key, Meta{
-		Status:     200,
-		Header:     http.Header{},
-		FreshUntil: time.Now().Add(-time.Hour).UnixNano(), // already expired
-		Size:       3,
-	}, []byte("xyz"))
+	storePut(t, a, key, Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(-time.Hour).UnixNano(), Size: 3}, []byte("xyz"))
+	// Age the files so the age-gated reap treats them as not-in-flight.
+	old := time.Now().Add(-2 * reapMinAge)
+	require.NoError(t, os.Chtimes(a.metaPath(key), old, old))
+	require.NoError(t, os.Chtimes(a.bodyPath(key), old, old))
 
-	// A new storage scans on startup and reaps the expired entry.
-	b, err := NewDisk(dir, 1<<20)
+	b := &DiskStorage{dir: dir, lru: newLRU(1 << 20)}
+	b.scan(time.Now())
+	_, _, ok := b.Get(key)
+	assert.False(t, ok, "scan reaps the aged, expired entry")
+}
+
+func TestDisk_ScanSparesRecentlyWrittenExpired(t *testing.T) {
+	dir := t.TempDir()
+	a, err := NewDisk(dir, 1<<20)
 	require.NoError(t, err)
-	assert.Eventually(t, func() bool {
-		_, _, ok := b.Get(key)
-		return !ok
-	}, time.Second, 10*time.Millisecond, "scan reaps the expired entry")
+	const key = "ffeeddccbbaa00112233445566778899"
+	// Expired but just written (fresh mtime): a commit racing the startup scan.
+	storePut(t, a, key, Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(-time.Hour).UnixNano(), Size: 3}, []byte("xyz"))
+
+	b := &DiskStorage{dir: dir, lru: newLRU(1 << 20)}
+	b.scan(time.Now())
+	_, _, ok := b.Get(key)
+	assert.True(t, ok, "a recently-written expired entry is spared (reaped on access instead)")
 }
 
 func TestDisk_PanicDuringFillNoTempLeak(t *testing.T) {


### PR DESCRIPTION
**Finding L1 (F2).** The startup scan's expired-reap used a bare `os.Remove`, the lone path not age-gated by `reapIfStale`. A commit re-filling a just-expired key during the scan window could have its fresh files destroyed, leaving `lru.cur` permanently skewed.

**Fix:** the expired path now uses `reapIfStale` for both files. A genuinely-expired-on-disk entry's mtime predates the downtime, so reaping is unaffected; a freshly re-committed entry (mtime≈now) is spared and reaped on access instead.

Tests: `TestDisk_ScanReapsExpired` rewritten to age the files (the realistic case); new `TestDisk_ScanSparesRecentlyWrittenExpired` locks in the in-flight protection. Both call `scan` synchronously for determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)