### PR TITLE
feat(authn): add remote JWKS key source for JWT verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,13 @@ prevents algorithm-confusion attacks. The signature, `exp`/`nbf` (with leeway),
 and optional `iss`/`aud` claims are all verified; verified claims are placed on
 the request context for downstream handlers.
 
-```go
-import (
-	jose "github.com/go-jose/go-jose/v4"
-	"github.com/moonrhythm/parapet/pkg/authn"
-)
+Algorithms are pinned with this package's own constants (`authn.HS256`,
+`authn.RS256`, …), so callers don't import a JOSE library — only `pkg/authn`.
 
-m := authn.JWT([]byte(secret), jose.HS256) // []byte for HMAC; a public key for RS*/ES*/EdDSA
+```go
+import "github.com/moonrhythm/parapet/pkg/authn"
+
+m := authn.JWT([]byte(secret), authn.HS256) // []byte for HMAC; a public key for RS*/ES*/EdDSA
 m.Issuer = "https://issuer.example.com"
 m.Audience = "my-api"
 s.Use(m)
@@ -247,7 +247,7 @@ and enforced exactly as above.
 ```go
 m := authn.JWTFromKeySource(
 	&authn.JWKS{URL: "https://issuer.example.com/.well-known/jwks.json"},
-	jose.RS256, // pin the accepted algorithm(s)
+	authn.RS256, // pin the accepted algorithm(s)
 )
 m.Issuer = "https://issuer.example.com"
 m.Audience = "my-api"

--- a/README.md
+++ b/README.md
@@ -232,6 +232,31 @@ s.Use(m)
 claims, ok := authn.JWTClaimsFromContext(r.Context())
 ```
 
+### Rotating keys from a remote JWKS
+
+For tokens signed by an OIDC provider (Auth0, Okta, Google, …), verify against
+the provider's `jwks_uri` instead of a static key with `authn.JWKS`. It fetches
+the key set over HTTP and caches it, picking up signing-key **rotation** without
+a restart: a stale cache is refreshed in the background while the last good set
+keeps serving, and a token bearing an unknown `kid` triggers a single-flighted
+refetch (rate-limited so bogus `kid`s can't hammer the endpoint). Refresh
+failures are **fail-static** — once a set has been fetched, a later fetch error
+never starts rejecting valid tokens. The algorithm allowlist is still mandatory
+and enforced exactly as above.
+
+```go
+m := authn.JWTFromKeySource(
+	&authn.JWKS{URL: "https://issuer.example.com/.well-known/jwks.json"},
+	jose.RS256, // pin the accepted algorithm(s)
+)
+m.Issuer = "https://issuer.example.com"
+m.Audience = "my-api"
+s.Use(m)
+```
+
+`JWKS` exposes `RefreshInterval` (cache TTL, default 15m), `MinRefreshInterval`
+(unknown-`kid` refetch rate limit, default 1m), `Client`, and `MaxResponseBytes`.
+
 ## Response caching
 
 The [`cache`](pkg/cache) package is a CDN-style, honor-origin response cache. It caches a response **only** when the origin opts in with explicit freshness (`Cache-Control: s-maxage`/`max-age` or `Expires`); refuses `private`/`no-store`/`no-cache`, `Set-Cookie`, and `Vary: *`; honors `Vary`; serves `GET`/`HEAD` only; and ignores the client's request `Cache-Control` so a client can't bust the shared cache. Concurrent misses for one key collapse into a single origin fetch (single-flight), and it's fail-static — any storage error degrades to a miss, never an error to the client. Every response is tagged `X-Cache: HIT|MISS`.

--- a/pkg/authn/algorithm.go
+++ b/pkg/authn/algorithm.go
@@ -1,0 +1,43 @@
+package authn
+
+import jose "github.com/go-jose/go-jose/v4"
+
+// SignatureAlgorithm is a JWS signature (or MAC) algorithm accepted by
+// JWTAuthenticator. The values are the standard JWA names from RFC 7518; pin
+// the exact algorithm(s) your tokens are signed with so a token signed with any
+// other algorithm — including "none" — is rejected.
+//
+// Use these constants instead of importing a JOSE library directly: the common
+// path needs only this package.
+type SignatureAlgorithm string
+
+// Supported signature algorithms.
+const (
+	HS256 SignatureAlgorithm = "HS256" // HMAC using SHA-256
+	HS384 SignatureAlgorithm = "HS384" // HMAC using SHA-384
+	HS512 SignatureAlgorithm = "HS512" // HMAC using SHA-512
+	RS256 SignatureAlgorithm = "RS256" // RSASSA-PKCS#1 v1.5 using SHA-256
+	RS384 SignatureAlgorithm = "RS384" // RSASSA-PKCS#1 v1.5 using SHA-384
+	RS512 SignatureAlgorithm = "RS512" // RSASSA-PKCS#1 v1.5 using SHA-512
+	ES256 SignatureAlgorithm = "ES256" // ECDSA using P-256 and SHA-256
+	ES384 SignatureAlgorithm = "ES384" // ECDSA using P-384 and SHA-384
+	ES512 SignatureAlgorithm = "ES512" // ECDSA using P-521 and SHA-512
+	PS256 SignatureAlgorithm = "PS256" // RSASSA-PSS using SHA-256 and MGF1 with SHA-256
+	PS384 SignatureAlgorithm = "PS384" // RSASSA-PSS using SHA-384 and MGF1 with SHA-384
+	PS512 SignatureAlgorithm = "PS512" // RSASSA-PSS using SHA-512 and MGF1 with SHA-512
+	EdDSA SignatureAlgorithm = "EdDSA" // EdDSA using Ed25519
+)
+
+// toJOSEAlgorithms converts the public algorithm allowlist to the underlying
+// JOSE type. The JWA string values are identical, so this is a plain remap that
+// keeps the third-party type off the package's public API.
+func toJOSEAlgorithms(algs []SignatureAlgorithm) []jose.SignatureAlgorithm {
+	if len(algs) == 0 {
+		return nil
+	}
+	out := make([]jose.SignatureAlgorithm, len(algs))
+	for i, a := range algs {
+		out[i] = jose.SignatureAlgorithm(a)
+	}
+	return out
+}

--- a/pkg/authn/example_test.go
+++ b/pkg/authn/example_test.go
@@ -1,0 +1,154 @@
+package authn_test
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/authn"
+)
+
+// Verify HS256 bearer tokens signed with a shared secret, requiring matching
+// iss/aud claims. Algorithms are pinned with this package's constants, so no
+// JOSE library is imported.
+func ExampleJWT() {
+	m := authn.JWT([]byte("0123456789abcdef0123456789abcdef"), authn.HS256)
+	m.Issuer = "https://issuer.example.com"
+	m.Audience = "my-api"
+
+	s := parapet.New()
+	s.Use(m)
+}
+
+// Verify asymmetric tokens against the issuer's public key. key may be an
+// *rsa.PublicKey, *ecdsa.PublicKey or ed25519.PublicKey — typically parsed from
+// PEM with x509.ParsePKIXPublicKey. Pin the matching algorithm(s).
+func ExampleJWT_publicKey() {
+	var pub *rsa.PublicKey // e.g. from x509.ParsePKIXPublicKey
+
+	s := parapet.New()
+	s.Use(authn.JWT(pub, authn.RS256))
+}
+
+// Read the verified claims that authn.JWT placed on the request context from a
+// downstream handler.
+func ExampleJWTClaimsFromContext() {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims, ok := authn.JWTClaimsFromContext(r.Context())
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		fmt.Fprintf(w, "subject: %v", claims["sub"])
+	})
+	_ = h
+}
+
+// Verify tokens against an OIDC provider's rotating JWKS (jwks_uri) instead of a
+// static key, so signing-key rotation is picked up without a restart.
+func ExampleJWTFromKeySource() {
+	m := authn.JWTFromKeySource(
+		&authn.JWKS{URL: "https://issuer.example.com/.well-known/jwks.json"},
+		authn.RS256, // pin the accepted algorithm(s)
+	)
+	m.Issuer = "https://issuer.example.com"
+	m.Audience = "my-api"
+
+	s := parapet.New()
+	s.Use(m)
+}
+
+// Tune the JWKS cache and accept more than one algorithm.
+func ExampleJWKS() {
+	jwks := &authn.JWKS{
+		URL:                "https://issuer.example.com/.well-known/jwks.json",
+		RefreshInterval:    15 * time.Minute, // serve a cached set this long before refreshing
+		MinRefreshInterval: time.Minute,      // rate-limit unknown-kid refetches
+		MaxResponseBytes:   1 << 20,          // cap the response body at 1 MiB
+	}
+
+	s := parapet.New()
+	s.Use(authn.JWTFromKeySource(jwks, authn.RS256, authn.ES256))
+}
+
+// kidKeys is a custom KeySource backed by a fixed table of public keys keyed by
+// the token's "kid". Any KeySource can supply verification keys; the built-in
+// JWKS is one implementation.
+type kidKeys map[string]any
+
+func (k kidKeys) VerificationKey(_ context.Context, kid string) (any, error) {
+	key, ok := k[kid]
+	if !ok {
+		return nil, fmt.Errorf("unknown kid %q", kid)
+	}
+	return key, nil
+}
+
+// Plug a custom KeySource into the JWT authenticator.
+func ExampleKeySource() {
+	var current, previous *rsa.PublicKey // during a rotation, accept both
+
+	keys := kidKeys{"2025-current": current, "2025-previous": previous}
+
+	s := parapet.New()
+	s.Use(authn.JWTFromKeySource(keys, authn.RS256))
+}
+
+// Require HTTP Basic credentials. Comparison is constant-time.
+func ExampleBasic() {
+	s := parapet.New()
+	s.Use(authn.Basic("admin", "s3cret"))
+}
+
+// Verify Basic credentials against a custom backend by setting Authenticate
+// directly, with a realm reported in the WWW-Authenticate challenge.
+func ExampleBasicAuthenticator() {
+	m := &authn.BasicAuthenticator{
+		Realm: "admin area",
+		Authenticate: func(_ *http.Request, username, password string) error {
+			// look the user up in a store, verify the password hash, etc.
+			if username == "admin" && password == "s3cret" {
+				return nil
+			}
+			return authn.ErrInvalidCredentials
+		},
+	}
+
+	s := parapet.New()
+	s.Use(m)
+}
+
+// Delegate the auth decision to an external auth server: the request is allowed
+// when the server returns 2xx, and selected response headers are copied onto the
+// request for downstream handlers.
+func ExampleForward() {
+	u, _ := url.Parse("http://auth.internal/verify")
+
+	m := authn.Forward(u)
+	m.AuthResponseHeaders = []string{"X-Auth-User", "X-Auth-Roles"}
+
+	s := parapet.New()
+	s.Use(m)
+}
+
+// Authenticator is the building block the other helpers wrap. Use it directly
+// for a custom scheme — here, a static API key. Type is echoed in the
+// WWW-Authenticate header on a 401.
+func ExampleAuthenticator() {
+	m := authn.Authenticator{
+		Type: "Bearer",
+		Authenticate: func(r *http.Request) error {
+			if r.Header.Get("X-API-Key") == "secret-key" {
+				return nil
+			}
+			return authn.ErrMissingAuthorization
+		},
+	}
+
+	s := parapet.New()
+	s.Use(m)
+}

--- a/pkg/authn/jwks.go
+++ b/pkg/authn/jwks.go
@@ -18,10 +18,11 @@ import (
 // "kid" from the token's JOSE header ("" when the token carries none); an
 // implementation may use it to decide whether a refresh is warranted.
 //
-// The returned value must be one of the types go-jose accepts for verification
-// (see JWT). Returning a *jose.JSONWebKeySet is the common case: go-jose then
-// selects the key whose "kid" matches the token header and verifies with the
-// algorithm the JWTAuthenticator pinned.
+// The returned value must be a key the verifier accepts: a standard public key
+// (*rsa.PublicKey, *ecdsa.PublicKey, ed25519.PublicKey) or an HMAC []byte (see
+// JWT). The built-in JWKS returns a key set keyed by "kid"; the token's pinned
+// algorithm is still enforced by JWTAuthenticator regardless of what is
+// returned.
 type KeySource interface {
 	VerificationKey(ctx context.Context, kid string) (any, error)
 }

--- a/pkg/authn/jwks.go
+++ b/pkg/authn/jwks.go
@@ -1,0 +1,245 @@
+package authn
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+// KeySource supplies the verification key for JWTAuthenticator at request time,
+// which lets the signing key rotate without restarting the process. kid is the
+// "kid" from the token's JOSE header ("" when the token carries none); an
+// implementation may use it to decide whether a refresh is warranted.
+//
+// The returned value must be one of the types go-jose accepts for verification
+// (see JWT). Returning a *jose.JSONWebKeySet is the common case: go-jose then
+// selects the key whose "kid" matches the token header and verifies with the
+// algorithm the JWTAuthenticator pinned.
+type KeySource interface {
+	VerificationKey(ctx context.Context, kid string) (any, error)
+}
+
+// ErrNoKeys is returned by a KeySource that has never successfully obtained any
+// key material (e.g. a JWKS whose first fetch failed). Once any key set has been
+// fetched, a later refresh failure is absorbed (fail-static) rather than
+// surfaced.
+var ErrNoKeys = errors.New("authn: no verification keys")
+
+var defaultJWKSClient = &http.Client{Timeout: 10 * time.Second}
+
+const (
+	defaultJWKSRefreshInterval    = 15 * time.Minute
+	defaultJWKSMinRefreshInterval = time.Minute
+	defaultJWKSMaxResponseBytes   = 1 << 20 // 1 MiB
+)
+
+// JWKS is a KeySource backed by a remote JSON Web Key Set — an OIDC provider's
+// jwks_uri (e.g. Auth0, Okta, Google). It fetches the set over HTTP and caches
+// it, refetching when the cache goes stale or when a token presents a kid the
+// cache doesn't know, so signing-key rotation is picked up without a restart.
+//
+// Fetches are single-flighted: concurrent verifications that need a refresh
+// share one HTTP request. It is fail-static — once a key set has been fetched,
+// a later refresh failure keeps the last good set in service instead of
+// rejecting requests. A merely-stale refresh happens in the background and
+// serves the cached set meanwhile; only an empty cache or an unknown kid blocks
+// the caller on the fetch.
+//
+// JWKS is safe for concurrent use. The zero value is not usable: set URL (and
+// optionally the tuning fields) and pass it as JWTAuthenticator.KeySource.
+//
+//nolint:govet
+type JWKS struct {
+	// URL is the jwks_uri to fetch the key set from. Required.
+	URL string
+
+	// Client fetches the key set. Defaults to an *http.Client with a 10s
+	// timeout. Give it a tighter timeout or a custom transport as needed.
+	Client *http.Client
+
+	// RefreshInterval is how long a fetched set is served before it is treated
+	// as stale and refetched (in the background) on the next use. Defaults to
+	// 15m.
+	RefreshInterval time.Duration
+
+	// MinRefreshInterval rate-limits unknown-kid refetches: a token whose kid is
+	// absent from the cached set triggers a refetch only if at least this long
+	// has passed since the last fetch. It stops a flood of tokens bearing bogus
+	// kids from hammering the jwks_uri. Defaults to 1m.
+	MinRefreshInterval time.Duration
+
+	// MaxResponseBytes caps how many bytes of the JWKS response body are read,
+	// defending against a hostile or runaway endpoint. Defaults to 1 MiB.
+	MaxResponseBytes int64
+
+	// Now overrides the clock used for cache aging; mainly for tests. Defaults
+	// to time.Now.
+	Now func() time.Time
+
+	mu        sync.Mutex
+	set       *jose.JSONWebKeySet
+	fetchedAt time.Time
+	inflight  *fetchCall
+}
+
+// fetchCall is one in-flight JWKS fetch that concurrent callers wait on.
+type fetchCall struct {
+	done chan struct{}
+	set  *jose.JSONWebKeySet
+	err  error
+}
+
+// VerificationKey implements KeySource. It returns the cached key set,
+// refreshing it as needed (see JWKS).
+func (j *JWKS) VerificationKey(ctx context.Context, kid string) (any, error) {
+	j.mu.Lock()
+	set, fetchedAt := j.set, j.fetchedAt
+	age := j.now().Sub(fetchedAt)
+	j.mu.Unlock()
+
+	fresh := set != nil && age < j.refreshInterval()
+	known := set != nil && (kid == "" || containsKID(set, kid))
+
+	switch {
+	case set != nil && fresh && known:
+		// Fast path: usable set in hand.
+		return set, nil
+
+	case set != nil && known && !fresh:
+		// Stale but usable: serve it now, refresh in the background.
+		j.startFetch()
+		return set, nil
+
+	case set != nil && !known && age < j.minRefreshInterval():
+		// Unknown kid, but we refetched too recently to try again. Serve what we
+		// have; go-jose will reject the token as kid-not-found.
+		return set, nil
+	}
+
+	// Blocking fetch: the cache is empty, or a possibly-rotated kid is unknown
+	// and we are past the rate-limit window.
+	c := j.startFetch()
+	select {
+	case <-ctx.Done():
+		if set != nil {
+			return set, nil // caller gave up; fall back to the stale set
+		}
+		return nil, ctx.Err()
+	case <-c.done:
+	}
+
+	if c.err != nil {
+		if set != nil {
+			return set, nil // fail-static: keep the last good set
+		}
+		return nil, fmt.Errorf("%w: %w", ErrNoKeys, c.err)
+	}
+	return c.set, nil
+}
+
+// startFetch returns the in-flight fetch, starting one if none is running. The
+// fetch runs on a detached context so it isn't cancelled when the request that
+// triggered it ends; it is bounded by the Client timeout. Caller must not hold
+// j.mu.
+func (j *JWKS) startFetch() *fetchCall {
+	j.mu.Lock()
+	if j.inflight != nil {
+		c := j.inflight
+		j.mu.Unlock()
+		return c
+	}
+	c := &fetchCall{done: make(chan struct{})}
+	j.inflight = c
+	j.mu.Unlock()
+
+	go func() {
+		set, err := j.fetch(context.Background())
+
+		j.mu.Lock()
+		if err == nil {
+			j.set = set
+			j.fetchedAt = j.now()
+		}
+		j.inflight = nil
+		j.mu.Unlock()
+
+		c.set, c.err = set, err
+		close(c.done)
+	}()
+	return c
+}
+
+// fetch retrieves and decodes the key set from URL.
+func (j *JWKS) fetch(ctx context.Context) (*jose.JSONWebKeySet, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, j.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := j.client().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("authn: jwks fetch: unexpected status %d", resp.StatusCode)
+	}
+
+	var set jose.JSONWebKeySet
+	if err := json.NewDecoder(io.LimitReader(resp.Body, j.maxResponseBytes())).Decode(&set); err != nil {
+		return nil, fmt.Errorf("authn: jwks decode: %w", err)
+	}
+	if len(set.Keys) == 0 {
+		return nil, errors.New("authn: jwks: empty key set")
+	}
+	return &set, nil
+}
+
+func (j *JWKS) client() *http.Client {
+	if j.Client != nil {
+		return j.Client
+	}
+	return defaultJWKSClient
+}
+
+func (j *JWKS) now() time.Time {
+	if j.Now != nil {
+		return j.Now()
+	}
+	return time.Now()
+}
+
+func (j *JWKS) refreshInterval() time.Duration {
+	if j.RefreshInterval > 0 {
+		return j.RefreshInterval
+	}
+	return defaultJWKSRefreshInterval
+}
+
+func (j *JWKS) minRefreshInterval() time.Duration {
+	if j.MinRefreshInterval > 0 {
+		return j.MinRefreshInterval
+	}
+	return defaultJWKSMinRefreshInterval
+}
+
+func (j *JWKS) maxResponseBytes() int64 {
+	if j.MaxResponseBytes > 0 {
+		return j.MaxResponseBytes
+	}
+	return defaultJWKSMaxResponseBytes
+}
+
+// containsKID reports whether set has a key with the given kid.
+func containsKID(set *jose.JSONWebKeySet, kid string) bool {
+	return len(set.Key(kid)) > 0
+}

--- a/pkg/authn/jwks_test.go
+++ b/pkg/authn/jwks_test.go
@@ -117,7 +117,7 @@ func TestJWKS(t *testing.T) {
 		srv, ts := newServer(pubJWK(k1, "k1"))
 		defer ts.Close()
 
-		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.RS256)
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, RS256)
 		m.Now = fixedNow
 		token := signRSA(t, k1, "k1", validClaims())
 
@@ -140,7 +140,7 @@ func TestJWKS(t *testing.T) {
 		defer ts.Close()
 
 		clock := &testClock{t: jwtNow}
-		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, MinRefreshInterval: time.Minute}, jose.RS256)
+		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, MinRefreshInterval: time.Minute}, RS256)
 		m.Now = fixedNow
 
 		// Prime the cache with the k1 set.
@@ -163,7 +163,7 @@ func TestJWKS(t *testing.T) {
 		defer ts.Close()
 
 		clock := &testClock{t: jwtNow}
-		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, MinRefreshInterval: time.Hour}, jose.RS256)
+		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, MinRefreshInterval: time.Hour}, RS256)
 		m.Now = fixedNow
 
 		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
@@ -182,7 +182,7 @@ func TestJWKS(t *testing.T) {
 		defer ts.Close()
 
 		clock := &testClock{t: jwtNow}
-		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, RefreshInterval: 15 * time.Minute}, jose.RS256)
+		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, RefreshInterval: 15 * time.Minute}, RS256)
 		m.Now = fixedNow
 
 		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
@@ -211,7 +211,7 @@ func TestJWKS(t *testing.T) {
 		defer ts.Close()
 
 		clock := &testClock{t: jwtNow}
-		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, RefreshInterval: 15 * time.Minute}, jose.RS256)
+		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, RefreshInterval: 15 * time.Minute}, RS256)
 		m.Now = fixedNow
 
 		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
@@ -236,7 +236,7 @@ func TestJWKS(t *testing.T) {
 		defer ts.Close()
 		srv.setStatus(http.StatusInternalServerError)
 
-		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.RS256)
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, RS256)
 		m.Now = fixedNow
 
 		w, got := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
@@ -258,7 +258,7 @@ func TestJWKS(t *testing.T) {
 		_, ts := newServer(pubJWK(k1, "k1"))
 		defer ts.Close()
 
-		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.RS256)
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, RS256)
 		m.Now = fixedNow
 
 		// kid claims k1 but the token is actually signed by k2.
@@ -272,7 +272,7 @@ func TestJWKS(t *testing.T) {
 		defer ts.Close()
 
 		// Pin ES256 while the token is RS256: rejected before key lookup.
-		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.ES256)
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, ES256)
 		m.Now = fixedNow
 
 		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
@@ -283,7 +283,7 @@ func TestJWKS(t *testing.T) {
 		srv, ts := newServer(pubJWK(k1, "k1"))
 		defer ts.Close()
 
-		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.RS256) // pinned alg
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, RS256) // pinned alg
 		m.Algorithms = nil                                    // ...then cleared
 		m.Now = fixedNow
 

--- a/pkg/authn/jwks_test.go
+++ b/pkg/authn/jwks_test.go
@@ -1,0 +1,295 @@
+package authn_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/moonrhythm/parapet/pkg/authn"
+)
+
+// testClock is a manually-advanced clock for exercising JWKS cache aging.
+type testClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *testClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *testClock) advance(d time.Duration) {
+	c.mu.Lock()
+	c.t = c.t.Add(d)
+	c.mu.Unlock()
+}
+
+// jwksServer is a swappable, hit-counting jwks_uri for tests.
+type jwksServer struct {
+	mu     sync.Mutex
+	keys   []jose.JSONWebKey
+	status int // 0 => 200
+	hits   int
+}
+
+func (s *jwksServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	s.hits++
+	status := s.status
+	set := jose.JSONWebKeySet{Keys: append([]jose.JSONWebKey(nil), s.keys...)}
+	s.mu.Unlock()
+
+	if status != 0 {
+		w.WriteHeader(status)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(set)
+}
+
+func (s *jwksServer) setKeys(keys ...jose.JSONWebKey) {
+	s.mu.Lock()
+	s.keys = keys
+	s.mu.Unlock()
+}
+
+func (s *jwksServer) setStatus(status int) {
+	s.mu.Lock()
+	s.status = status
+	s.mu.Unlock()
+}
+
+func (s *jwksServer) hitCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.hits
+}
+
+func pubJWK(key *rsa.PrivateKey, kid string) jose.JSONWebKey {
+	return jose.JSONWebKey{Key: key.Public(), KeyID: kid, Algorithm: string(jose.RS256), Use: "sig"}
+}
+
+// signRSA signs claims with key under RS256, embedding kid in the JOSE header.
+func signRSA(t *testing.T, key *rsa.PrivateKey, kid string, claims any) string {
+	t.Helper()
+	jwk := jose.JSONWebKey{Key: key, KeyID: kid, Algorithm: string(jose.RS256)}
+	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: jwk}, (&jose.SignerOptions{}).WithType("JWT"))
+	require.NoError(t, err)
+	raw, err := jwt.Signed(sig).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+func validClaims() jwt.Claims {
+	return jwt.Claims{Subject: "user1", Expiry: jwt.NewNumericDate(jwtNow.Add(time.Hour))}
+}
+
+func fixedNow() time.Time { return jwtNow }
+
+func TestJWKS(t *testing.T) {
+	t.Parallel()
+
+	k1, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	k2, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	newServer := func(keys ...jose.JSONWebKey) (*jwksServer, *httptest.Server) {
+		srv := &jwksServer{keys: keys}
+		ts := httptest.NewServer(srv)
+		return srv, ts
+	}
+
+	t.Run("ValidAndCached", func(t *testing.T) {
+		srv, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.RS256)
+		m.Now = fixedNow
+		token := signRSA(t, k1, "k1", validClaims())
+
+		w, got := serveJWT(m, token)
+		assert.Equal(t, http.StatusOK, w.Code)
+		require.NotNil(t, got)
+		claims, ok := JWTClaimsFromContext(got.Context())
+		assert.True(t, ok)
+		assert.Equal(t, "user1", claims["sub"])
+		assert.Equal(t, 1, srv.hitCount())
+
+		// A second request within the refresh interval is served from cache.
+		w, _ = serveJWT(m, token)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 1, srv.hitCount(), "second verification must not refetch")
+	})
+
+	t.Run("RotationViaUnknownKid", func(t *testing.T) {
+		srv, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+
+		clock := &testClock{t: jwtNow}
+		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, MinRefreshInterval: time.Minute}, jose.RS256)
+		m.Now = fixedNow
+
+		// Prime the cache with the k1 set.
+		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, 1, srv.hitCount())
+
+		// Origin rotates to k2; past the rate-limit window an unknown kid forces
+		// a blocking refetch that then verifies the new token.
+		srv.setKeys(pubJWK(k2, "k2"))
+		clock.advance(2 * time.Minute)
+
+		w, _ = serveJWT(m, signRSA(t, k2, "k2", validClaims()))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 2, srv.hitCount())
+	})
+
+	t.Run("UnknownKidRateLimited", func(t *testing.T) {
+		srv, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+
+		clock := &testClock{t: jwtNow}
+		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, MinRefreshInterval: time.Hour}, jose.RS256)
+		m.Now = fixedNow
+
+		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, 1, srv.hitCount())
+
+		// Unknown kid within the rate-limit window: no refetch, token rejected.
+		w, got := serveJWT(m, signRSA(t, k2, "k2", validClaims()))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Nil(t, got)
+		assert.Equal(t, 1, srv.hitCount(), "bogus kid must not hammer the jwks_uri")
+	})
+
+	t.Run("StaleServedThenBackgroundRefresh", func(t *testing.T) {
+		srv, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+
+		clock := &testClock{t: jwtNow}
+		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, RefreshInterval: 15 * time.Minute}, jose.RS256)
+		m.Now = fixedNow
+
+		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, 1, srv.hitCount())
+
+		// Origin now publishes both keys; advance past the TTL.
+		srv.setKeys(pubJWK(k1, "k1"), pubJWK(k2, "k2"))
+		clock.advance(16 * time.Minute)
+
+		// A known-kid token is served immediately from the stale set...
+		w, _ = serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// ...while a background refetch picks up the rotated set.
+		require.Eventually(t, func() bool { return srv.hitCount() == 2 }, 2*time.Second, 5*time.Millisecond)
+
+		// The newly-published k2 now verifies without another fetch.
+		w, _ = serveJWT(m, signRSA(t, k2, "k2", validClaims()))
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, 2, srv.hitCount())
+	})
+
+	t.Run("FailStaticKeepsLastGoodSet", func(t *testing.T) {
+		srv, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+
+		clock := &testClock{t: jwtNow}
+		m := JWTFromKeySource(&JWKS{URL: ts.URL, Now: clock.now, RefreshInterval: 15 * time.Minute}, jose.RS256)
+		m.Now = fixedNow
+
+		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, 1, srv.hitCount())
+
+		// Origin starts failing; the stale-triggered background refetch fails.
+		srv.setStatus(http.StatusInternalServerError)
+		clock.advance(16 * time.Minute)
+
+		w, _ = serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		assert.Equal(t, http.StatusOK, w.Code, "a failed refresh must keep the last good key set")
+		require.Eventually(t, func() bool { return srv.hitCount() >= 2 }, 2*time.Second, 5*time.Millisecond)
+
+		// Still serving the cached k1 key on subsequent requests.
+		w, _ = serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("FirstFetchFailureRejects", func(t *testing.T) {
+		srv, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+		srv.setStatus(http.StatusInternalServerError)
+
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.RS256)
+		m.Now = fixedNow
+
+		w, got := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Nil(t, got)
+	})
+
+	t.Run("VerificationKeyReportsNoKeysOnFirstFailure", func(t *testing.T) {
+		srv, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+		srv.setStatus(http.StatusInternalServerError)
+
+		jwks := &JWKS{URL: ts.URL}
+		_, err := jwks.VerificationKey(context.Background(), "k1")
+		assert.ErrorIs(t, err, ErrNoKeys)
+	})
+
+	t.Run("WrongSigningKeyRejected", func(t *testing.T) {
+		_, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.RS256)
+		m.Now = fixedNow
+
+		// kid claims k1 but the token is actually signed by k2.
+		w, got := serveJWT(m, signRSA(t, k2, "k1", validClaims()))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Nil(t, got)
+	})
+
+	t.Run("WrongAlgorithmRejected", func(t *testing.T) {
+		_, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+
+		// Pin ES256 while the token is RS256: rejected before key lookup.
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.ES256)
+		m.Now = fixedNow
+
+		w, _ := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("NoAlgorithmsFailsClosed", func(t *testing.T) {
+		srv, ts := newServer(pubJWK(k1, "k1"))
+		defer ts.Close()
+
+		m := JWTFromKeySource(&JWKS{URL: ts.URL}, jose.RS256) // pinned alg
+		m.Algorithms = nil                                    // ...then cleared
+		m.Now = fixedNow
+
+		w, got := serveJWT(m, signRSA(t, k1, "k1", validClaims()))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Nil(t, got)
+		assert.Equal(t, 0, srv.hitCount(), "must reject before fetching keys")
+	})
+}

--- a/pkg/authn/jwt.go
+++ b/pkg/authn/jwt.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 
 	"github.com/moonrhythm/parapet/pkg/header"
@@ -27,13 +26,16 @@ var ErrInvalidToken = errors.New("invalid token")
 // prevents algorithm-confusion attacks, where an attacker re-signs a token with
 // an algorithm the verifier did not intend to accept.
 //
-// key may be any type go-jose accepts for verification: []byte for HMAC
-// (HS256/384/512), an *rsa.PublicKey, *ecdsa.PublicKey or ed25519.PublicKey for
-// asymmetric signatures, or a *jose.JSONWebKey / *jose.JSONWebKeySet.
+// algs pins the accepted algorithms with this package's SignatureAlgorithm
+// constants (e.g. authn.RS256) — callers don't import a JOSE library.
+//
+// key is a standard crypto key: []byte for HMAC (HS256/384/512), or an
+// *rsa.PublicKey, *ecdsa.PublicKey or ed25519.PublicKey for asymmetric
+// signatures.
 //
 // To verify against a rotating remote key set instead of a static key, leave
 // key nil and set JWTAuthenticator.KeySource (see JWTFromKeySource and JWKS).
-func JWT(key any, algs ...jose.SignatureAlgorithm) *JWTAuthenticator {
+func JWT(key any, algs ...SignatureAlgorithm) *JWTAuthenticator {
 	return &JWTAuthenticator{
 		Key:        key,
 		Algorithms: algs,
@@ -44,7 +46,7 @@ func JWT(key any, algs ...jose.SignatureAlgorithm) *JWTAuthenticator {
 // resolves its verification key from src at request time — typically a remote,
 // rotating JWKS via JWKS — instead of a fixed key. The algorithm allowlist is
 // still mandatory and enforced exactly as in JWT.
-func JWTFromKeySource(src KeySource, algs ...jose.SignatureAlgorithm) *JWTAuthenticator {
+func JWTFromKeySource(src KeySource, algs ...SignatureAlgorithm) *JWTAuthenticator {
 	return &JWTAuthenticator{
 		KeySource:  src,
 		Algorithms: algs,
@@ -66,7 +68,7 @@ type JWTAuthenticator struct {
 
 	// Algorithms is the set of accepted signature algorithms. It is required;
 	// when empty every request is rejected.
-	Algorithms []jose.SignatureAlgorithm
+	Algorithms []SignatureAlgorithm
 
 	// Issuer and Audience, when set, must match the token's "iss" and "aud"
 	// claims respectively.
@@ -107,6 +109,9 @@ func (m JWTAuthenticator) ServeHandler(h http.Handler) http.Handler {
 		now = time.Now
 	}
 
+	// Convert the pinned algorithms to the JOSE type once, at setup.
+	algs := toJOSEAlgorithms(m.Algorithms)
+
 	return Authenticator{
 		Type:            challenge,
 		ShareValueSlice: m.ShareValueSlice,
@@ -118,11 +123,11 @@ func (m JWTAuthenticator) ServeHandler(h http.Handler) http.Handler {
 
 			// Fail closed when no algorithm is pinned, rather than trusting
 			// whatever the token header claims.
-			if len(m.Algorithms) == 0 {
+			if len(algs) == 0 {
 				return ErrInvalidToken
 			}
 
-			tok, err := jwt.ParseSigned(raw, m.Algorithms)
+			tok, err := jwt.ParseSigned(raw, algs)
 			if err != nil {
 				return ErrInvalidToken
 			}

--- a/pkg/authn/jwt.go
+++ b/pkg/authn/jwt.go
@@ -30,9 +30,23 @@ var ErrInvalidToken = errors.New("invalid token")
 // key may be any type go-jose accepts for verification: []byte for HMAC
 // (HS256/384/512), an *rsa.PublicKey, *ecdsa.PublicKey or ed25519.PublicKey for
 // asymmetric signatures, or a *jose.JSONWebKey / *jose.JSONWebKeySet.
+//
+// To verify against a rotating remote key set instead of a static key, leave
+// key nil and set JWTAuthenticator.KeySource (see JWTFromKeySource and JWKS).
 func JWT(key any, algs ...jose.SignatureAlgorithm) *JWTAuthenticator {
 	return &JWTAuthenticator{
 		Key:        key,
+		Algorithms: algs,
+	}
+}
+
+// JWTFromKeySource creates a JWT bearer-token authentication middleware that
+// resolves its verification key from src at request time — typically a remote,
+// rotating JWKS via JWKS — instead of a fixed key. The algorithm allowlist is
+// still mandatory and enforced exactly as in JWT.
+func JWTFromKeySource(src KeySource, algs ...jose.SignatureAlgorithm) *JWTAuthenticator {
+	return &JWTAuthenticator{
+		KeySource:  src,
 		Algorithms: algs,
 	}
 }
@@ -41,8 +55,14 @@ func JWT(key any, algs ...jose.SignatureAlgorithm) *JWTAuthenticator {
 //
 //nolint:govet
 type JWTAuthenticator struct {
-	// Key verifies the token signature. See JWT for accepted types.
+	// Key verifies the token signature. See JWT for accepted types. Ignored when
+	// KeySource is set.
 	Key any
+
+	// KeySource, when set, supplies the verification key dynamically at request
+	// time (e.g. a rotating remote JWKS via JWKS) and takes precedence over Key.
+	// The token's "kid" header is passed to it so it can select or refresh keys.
+	KeySource KeySource
 
 	// Algorithms is the set of accepted signature algorithms. It is required;
 	// when empty every request is rejected.
@@ -107,12 +127,27 @@ func (m JWTAuthenticator) ServeHandler(h http.Handler) http.Handler {
 				return ErrInvalidToken
 			}
 
+			// Resolve the verification key. A KeySource (e.g. a rotating remote
+			// JWKS) takes precedence over the static Key and is handed the
+			// token's kid so it can select or refresh the right key.
+			key := m.Key
+			if m.KeySource != nil {
+				var kid string
+				if len(tok.Headers) > 0 {
+					kid = tok.Headers[0].KeyID
+				}
+				key, err = m.KeySource.VerificationKey(r.Context(), kid)
+				if err != nil {
+					return ErrInvalidToken
+				}
+			}
+
 			// Claims verifies the signature, then decodes the payload into the
 			// registered-claims struct (for validation) and a map (for
 			// downstream consumers).
 			var claims jwt.Claims
 			all := map[string]any{}
-			if err := tok.Claims(m.Key, &claims, &all); err != nil {
+			if err := tok.Claims(key, &claims, &all); err != nil {
 				return ErrInvalidToken
 			}
 

--- a/pkg/authn/jwt_test.go
+++ b/pkg/authn/jwt_test.go
@@ -58,7 +58,7 @@ func TestJWT(t *testing.T) {
 			Subject: "user1",
 			Expiry:  jwt.NewNumericDate(jwtNow.Add(time.Hour)),
 		})
-		m := JWT(jwtSecret, jose.HS256)
+		m := JWT(jwtSecret, HS256)
 		m.Now = fixedNow
 
 		w, got := serveJWT(m, token)
@@ -70,7 +70,7 @@ func TestJWT(t *testing.T) {
 	})
 
 	t.Run("MissingAuthorization", func(t *testing.T) {
-		m := JWT(jwtSecret, jose.HS256)
+		m := JWT(jwtSecret, HS256)
 		m.Realm = "api"
 		w, got := serveJWT(m, "")
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -79,7 +79,7 @@ func TestJWT(t *testing.T) {
 	})
 
 	t.Run("NotBearer", func(t *testing.T) {
-		m := JWT(jwtSecret, jose.HS256)
+		m := JWT(jwtSecret, HS256)
 		h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Fail(t, "must not be called")
 		}))
@@ -101,7 +101,7 @@ func TestJWT(t *testing.T) {
 
 	t.Run("WrongAlgorithmRejected", func(t *testing.T) {
 		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Subject: "user1"})
-		m := JWT(jwtSecret, jose.HS384) // token is HS256
+		m := JWT(jwtSecret, HS384) // token is HS256
 		m.Now = fixedNow
 		w, _ := serveJWT(m, token)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -109,7 +109,7 @@ func TestJWT(t *testing.T) {
 
 	t.Run("BadSignatureRejected", func(t *testing.T) {
 		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Subject: "user1"})
-		m := JWT(jwtOtherSecret, jose.HS256) // verifies with the wrong key
+		m := JWT(jwtOtherSecret, HS256) // verifies with the wrong key
 		m.Now = fixedNow
 		w, _ := serveJWT(m, token)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -120,7 +120,7 @@ func TestJWT(t *testing.T) {
 			Subject: "user1",
 			Expiry:  jwt.NewNumericDate(jwtNow.Add(-time.Hour)),
 		})
-		m := JWT(jwtSecret, jose.HS256)
+		m := JWT(jwtSecret, HS256)
 		m.Now = fixedNow
 		w, _ := serveJWT(m, token)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -131,7 +131,7 @@ func TestJWT(t *testing.T) {
 			Subject:   "user1",
 			NotBefore: jwt.NewNumericDate(jwtNow.Add(time.Hour)),
 		})
-		m := JWT(jwtSecret, jose.HS256)
+		m := JWT(jwtSecret, HS256)
 		m.Now = fixedNow
 		w, _ := serveJWT(m, token)
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
@@ -139,7 +139,7 @@ func TestJWT(t *testing.T) {
 
 	t.Run("Issuer", func(t *testing.T) {
 		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Issuer: "good"})
-		m := JWT(jwtSecret, jose.HS256)
+		m := JWT(jwtSecret, HS256)
 		m.Now = fixedNow
 		m.Issuer = "good"
 		w, _ := serveJWT(m, token)
@@ -152,7 +152,7 @@ func TestJWT(t *testing.T) {
 
 	t.Run("Audience", func(t *testing.T) {
 		token := signToken(t, jose.HS256, jwtSecret, jwt.Claims{Audience: jwt.Audience{"svc"}})
-		m := JWT(jwtSecret, jose.HS256)
+		m := JWT(jwtSecret, HS256)
 		m.Now = fixedNow
 		m.Audience = "svc"
 		w, _ := serveJWT(m, token)
@@ -164,7 +164,7 @@ func TestJWT(t *testing.T) {
 	})
 
 	t.Run("ShareValueSlice", func(t *testing.T) {
-		m := JWT(jwtSecret, jose.HS256)
+		m := JWT(jwtSecret, HS256)
 		m.Realm = "api"
 		m.ShareValueSlice = true
 		h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

Two related changes to `pkg/authn`:

1. **`authn.JWKS`** — a remote JSON Web Key Set backend that lets `JWTAuthenticator` verify tokens against an OIDC provider's `jwks_uri` (Auth0, Okta, Google, …) instead of a static key, picking up **signing-key rotation without a restart**. Wired in via a new `KeySource` interface and a `JWTAuthenticator.KeySource` field (takes precedence over `Key`, fed the token's `kid`), plus a `JWTFromKeySource(src, algs...)` constructor.

2. **`authn.SignatureAlgorithm`** — a local algorithm enum so callers no longer import a JOSE library to name an algorithm. go-jose becomes an internal implementation detail.

```go
import "github.com/moonrhythm/parapet/pkg/authn"

// static key — only pkg/authn is imported
m := authn.JWT([]byte(secret), authn.HS256)

// rotating remote JWKS
m := authn.JWTFromKeySource(
    &authn.JWKS{URL: "https://issuer.example.com/.well-known/jwks.json"},
    authn.RS256, // pin the accepted algorithm(s)
)
m.Issuer = "https://issuer.example.com"
m.Audience = "my-api"
s.Use(m)
```

## How — JWKS

- go-jose performs `kid`→key selection when handed the `*jose.JSONWebKeySet`; `JWKS` just supplies the current set.
- **Background refresh**: a stale cache (`RefreshInterval`, default 15m) is refreshed in the background while the last good set keeps serving — zero added latency in steady state. An unknown-`kid` token forces a blocking refetch.
- **Single-flighted** fetches so concurrent verifications collapse into one HTTP request.
- **Rate-limited** unknown-`kid` refetches (`MinRefreshInterval`, default 1m) so bogus `kid`s can't hammer the IdP.
- **Fail-static**: once a set has been fetched, a later fetch failure never starts rejecting valid tokens; only an empty cache errors (wrapped `ErrNoKeys`).
- `MaxResponseBytes` cap (1 MiB) against a hostile endpoint; injectable `Client` and `Now`.
- The mandatory algorithm allowlist is enforced unchanged, **before** any key lookup.

## How — hiding go-jose

- New `authn.SignatureAlgorithm` (string type) with the standard JWA constants: `HS256/384/512`, `RS256/384/512`, `ES256/384/512`, `PS256/384/512`, `EdDSA`.
- `JWT`, `JWTFromKeySource`, and `JWTAuthenticator.Algorithms` take the local type; a single `toJOSEAlgorithms` remap (identical JWA string values) converts to the JOSE type **once at setup**, not per request.
- Keys stay standard crypto types (`[]byte`, `*rsa.PublicKey`, …); `KeySource`/`JWKS` expose only `any`. A consumer verifying tokens now imports **only `pkg/authn`** — verified with an in-module build whose direct import set contains no go-jose, and via `go doc` (no `jose` type in any exported signature).
- go-jose remains a *transitive* dependency (the internal JOSE engine); it is hidden from the public API, not removed from the module.

## Design notes

- **No new dependencies** — single-flight is hand-rolled to match the package's minimal style; `go.mod`/`go.sum` untouched.
- **No long-lived goroutine / no `Close()`** — refresh runs on transient, detached (`context.Background()`), timeout-bounded goroutines, so nothing leaks and there's no lifecycle to manage.
- Tokens must carry a `kid` (universal for OIDC); go-jose safely rejects a `kid`-less token against a multi-key set.

## ⚠️ Breaking change

Pinning the algorithm now uses `authn.*` constants instead of `jose.*`: callers of the JWT API (added in #178) must switch `jose.HS256` → `authn.HS256` (same JWA string values). Flagged `BREAKING:` in the commit body.

## Tests

`pkg/authn/jwks_test.go` covers: valid+cached, rotation via unknown kid, unknown-kid rate-limiting, stale-served-then-background-refresh, fail-static, first-fetch-failure (`ErrNoKeys`), wrong-signing-key, wrong-algorithm, and fail-closed. `make` passes clean (vet + lint 0 issues + full `-race` suite); concurrency paths verified over 10× repeated race runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)