### PR TITLE
fix(cache): add done-guard to memWriter.Abort

### DIFF
--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -129,6 +129,9 @@ func (w *memWriter) Commit(meta Meta) error {
 }
 
 func (w *memWriter) Abort() {
+	if w.done {
+		return // matches diskWriter: Abort after Commit/Abort is a no-op
+	}
 	w.done = true
 	w.buf.Reset()
 }

--- a/pkg/cache/memory_test.go
+++ b/pkg/cache/memory_test.go
@@ -81,3 +81,16 @@ func TestMemory_RangeMetaMutationDoesNotCorrupt(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "", m.Header.Get("X-Injected"), "Range fn mutation must not poison the cached entry")
 }
+
+func TestMemory_AbortAfterCommitIsNoop(t *testing.T) {
+	s := NewMemory(1 << 20)
+	w, err := s.Writer("k")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("abc"))
+	require.NoError(t, err)
+	require.NoError(t, w.Commit(Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3}))
+	w.Abort() // must be a no-op
+	_, body, ok := s.Get("k")
+	require.True(t, ok)
+	assert.Equal(t, "abc", string(body))
+}


### PR DESCRIPTION
**Finding I1 (F18).** `memWriter.Abort` lacked the `if w.done { return }` guard `diskWriter.Abort` has, diverging from the `EntryWriter` "Abort after Commit is a no-op" contract. Benign today, but a hazard if Abort ever gains real side effects.

**Fix:** add the guard.

Test: `TestMemory_AbortAfterCommitIsNoop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)