### PR TITLE
feat(cache): make DecoupleFill contention-gated

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/moonrhythm/parapet"
@@ -67,23 +68,26 @@ type Options struct {
 	LockTimeout time.Duration
 
 	// DecoupleFill, when true, stops a slow leader client (or a slow disk) from
-	// holding the fill lock while the response streams to that client. A cacheable
-	// fill is read from the origin at origin speed — the leader's client receives
-	// nothing until the fill is done — while the body is streamed to storage and also
-	// buffered in memory for the leader (so the leader's response never depends on the
-	// stored entry, which may expire, be evicted, or be purged). The entry is then
-	// committed, the fill lock is released (waiting followers immediately hit the
-	// cache), and only then is the leader's own client served from the buffered body.
+	// holding the fill lock — and thus stalling waiting followers — while its response
+	// streams to that client. It engages only when the fill is CONTENDED, i.e. at
+	// least one follower is already blocked waiting for it (the stampede case
+	// single-flight exists for); an uncontended fill has nothing to isolate and
+	// streams to the client in lockstep with no added latency.
 	//
-	// It trades the leader's time-to-first-byte (it waits for the whole fill) and an
-	// extra in-memory copy of the leader's body (bounded by MaxFileSize, per in-flight
-	// decoupled fill) for follower isolation, and serves the leader the sanitized
-	// response headers (hop-by-hop stripped, no Age) rather than the raw origin
-	// headers. Non-cacheable responses, and cacheable ones whose handler relies on
-	// incremental flushing, are unaffected (streamed to the client in lockstep; a
-	// Flush during a decoupled fill is ignored). When false (default), the leader
-	// streams its response in lockstep and holds the fill lock until that stream and
-	// the commit finish (see LockTimeout).
+	// When it engages, the cacheable body is read from the origin at origin speed —
+	// the leader's client receives nothing until the fill is done — while it is
+	// streamed to storage and also buffered in memory for the leader (so the leader's
+	// response never depends on the stored entry, which may expire, be evicted, or be
+	// purged). The entry is then committed, the fill lock released (waiting followers
+	// immediately hit the cache), and only then is the leader's own client served from
+	// the buffered body. This trades the leader's time-to-first-byte (it waits for the
+	// whole fill) and an extra in-memory copy of the leader's body (bounded by
+	// MaxFileSize, per in-flight decoupled fill) for follower isolation, and serves
+	// the leader the sanitized response headers (hop-by-hop stripped, no Age) rather
+	// than the raw origin headers. A handler that relies on incremental flushing is
+	// unaffected (a Flush during a decoupled fill is ignored). When false (default),
+	// the leader always streams in lockstep and holds the fill lock until that stream
+	// and the commit finish (see LockTimeout).
 	DecoupleFill bool
 }
 
@@ -106,8 +110,11 @@ type Cache struct {
 
 // fillLock coordinates concurrent misses for one variant: the leader fills, the
 // rest wait on done (then re-read the cache) or time out and fetch on their own.
+// waiters counts the followers currently blocked on done — the leader reads it to
+// decide whether a fill is contended (see DecoupleFill).
 type fillLock struct {
-	done chan struct{}
+	done    chan struct{}
+	waiters atomic.Int32
 }
 
 // New builds the cache middleware over the given Storage backend (memory or
@@ -202,10 +209,12 @@ func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.H
 			c.fill(w, r, next, primaryHex, variantHex, lock)
 			return
 		}
+		lock.waiters.Add(1)
 		select {
 		case <-lock.done:
 		case <-time.After(c.lockTimeout):
 		}
+		lock.waiters.Add(-1)
 		// Leader finished (or we timed out). Re-read: it may have just learned this
 		// primary's Vary, so our key now matches the stored entry IF our varied
 		// values match the leader's. A wrong-Vary variant is never served.
@@ -237,7 +246,7 @@ func (c *Cache) fill(w http.ResponseWriter, r *http.Request, next http.Handler, 
 	}
 	defer release() // ensure the lock is freed on every path (incl. panic)
 
-	tw := &teeWriter{rw: w, r: r, c: c, method: r.Method, primaryHex: primaryHex}
+	tw := &teeWriter{rw: w, r: r, c: c, method: r.Method, primaryHex: primaryHex, lock: lock}
 	defer tw.cleanup() // panic-safe: abort an uncommitted entry if finish never ran
 	next.ServeHTTP(tw, r)
 	tw.finish()

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -726,31 +726,50 @@ func TestCache_DecoupleFill_MissThenHit(t *testing.T) {
 	})
 }
 
-// The headline property: a leader whose own client is blocked must NOT hold the
-// fill lock — followers hit the just-committed entry immediately.
+// The headline property: under contention, a leader whose own client is blocked
+// must NOT hold the fill lock — followers hit the just-committed entry immediately.
 func TestCache_DecoupleFill_SlowLeaderDoesNotBlockFollowers(t *testing.T) {
 	c := New(NewMemory(1<<20), Options{MaxFileSize: 1 << 20, DecoupleFill: true})
+	originEntered := make(chan struct{})
+	originGate := make(chan struct{})
 	var calls int32
-	h := origin(originSpec{body: []byte("payload"), header: hdr("Cache-Control", "max-age=60")}, &calls)
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		close(originEntered) // the leader is in origin (single-flight: called once)
+		<-originGate         // hold the leader here so followers can pile onto the lock
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.Header().Set("Content-Length", "7")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("payload"))
+	})
 	mw := c.ServeHandler(h)
 
+	// Leader with a slow client.
 	leaderRW := &blockingRW{release: make(chan struct{}), written: make(chan struct{})}
 	leaderDone := make(chan struct{})
 	go func() {
 		mw.ServeHTTP(leaderRW, httptest.NewRequest("GET", "http://acme.com/x", nil))
 		close(leaderDone)
 	}()
+	<-originEntered // leader holds the lock, blocked in origin
 
-	// Wait until the leader has committed + released and is blocked writing to its client.
-	select {
-	case <-leaderRW.written:
-	case <-time.After(2 * time.Second):
-		t.Fatal("leader never reached its client write")
+	// Followers pile onto the lock while the leader is still in origin (contention).
+	var fwg sync.WaitGroup
+	recs := make([]*httptest.ResponseRecorder, 5)
+	for i := range recs {
+		recs[i] = httptest.NewRecorder()
+		fwg.Add(1)
+		go func(i int) {
+			defer fwg.Done()
+			mw.ServeHTTP(recs[i], httptest.NewRequest("GET", "http://acme.com/x", nil))
+		}(i)
 	}
+	time.Sleep(50 * time.Millisecond) // let the followers reach the wait
 
-	// While the leader's client is blocked, followers get an immediate HIT.
-	for i := 0; i < 5; i++ {
-		rec := do(c, h, "GET", "http://acme.com/x", nil)
+	close(originGate) // leader proceeds; WriteHeader sees waiters>0 -> decouple, commit, release
+	fwg.Wait()        // followers complete WITHOUT the leader's blocked client being released
+
+	for _, rec := range recs {
 		assert.Equal(t, "HIT", rec.Header().Get("X-Cache"), "follower hits while the leader's client is blocked")
 		assert.Equal(t, "payload", rec.Body.String())
 	}
@@ -819,22 +838,78 @@ func TestCache_DecoupleFill_TruncatedNotCached(t *testing.T) {
 	assert.EqualValues(t, 2, atomic.LoadInt32(&calls))
 }
 
-// The decoupled leader's own response has hop-by-hop headers stripped and no Age
-// header (the body is served from the buffer, not via the HIT path).
+// decoupledContended drives one decoupled leader fill that is guaranteed contended
+// (followers wait on the lock before the leader's WriteHeader, via a gated origin),
+// and returns the leader's recorder plus the origin call count. write produces the
+// response inside the origin (after the gate).
+func decoupledContended(t *testing.T, c *Cache, target string, write func(w http.ResponseWriter)) (*httptest.ResponseRecorder, int32) {
+	t.Helper()
+	originEntered := make(chan struct{})
+	originGate := make(chan struct{})
+	var calls int32
+	var once sync.Once
+	mw := c.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		once.Do(func() { close(originEntered) })
+		<-originGate
+		write(w)
+	}))
+
+	leaderRec := httptest.NewRecorder()
+	leaderDone := make(chan struct{})
+	go func() {
+		mw.ServeHTTP(leaderRec, httptest.NewRequest("GET", target, nil))
+		close(leaderDone)
+	}()
+	<-originEntered // leader holds the lock, blocked in origin
+
+	var fwg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		fwg.Add(1)
+		go func() {
+			defer fwg.Done()
+			mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", target, nil))
+		}()
+	}
+	time.Sleep(50 * time.Millisecond) // let the followers reach the wait
+
+	close(originGate)
+	<-leaderDone
+	fwg.Wait()
+	return leaderRec, atomic.LoadInt32(&calls)
+}
+
+// Under contention the decoupled leader's own response has hop-by-hop headers
+// stripped and no Age header (the body is served from the buffer, not the HIT path).
 func TestCache_DecoupleFill_LeaderHeadersSanitized(t *testing.T) {
 	eachBackendDecoupled(t, func(t *testing.T, c *Cache) {
-		var calls int32
-		h := origin(originSpec{
-			body:   []byte("ok"),
-			header: hdr("Cache-Control", "max-age=60", "Connection", "keep-alive", "X-App", "yes"),
-		}, &calls)
-		r := do(c, h, "GET", "http://acme.com/s", nil)
-		assert.Equal(t, "MISS", r.Header().Get("X-Cache"))
-		assert.Equal(t, "ok", r.Body.String())
-		assert.Equal(t, "yes", r.Header().Get("X-App"), "end-to-end header kept")
-		assert.Equal(t, "", r.Header().Get("Connection"), "hop-by-hop stripped from the decoupled leader")
-		assert.Equal(t, "", r.Header().Get("Age"), "a MISS carries no Age header")
+		leaderRec, calls := decoupledContended(t, c, "http://acme.com/s", func(w http.ResponseWriter) {
+			w.Header().Set("Cache-Control", "max-age=60")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("X-App", "yes")
+			w.Header().Set("Content-Length", "2")
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte("ok"))
+		})
+		assert.EqualValues(t, 1, calls, "origin contacted once")
+		assert.Equal(t, "MISS", leaderRec.Header().Get("X-Cache"))
+		assert.Equal(t, "ok", leaderRec.Body.String())
+		assert.Equal(t, "yes", leaderRec.Header().Get("X-App"), "end-to-end header kept")
+		assert.Equal(t, "", leaderRec.Header().Get("Connection"), "hop-by-hop stripped from the decoupled leader")
+		assert.Equal(t, "", leaderRec.Header().Get("Age"), "a MISS carries no Age header")
 	})
+}
+
+// Without contention (no follower waiting), DecoupleFill streams in lockstep — the
+// leader's raw headers pass straight through, with no buffering.
+func TestCache_DecoupleFill_SoloUsesLockstep(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024, DecoupleFill: true})
+	var calls int32
+	h := origin(originSpec{body: []byte("ok"), header: hdr("Cache-Control", "max-age=60", "Connection", "keep-alive")}, &calls)
+	r := do(c, h, "GET", "http://acme.com/solo", nil)
+	assert.Equal(t, "MISS", r.Header().Get("X-Cache"))
+	assert.Equal(t, "ok", r.Body.String())
+	assert.Equal(t, "keep-alive", r.Header().Get("Connection"), "uncontended fill streams in lockstep (raw headers)")
 }
 
 // A mid-fill storage write failure must still deliver the full body to the leader

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -33,6 +33,7 @@ type teeWriter struct {
 	ew         EntryWriter // nil = not caching this response
 	r          *http.Request
 	c          *Cache
+	lock       *fillLock // the leader's fill lock; its waiter count gates DecoupleFill
 	metaHeader http.Header
 	method     string
 	storeKey   string
@@ -78,11 +79,13 @@ func (tw *teeWriter) WriteHeader(code int) {
 			}
 		}
 	}
-	// DecoupleFill: when caching, buffer the body for the leader and stream it to
-	// storage, serving the client later (see fill/serveLeader) so a slow client can't
-	// hold the fill lock. Don't touch the client now. A non-cacheable response
-	// (ew == nil) still streams in lockstep.
-	if tw.ew != nil && tw.c.decoupleFill {
+	// DecoupleFill, but only when the fill is actually CONTENDED — at least one
+	// follower is already blocked on this lock. Then buffer the body for the leader
+	// and stream it to storage, serving the client later (see fill/serveLeader) so a
+	// slow client can't hold the lock from those followers. With no follower waiting
+	// there's nothing to isolate, so the leader streams in lockstep and pays no
+	// added latency. A non-cacheable response (ew == nil) always streams in lockstep.
+	if tw.ew != nil && tw.c.decoupleFill && tw.lock != nil && tw.lock.waiters.Load() > 0 {
 		tw.deferredClient = true
 		return
 	}


### PR DESCRIPTION
Refines `DecoupleFill` (#205) so it only pays its cost when there's actually something to gain.

## Problem

`DecoupleFill` buffered **every** cacheable fill. Even an uncontended miss (no follower waiting) paid the full cost: the leader waited for the whole fill — plus an extra in-memory copy of the body — before its first byte, isolating followers that didn't exist.

## Fix

Decoupling now engages **only when the fill is contended** — at least one follower is already blocked on the lock when the leader reaches `WriteHeader`.

- `fillLock` gains an atomic `waiters` counter, incremented around the follower's wait in `fillAndServe`.
- `fill` passes the lock to the `teeWriter`; `WriteHeader` decouples only when `decoupleFill && ew != nil && lock.waiters.Load() > 0`.

So:
- **Solo miss** → streams to the client in lockstep, **no added latency** (just like `DecoupleFill: false`).
- **Stampede** → decouples as before: fill at origin speed, commit, release followers, then serve the leader.

The common case is free; the slow-leader isolation kicks in exactly when followers are waiting on it. (A follower that arrives *after* the leader's `WriteHeader` on an otherwise-solo fill isn't isolated — it falls back to the normal `LockTimeout` path — which is the documented trade for zero uncontended latency.)

## Tests

- Reworked `SlowLeaderDoesNotBlockFollowers` to create genuine contention (followers gated behind the leader's still-running origin) — the headline property now actually exercises the gate.
- `LeaderHeadersSanitized` made contended via a new `decoupledContended` helper (asserts the decoupled leader gets sanitized headers).
- New `SoloUsesLockstep` — an uncontended fill keeps raw headers (proves the gate avoids decoupling).
- Existing solo tests (HEAD/204, truncation, storage-error, flush) keep passing on the lockstep path.

`go vet`, `go test -race ./...` (10× on the concurrency tests, no flakiness), `golangci-lint` (0 issues, incl. fieldalignment) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)