### PR TITLE
style(cache): satisfy fieldalignment, drop //nolint:govet

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -60,19 +60,17 @@ type Options struct {
 
 // Cache is the HTTP response-cache middleware. It implements parapet.Middleware
 // (ServeHandler). Construct with New, giving it a Storage backend.
-//
-//nolint:govet
 type Cache struct {
 	storage          Storage
+	invalidatedAfter func(r *http.Request, m Meta) int64
+	primaryVary      map[string][]string  // primaryHex -> Vary header names learned from a stored response
+	locks            map[string]*fillLock // variantHex -> in-flight fill
 	maxFileSize      int64
 	lockTimeout      time.Duration
-	invalidatedAfter func(r *http.Request, m Meta) int64
 
-	pvMu        sync.RWMutex
-	primaryVary map[string][]string // primaryHex -> Vary header names learned from a stored response
+	pvMu sync.RWMutex
 
 	lockMu sync.Mutex
-	locks  map[string]*fillLock // variantHex -> in-flight fill
 }
 
 // fillLock coordinates concurrent misses for one variant: the leader fills, the

--- a/pkg/cache/disk.go
+++ b/pkg/cache/disk.go
@@ -32,12 +32,10 @@ const minKeyLen = 2
 //	<dir>/<aa>/<key>.body   response body bytes
 //	<dir>/<aa>/<key>.meta   JSON sidecar (written last)
 //	<dir>/tmp/<key>.<seq>   in-progress writes, atomically renamed on commit
-//
-//nolint:govet
 type DiskStorage struct {
+	lru *lru
 	dir string
 	seq atomic.Uint64
-	lru *lru
 }
 
 // NewDisk creates (or opens) a disk storage rooted at dir, bounded to maxSize
@@ -166,11 +164,10 @@ func (s *DiskStorage) Range(fn func(key string, m Meta) bool) {
 	}
 }
 
-//nolint:govet
 type diskWriter struct {
 	s    *DiskStorage
-	key  string
 	f    *os.File
+	key  string
 	tmp  string
 	done bool
 }

--- a/pkg/cache/lru.go
+++ b/pkg/cache/lru.go
@@ -9,14 +9,12 @@ import (
 // tracks keys and their byte weights; the owning Storage holds the actual data
 // and deletes a key's data when lru returns it as a victim. Both the memory and
 // disk backends embed an lru.
-//
-//nolint:govet
 type lru struct {
-	mu    sync.Mutex
-	max   int64
-	cur   int64
 	ll    *list.List               // front = most recently used
 	items map[string]*list.Element // key -> element holding *lruItem
+	max   int64
+	cur   int64
+	mu    sync.Mutex
 }
 
 type lruItem struct {

--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -12,18 +12,15 @@ import (
 // whole body is buffered in RAM (and retained if the response is cached), so peak
 // transient memory is up to MaxFileSize per concurrent miss, independent of the
 // byte cap.
-//
-//nolint:govet
 type MemoryStorage struct {
-	mu  sync.RWMutex
 	m   map[string]memEntry
 	lru *lru
+	mu  sync.RWMutex
 }
 
-//nolint:govet
 type memEntry struct {
-	meta Meta
 	body []byte
+	meta Meta
 }
 
 // NewMemory creates an in-memory storage bounded to maxSize total body bytes.
@@ -101,7 +98,6 @@ func (s *MemoryStorage) Range(fn func(key string, m Meta) bool) {
 	}
 }
 
-//nolint:govet
 type memWriter struct {
 	s    *MemoryStorage
 	key  string

--- a/pkg/cache/policy.go
+++ b/pkg/cache/policy.go
@@ -43,12 +43,10 @@ func cacheableStatus(code int) bool {
 }
 
 // decision is the outcome of the honor-origin cacheability check.
-//
-//nolint:govet
 type decision struct {
-	cacheable  bool
 	freshUntil time.Time
 	vary       []string // lowercased Vary header names (nil when no Vary)
+	cacheable  bool
 }
 
 // decide applies the honor-origin policy to an origin response. method is the
@@ -128,15 +126,14 @@ func parseVary(h http.Header) (names []string, star bool) {
 	return names, false
 }
 
-//nolint:govet
 type cacheControl struct {
+	maxAge         int64
+	sMaxAge        int64
 	private        bool
 	noStore        bool
 	noCache        bool
 	public         bool
 	mustRevalidate bool
-	maxAge         int64
-	sMaxAge        int64
 	hasMax         bool
 	hasSMax        bool
 }

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -84,10 +84,7 @@ type EntryWriter interface {
 
 // Meta is the stored metadata for a cached response. Backends persist it
 // alongside the body (the disk backend marshals it to JSON).
-//
-//nolint:govet
 type Meta struct {
-	Status     int         `json:"status"`
 	Header     http.Header `json:"header"`
 	PrimaryHex string      `json:"primary"`        // primary key hash (host+method+scheme+uri)
 	Host       string      `json:"host,omitempty"` // normalized host (lowercased, port-stripped); for out-of-band Range maintenance
@@ -96,4 +93,5 @@ type Meta struct {
 	Created    int64       `json:"created"`        // unix nanos
 	FreshUntil int64       `json:"fresh"`          // unix nanos; entry is stale after this
 	Size       int64       `json:"size"`           // body bytes (== eviction weight)
+	Status     int         `json:"status"`
 }

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -26,26 +26,23 @@ var hopByHop = map[string]struct{}{
 // finish it Commits iff the body is complete (Content-Length matched, or HEAD),
 // guaranteeing a truncated response is never stored; otherwise it Aborts. cleanup
 // Aborts on a panic before finish so no temp/partial state is left.
-//
-//nolint:govet
 type teeWriter struct {
+	freshUntil time.Time
+	ew         EntryWriter // nil = not caching this response
 	rw         http.ResponseWriter
 	r          *http.Request
 	c          *Cache
+	metaHeader http.Header
 	method     string
+	storeKey   string
 	primaryHex string
-
-	wroteHeader bool
-	status      int
-
-	ew         EntryWriter // nil = not caching this response
+	vary       []string // sorted, lowercased
 	written    int64
 	contentLen int64
-	hasCL      bool
-	storeKey   string
-	freshUntil time.Time
-	vary       []string // sorted, lowercased
-	metaHeader http.Header
+	status     int
+
+	wroteHeader bool
+	hasCL       bool
 }
 
 func (tw *teeWriter) Header() http.Header { return tw.rw.Header() }


### PR DESCRIPTION
**Finding I2 (F19).** Nine structs carried blanket `//nolint:govet` suppressing the repo-wide `fieldalignment` check; most shrink for free by reordering (incl. the public JSON-tagged `Meta`).

**Fix:** reorder fields to satisfy `fieldalignment` and drop the `//nolint:govet` lines. No field names/types/tags changed, so no behavior or JSON change.

Gate: `golangci-lint run` reports 0 issues without the suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
