### PR TITLE
fix(cache): skip size-mismatched entries in the disk startup scan

### DIFF
--- a/pkg/cache/disk.go
+++ b/pkg/cache/disk.go
@@ -295,6 +295,14 @@ func (s *DiskStorage) scan(now time.Time) {
 				reapIfStale(filepath.Join(shardPath, key+".body"), now)
 				continue
 			}
+			bp := filepath.Join(shardPath, key+".body")
+			if fi, err := os.Stat(bp); err != nil || fi.Size() != m.Size {
+				// Body length disagrees with meta (torn/truncated). Get would reject it,
+				// so don't admit it as permanent dead weight; reap (age-gated).
+				reapIfStale(mp, now)
+				reapIfStale(bp, now)
+				continue
+			}
 			for _, victim := range s.lru.admit(key, m.Size) {
 				s.removeFiles(victim)
 			}

--- a/pkg/cache/disk_test.go
+++ b/pkg/cache/disk_test.go
@@ -118,3 +118,16 @@ func TestDisk_FsyncDir(t *testing.T) {
 	assert.NoError(t, fsyncDir(dir))
 	assert.Error(t, fsyncDir(filepath.Join(dir, "does-not-exist")))
 }
+
+func TestDisk_ScanSkipsSizeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	a, err := NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	const key = "1122334455667788990011223344aabb"
+	storePut(t, a, key, Meta{Status: 200, Header: http.Header{}, FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3}, []byte("xyz"))
+	require.NoError(t, os.WriteFile(a.bodyPath(key), []byte("xyzzz"), 0o644)) // body now 5, meta says 3
+
+	b := &DiskStorage{dir: dir, lru: newLRU(1 << 20)}
+	b.scan(time.Now())
+	assert.EqualValues(t, 0, b.lru.size(), "size-mismatched entry is not admitted to the byte cap")
+}


### PR DESCRIPTION
**Finding L4 (F14).** The startup scan admitted survivors at `meta.Size` without verifying the on-disk body length. A torn entry (which `Get` rejects via `len(body) != m.Size`) was counted against the byte cap forever — dead weight.

**Fix:** the scan `Stat`s the body file; on a size mismatch it skips admission and reaps (age-gated) rather than counting it.

Test: `TestDisk_ScanSkipsSizeMismatch` (corrupt the body length; scan doesn't admit it to the cap).

`go vet`, `go test -race ./pkg/cache/...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)