### PR TITLE
fix(cache): bypass the cache for Range requests

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -121,7 +121,10 @@ func (c *Cache) ServeHandler(next http.Handler) http.Handler {
 }
 
 func (c *Cache) serve(w http.ResponseWriter, r *http.Request, next http.Handler) {
-	if !cacheableMethod(r.Method) || isUpgrade(r) || (c.cacheable != nil && !c.cacheable(r)) {
+	// Range requests are passed straight through: this cache has no Range support,
+	// so it must not answer a Range request with a stored full 200 (let the origin
+	// serve 206). They are also not used to fill the cache.
+	if !cacheableMethod(r.Method) || isUpgrade(r) || r.Header.Get("Range") != "" || (c.cacheable != nil && !c.cacheable(r)) {
 		next.ServeHTTP(w, r) // never cache these; no X-Cache header
 		return
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -643,3 +643,15 @@ func TestCache_CacheablePredicate(t *testing.T) {
 	assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/yes", nil).Header().Get("X-Cache"))
 	assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/yes", nil).Header().Get("X-Cache"))
 }
+
+func TestCache_RangeRequestBypassesCache(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		h := origin(originSpec{body: []byte("0123456789"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+		assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/r", nil).Header().Get("X-Cache"))
+		assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/r", nil).Header().Get("X-Cache"))
+		r := do(c, h, "GET", "http://acme.com/r", hdr("Range", "bytes=0-3"))
+		assert.Equal(t, "", r.Header().Get("X-Cache"), "Range request bypasses the cache")
+		assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "Range request reaches the origin")
+	})
+}


### PR DESCRIPTION
**Finding L6 (F16).** A `Range` request was answered with the stored full 200 (RFC-permitted but surprising), and a hit could replay the origin's `Accept-Ranges: bytes` while returning a full 200.

**Fix:** `serve` passes a request carrying a `Range` header straight through to the origin (which can serve a proper 206); it isn't served from, or used to fill, the cache. Simpler and more correct than slicing/normalizing.

Test: `TestCache_RangeRequestBypassesCache` (prime the cache, then a Range request is untagged and reaches the origin).

`go vet`, `go test -race ./pkg/cache/...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)