### PR TITLE
fix(cache): emit an Age header on cache hits (RFC 9111 §5.1)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -303,10 +304,23 @@ func writeStored(w http.ResponseWriter, r *http.Request, m Meta, body []byte, ta
 	for k, vs := range m.Header {
 		h[k] = append([]string(nil), vs...)
 	}
+	h.Set("Age", strconv.FormatInt(servedAgeSeconds(m, time.Now()), 10))
 	h.Set("X-Cache", tag)
 	w.WriteHeader(m.Status)
 	if r.Method == http.MethodHead || m.Status == http.StatusNoContent {
 		return
 	}
 	_, _ = w.Write(body)
+}
+
+// servedAgeSeconds is the Age header value for a cache hit: the age the response
+// already had when it was stored (RFC 9111 §4.2.3, reusing responseAge) plus how
+// long it has since resided in the cache. Never negative.
+func servedAgeSeconds(m Meta, now time.Time) int64 {
+	created := time.Unix(0, m.Created)
+	age := responseAge(m.Header, created) + now.Sub(created)
+	if age < 0 {
+		age = 0
+	}
+	return int64(age / time.Second)
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -596,3 +596,23 @@ func TestCache_ObjectLargerThanCapNotCached(t *testing.T) {
 	assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/big", nil).Header().Get("X-Cache"), "object larger than the storage cap is not cached")
 	assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
 }
+
+func TestCache_HitCarriesAgeHeader(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		req := httptest.NewRequest("GET", "http://acme.com/age", nil)
+		primary := c.primaryHash(req)
+		key := c.variantHash(primary, req)
+		storePut(t, c.storage, key, Meta{
+			Status: 200, Header: http.Header{}, PrimaryHex: primary,
+			Created:    time.Now().Add(-30 * time.Second).UnixNano(),
+			FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3,
+		}, []byte("abc"))
+
+		r := do(c, http.NotFoundHandler(), "GET", "http://acme.com/age", nil)
+		require.Equal(t, "HIT", r.Header().Get("X-Cache"))
+		age, err := strconv.Atoi(r.Header().Get("Age"))
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, age, 30)
+		assert.LessOrEqual(t, age, 31)
+	})
+}


### PR DESCRIPTION
**Finding M6 (F4).** `writeStored` copied the stored headers (incl. the origin `Date`) and only set `X-Cache`; it never generated an `Age` header (RFC 9111 §5.1 says a cache MUST). Downstream caches then recomputed freshness from the stale `Date` and over-cached — compounding the Age issue fixed in #186 across tiers.

**Fix:** `servedAgeSeconds(m, now)` = `responseAge(m.Header, created)` (the initial age, reusing the helper from #186) + resident time; `writeStored` sets `Age` on every hit.

Test: `TestCache_HitCarriesAgeHeader` (seed an entry created 30s ago; hit carries Age≈30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)