### PR TITLE
fix(cache): canonicalize X-Forwarded-Proto in the cache key

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -221,21 +221,31 @@ func (c *Cache) release(variantHex string, l *fillLock) {
 // primaryHash keys on host + method + scheme + uri (so distinct hosts/schemes/
 // methods never collide). The host is lowercased and port-stripped so
 // "example.com" and "example.com:443" share a key regardless of upstream host
-// normalization. scheme reflects the terminating listener via X-Forwarded-Proto
-// (set by the parapet server), defaulting to the request TLS state.
+// normalization. scheme is canonicalized to http/https by schemeOf.
 func (c *Cache) primaryHash(r *http.Request) string {
-	scheme := r.Header.Get("X-Forwarded-Proto")
-	if scheme == "" {
-		if r.TLS != nil {
-			scheme = "https"
-		} else {
-			scheme = "http"
-		}
-	}
+	scheme := schemeOf(r)
 	host := normalizeHost(r.Host)
 	uri := r.URL.RequestURI()
 	sum := sha256.Sum256([]byte(host + "\n" + r.Method + "\n" + scheme + "\n" + uri))
 	return hex.EncodeToString(sum[:16])
+}
+
+// schemeOf returns the request scheme for the cache key, canonicalized to exactly
+// "http" or "https". X-Forwarded-Proto is honored only when it is exactly http or
+// https (case-insensitive); any other value — including attacker-supplied junk
+// meant to fragment the key — falls back to the TLS state. Mount the cache behind
+// a proxy that sets X-Forwarded-Proto from a trusted source.
+func schemeOf(r *http.Request) string {
+	switch {
+	case strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https"):
+		return "https"
+	case strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "http"):
+		return "http"
+	case r.TLS != nil:
+		return "https"
+	default:
+		return "http"
+	}
 }
 
 // normalizeHost lowercases a host and strips any port, matching the form used in

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -616,3 +616,18 @@ func TestCache_HitCarriesAgeHeader(t *testing.T) {
 		assert.LessOrEqual(t, age, 31)
 	})
 }
+
+func TestCache_XFPCanonicalizedInKey(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024})
+	mk := func(xfp string) string {
+		r := httptest.NewRequest("GET", "http://acme.com/p", nil)
+		if xfp != "" {
+			r.Header.Set("X-Forwarded-Proto", xfp)
+		}
+		return c.primaryHash(r)
+	}
+	assert.Equal(t, mk("https"), mk("HTTPS"), "case-insensitive https collapses")
+	assert.Equal(t, mk(""), mk("evil-1"), "junk XFP falls back to TLS state, like no XFP")
+	assert.Equal(t, mk("evil-1"), mk("evil-2"), "distinct junk values don't fragment the key")
+	assert.NotEqual(t, mk("http"), mk("https"), "legit http vs https still differ")
+}


### PR DESCRIPTION
**Finding M4 (F10).** `primaryHash` read the raw `X-Forwarded-Proto` header straight into the cache key with no canonicalization — unlike every other XFP consumer in parapet, which honors it only from trusted upstreams. Arbitrary XFP values minted distinct keys (LRU churn / eviction of warm entries), and the scheme component was client-controllable.

**Fix:** `schemeOf(r)` honors `X-Forwarded-Proto` only when it is exactly `http`/`https` (case-insensitive); any other value falls back to `r.TLS`. Documented that the cache must sit behind a proxy that sets XFP from a trusted source.

Test: `TestCache_XFPCanonicalizedInKey` (case-insensitive collapse; junk falls back to TLS and can't fragment; http≠https preserved).

`go vet`, `go test -race ./pkg/cache/...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)