### PR TITLE
feat(cache): add Options.Cacheable predicate + unkeyed-input doc

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -43,6 +43,14 @@ type Options struct {
 	// overhead). The callee owns its own concurrency.
 	InvalidatedAfter func(r *http.Request, m Meta) int64
 
+	// Cacheable, when non-nil, is called for each GET/HEAD request; returning false
+	// excludes the request from the cache entirely (served straight from the origin,
+	// untagged), exactly as if it were uncacheable. Use it to restrict caching to
+	// vetted paths, or to refuse requests carrying headers an origin might reflect
+	// into the body without declaring them in Vary (an unkeyed-input poisoning
+	// vector — see the package doc). nil caches everything otherwise cacheable.
+	Cacheable func(r *http.Request) bool
+
 	// MaxFileSize caps a cacheable response's body. A GET response larger than
 	// this (by Content-Length, or mid-stream) is not cached but still served in
 	// full. Defaults to 8 MiB when <= 0.
@@ -64,6 +72,7 @@ type Options struct {
 type Cache struct {
 	storage          Storage
 	invalidatedAfter func(r *http.Request, m Meta) int64
+	cacheable        func(r *http.Request) bool
 	primaryVary      map[string][]string  // primaryHex -> Vary header names learned from a stored response
 	locks            map[string]*fillLock // variantHex -> in-flight fill
 	maxFileSize      int64
@@ -96,6 +105,7 @@ func New(storage Storage, opts Options) *Cache {
 		maxFileSize:      mfs,
 		lockTimeout:      lt,
 		invalidatedAfter: opts.InvalidatedAfter,
+		cacheable:        opts.Cacheable,
 		primaryVary:      map[string][]string{},
 		locks:            map[string]*fillLock{},
 	}
@@ -111,7 +121,7 @@ func (c *Cache) ServeHandler(next http.Handler) http.Handler {
 }
 
 func (c *Cache) serve(w http.ResponseWriter, r *http.Request, next http.Handler) {
-	if !cacheableMethod(r.Method) || isUpgrade(r) {
+	if !cacheableMethod(r.Method) || isUpgrade(r) || (c.cacheable != nil && !c.cacheable(r)) {
 		next.ServeHTTP(w, r) // never cache these; no X-Cache header
 		return
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -631,3 +631,15 @@ func TestCache_XFPCanonicalizedInKey(t *testing.T) {
 	assert.Equal(t, mk("evil-1"), mk("evil-2"), "distinct junk values don't fragment the key")
 	assert.NotEqual(t, mk("http"), mk("https"), "legit http vs https still differ")
 }
+
+func TestCache_CacheablePredicate(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024, Cacheable: func(r *http.Request) bool {
+		return r.URL.Path != "/no"
+	}})
+	var calls int32
+	h := origin(originSpec{body: []byte("x"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+	assert.Equal(t, "", do(c, h, "GET", "http://acme.com/no", nil).Header().Get("X-Cache"))
+	assert.Equal(t, "", do(c, h, "GET", "http://acme.com/no", nil).Header().Get("X-Cache"))
+	assert.Equal(t, "MISS", do(c, h, "GET", "http://acme.com/yes", nil).Header().Get("X-Cache"))
+	assert.Equal(t, "HIT", do(c, h, "GET", "http://acme.com/yes", nil).Header().Get("X-Cache"))
+}

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -23,6 +23,12 @@
 // follows RFC 9111 §3.5: a response to a request bearing an Authorization header
 // is cached only when the origin explicitly opts in via public, s-maxage, or
 // must-revalidate.
+//
+// The key is the request's host+method+scheme+uri plus the origin-declared Vary
+// headers; it does not include request headers the origin reflects but doesn't
+// declare in Vary (e.g. X-Forwarded-Host into a Location), so — as with any
+// honor-origin shared cache — such a response can be poisoned. Use Options.Cacheable
+// to exclude untrusted requests or paths from the cache.
 package cache
 
 import (


### PR DESCRIPTION
**Finding L8 (F11).** The key covers URL + origin-*declared* Vary only, so an origin reflecting an undeclared header (e.g. `X-Forwarded-Host` into a `Location`) and marking the response cacheable can be poisoned. Inherent to honor-origin/CDN caches, but the package offered no mitigation lever and no warning.

**Fix:** add an opt-in `Options.Cacheable func(r) bool` — returning false excludes a request from the cache (served straight from origin, untagged) — for path allowlists or refusing requests with reflected headers. Documented the unkeyed-input sharp edge in the package doc.

Test: `TestCache_CacheablePredicate`.

`go vet`, `go test -race ./pkg/cache/...`, and `golangci-lint run ./pkg/cache/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)