### PR TITLE
feat(cache): capture response Cache-Tag (surrogate keys) into Meta.Tags

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -417,6 +418,39 @@ func TestCache_MetaCarriesHostURIForRange(t *testing.T) {
 			assert.Equal(t, "/p?q=1", m.URI)
 		}
 	})
+}
+
+func TestCache_MetaCapturesCacheTags(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		var calls int32
+		// Comma-separated, with surrounding spaces and a duplicate.
+		h := origin(originSpec{body: []byte("x"), header: hdr("Cache-Control", "max-age=60", "Cache-Tag", "product-42, category-shoes , product-42")}, &calls)
+		do(c, h, "GET", "http://acme.com/p", nil) // fill
+
+		got := map[string]Meta{}
+		c.storage.Range(func(k string, m Meta) bool { got[k] = m; return true })
+		require.Len(t, got, 1)
+		for _, m := range got {
+			assert.Equal(t, []string{"product-42", "category-shoes"}, m.Tags, "trimmed + de-duplicated, order preserved")
+		}
+	})
+}
+
+func TestParseCacheTags(t *testing.T) {
+	assert.Nil(t, parseCacheTags(http.Header{}), "no header -> nil")
+	assert.Nil(t, parseCacheTags(hdr("Cache-Tag", " , ,")), "only blanks -> nil")
+	assert.Equal(t, []string{"a", "b", "c"}, parseCacheTags(hdr("Cache-Tag", "a,b,c")))
+	// Multiple header lines are merged.
+	multi := http.Header{"Cache-Tag": {"a, b", "b, c"}}
+	assert.Equal(t, []string{"a", "b", "c"}, parseCacheTags(multi), "merged across header lines, deduped")
+	// Over-long tags are dropped; the count is capped.
+	long := strings.Repeat("x", maxCacheTagLen+1)
+	assert.Equal(t, []string{"ok"}, parseCacheTags(hdr("Cache-Tag", long+", ok")), "over-length tag dropped")
+	var many []string
+	for i := 0; i < maxCacheTags+10; i++ {
+		many = append(many, "t"+strconv.Itoa(i))
+	}
+	assert.Len(t, parseCacheTags(hdr("Cache-Tag", strings.Join(many, ","))), maxCacheTags, "count capped")
 }
 
 func TestCache_PanicDuringFillIsSafe(t *testing.T) {

--- a/pkg/cache/memory.go
+++ b/pkg/cache/memory.go
@@ -43,10 +43,10 @@ func (s *MemoryStorage) Get(key string) (Meta, []byte, bool) {
 	return cloneMeta(e.meta), e.body, true
 }
 
-// cloneMeta returns m with its Header map and Vary slice deep-copied, so a caller
-// can't mutate (or data-race) the live stored entry's metadata. The body is not
-// copied (it is large and read-only by contract). The disk backend gets this for
-// free by unmarshaling a fresh Meta per call.
+// cloneMeta returns m with its Header map and Vary/Tags slices deep-copied, so a
+// caller can't mutate (or data-race) the live stored entry's metadata. The body is
+// not copied (it is large and read-only by contract). The disk backend gets this
+// for free by unmarshaling a fresh Meta per call.
 func cloneMeta(m Meta) Meta {
 	if m.Header != nil {
 		h := make(http.Header, len(m.Header))
@@ -57,6 +57,9 @@ func cloneMeta(m Meta) Meta {
 	}
 	if m.Vary != nil {
 		m.Vary = append([]string(nil), m.Vary...)
+	}
+	if m.Tags != nil {
+		m.Tags = append([]string(nil), m.Tags...)
 	}
 	return m
 }

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -96,6 +96,7 @@ type Meta struct {
 	Host       string      `json:"host,omitempty"` // normalized host (lowercased, port-stripped); for out-of-band Range maintenance
 	URI        string      `json:"uri,omitempty"`  // request-uri (path+query); for out-of-band Range maintenance
 	Vary       []string    `json:"vary"`           // lowercased Vary header names
+	Tags       []string    `json:"tags,omitempty"` // surrogate keys from the response Cache-Tag header; for out-of-band tag-scoped Range maintenance
 	Created    int64       `json:"created"`        // unix nanos
 	FreshUntil int64       `json:"fresh"`          // unix nanos; entry is stale after this
 	Size       int64       `json:"size"`           // body bytes (== eviction weight)

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -39,6 +40,7 @@ type teeWriter struct {
 	storeKey   string
 	primaryHex string
 	vary       []string     // sorted, lowercased
+	tags       []string     // surrogate keys parsed from the response Cache-Tag header
 	leaderBuf  bytes.Buffer // DecoupleFill: the leader's own copy of the body, served after the lock is released
 	written    int64
 	contentLen int64
@@ -71,6 +73,7 @@ func (tw *teeWriter) WriteHeader(code int) {
 			tw.ew = ew
 			tw.storeKey = storeKey
 			tw.vary = vary
+			tw.tags = parseCacheTags(h)
 			tw.freshUntil = dec.freshUntil
 			tw.metaHeader = sanitizeHeader(h)
 			if cl, ok := contentLength(h); ok {
@@ -169,6 +172,7 @@ func (tw *teeWriter) finish() {
 		Host:       normalizeHost(tw.r.Host),
 		URI:        tw.r.URL.RequestURI(),
 		Vary:       tw.vary,
+		Tags:       tw.tags,
 		Created:    time.Now().UnixNano(),
 		FreshUntil: tw.freshUntil.UnixNano(),
 		Size:       tw.written,
@@ -239,4 +243,43 @@ func sanitizeHeader(h http.Header) http.Header {
 		out[k] = append([]string(nil), vs...)
 	}
 	return out
+}
+
+// Surrogate-key (Cache-Tag) caps: an entry's tags are stored in its Meta and held
+// in RAM by the memory backend, so bound both the count and the length per entry so
+// a hostile/buggy origin can't bloat metadata.
+const (
+	maxCacheTags   = 64
+	maxCacheTagLen = 256
+)
+
+// parseCacheTags extracts surrogate keys from the response Cache-Tag header(s):
+// comma-separated, trimmed, de-duplicated, and capped (count + per-tag length).
+// Returns nil when there are none, so a no-tag response stores no Tags. The header
+// is left on the response (capture-only) — strip it at the origin if it must not
+// reach clients.
+func parseCacheTags(h http.Header) []string {
+	values := h.Values("Cache-Tag")
+	if len(values) == 0 {
+		return nil
+	}
+	var tags []string
+	seen := make(map[string]struct{})
+	for _, v := range values {
+		for _, t := range strings.Split(v, ",") {
+			t = strings.TrimSpace(t)
+			if t == "" || len(t) > maxCacheTagLen {
+				continue
+			}
+			if _, dup := seen[t]; dup {
+				continue
+			}
+			seen[t] = struct{}{}
+			tags = append(tags, t)
+			if len(tags) >= maxCacheTags {
+				return tags
+			}
+		}
+	}
+	return tags
 }


### PR DESCRIPTION
## What

Parse the response **`Cache-Tag`** header (comma-separated surrogate keys) at fill time and store the de-duplicated, capped list in **`Meta.Tags`**. `cloneMeta` deep-copies `Tags` too (consistent with the recent `Header`/`Vary` copy hardening), so `InvalidatedAfter`/`Range` callers can't mutate or data-race the live stored entry.

## Why

`Meta` keeps only the opaque `PrimaryHex` plus host/uri, so an out-of-band maintenance loop can match a stored entry by URL or host but not by **content identity**. Surrogate keys (Fastly/Cloudflare-style `Cache-Tag`) are the standard way to invalidate "everything tagged `product-42`" across URLs/hosts. Capturing them here lets a consumer — the parapet-ingress-controller edge's upcoming **tag-scoped cache purge** — match tagged entries off the serving path.

## Behavior

- Comma-separated, trimmed, de-duplicated, order-preserving. **Bounded per entry**: `maxCacheTags` (64) and `maxCacheTagLen` (256), so a hostile/buggy origin can't bloat metadata.
- **Capture-only**: the `Cache-Tag` header is left on the response (strip it at the origin if it must not reach clients).
- A no-tag response stores no `Tags` (`nil`).

## Compatibility

Additive: `Meta` gains `Tags` (`omitempty`; old on-disk entries deserialize with it empty). Field ordering keeps `fieldalignment` clean (the only flags are in `_test.go`, which CI excludes from govet).

## Tests

`TestCache_MetaCapturesCacheTags` (both backends, through the middleware: trim + dedup + order) and `TestParseCacheTags` (empty/blank, multi-line merge, over-length drop, count cap). `gofmt`/`go vet` clean, full module builds and all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)