### PR TITLE
feat(proxyprotocol): add HAProxy PROXY protocol (v1/v2) reader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Each subdirectory under `pkg/` is a self-contained middleware or feature:
 | `router` | URL routing. |
 | `fileserver` | Static file serving. |
 | `authn` | Authentication helpers (JWT, basic auth). |
+| `proxyprotocol` | HAProxy PROXY protocol (v1/v2) reader; rewrites conn `RemoteAddr` to the real client behind an L4 LB. Wired via `Server.ModifyConnection`. |
 | `gcp` / `stackdriver` / `trace` | Google Cloud integration and distributed tracing (OpenCensus/OpenTelemetry). |
 
 ### Middleware composition pattern

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Each subdirectory under `pkg/` is a self-contained middleware:
 | [`authn`](pkg/authn) | JWT and basic-auth helpers |
 | [`waf`](pkg/waf) | Web application firewall driven by CEL expressions, hot reloadable |
 | [`prom`](pkg/prom) | Prometheus metrics |
+| [`proxyprotocol`](pkg/proxyprotocol) | HAProxy PROXY protocol (v1/v2) — recover the real client IP behind an L4 load balancer |
 | [`h2push`](pkg/h2push) | HTTP/2 server push helpers |
 | [`gcp`](pkg/gcp), [`gcs`](pkg/gcs), [`stackdriver`](pkg/stackdriver), [`trace`](pkg/trace) | Google Cloud integrations and distributed tracing |
 
@@ -283,6 +284,30 @@ s.Use(h)
 ## Trusted proxies
 
 Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes from a trusted CIDR. Configure trust with `TrustCIDRs(...)` or accept the defaults from `Trusted()` (standard private and loopback ranges). Servers created with `NewFrontend()` start with no trusted proxies by default.
+
+## PROXY protocol
+
+An L4 load balancer (AWS NLB, HAProxy in TCP mode, …) terminates the TCP
+connection, so without help the proxy sees the balancer's IP, not the client's —
+and an L4 balancer adds no `X-Forwarded-For`. The [`proxyprotocol`](pkg/proxyprotocol)
+package reads the HAProxy **PROXY protocol** header (v1 and v2) that such
+balancers prepend and rewrites the connection's `RemoteAddr` to the real client,
+so `ratelimit`, `waf`, `logger`, and the trust logic above all see the right
+address. Mount it with `Server.ModifyConnection`; the header is parsed lazily on
+the connection's first read, off the accept loop.
+
+```go
+// Only the listed CIDRs (your load balancer) may set a client address; a direct
+// connection from outside them is passed through untouched and cannot spoof one.
+pp := proxyprotocol.New("10.0.0.0/8")
+
+s := parapet.NewFrontend()
+s.ModifyConnection(pp.ModifyConnection)
+```
+
+Set `Require` to reject a trusted connection that arrives without a PROXY header
+(use it when every connection from the balancer is guaranteed to carry one); by
+default such a connection is served with its real peer address.
 
 ## Performance tuning
 

--- a/pkg/proxyprotocol/example_test.go
+++ b/pkg/proxyprotocol/example_test.go
@@ -1,0 +1,28 @@
+package proxyprotocol_test
+
+import (
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/proxyprotocol"
+)
+
+// Recover the real client IP behind an L4 load balancer that speaks the PROXY
+// protocol. Only connections from the balancer's range may set a client
+// address.
+func ExampleNew() {
+	pp := proxyprotocol.New("10.0.0.0/8") // your load balancer's CIDR(s)
+
+	s := parapet.NewFrontend()
+	s.ModifyConnection(pp.ModifyConnection)
+	// s.Use(...) the rest of the chain; ratelimit/waf/logger now see the client.
+}
+
+// Require every trusted connection to carry a PROXY header — appropriate when
+// the balancer always prepends one. A trusted connection without a header is
+// rejected instead of served with the balancer's address.
+func ExampleModifier_require() {
+	pp := proxyprotocol.New("10.0.0.0/8")
+	pp.Require = true
+
+	s := parapet.NewFrontend()
+	s.ModifyConnection(pp.ModifyConnection)
+}

--- a/pkg/proxyprotocol/parse.go
+++ b/pkg/proxyprotocol/parse.go
@@ -1,0 +1,189 @@
+package proxyprotocol
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// v2Signature is the 12-byte block that begins every PROXY protocol v2 header.
+var v2Signature = []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+
+var v1Prefix = []byte("PROXY ")
+
+// errNoHeader reports that the stream does not begin with a PROXY header. When
+// it is returned, nothing has been consumed from the reader.
+var errNoHeader = errors.New("proxyprotocol: no PROXY header")
+
+// errMalformed reports a PROXY header that was identified but could not be
+// parsed. Bytes may have been consumed, so the connection can no longer serve a
+// request and should be dropped.
+var errMalformed = errors.New("proxyprotocol: malformed PROXY header")
+
+// maxV1Line is the maximum length of a v1 header line including CRLF (RFC: 108).
+const maxV1Line = 108
+
+// parseHeader reads a PROXY protocol v1 or v2 header from r and returns the
+// real client (source) address.
+//
+//   - (addr, nil): a PROXY command carrying a TCP/UDP source address.
+//   - (nil, nil):  a header with no usable source — v1 UNKNOWN, v2 LOCAL, or an
+//     AF_UNSPEC/AF_UNIX v2 address. The header is consumed; keep the real peer.
+//   - (nil, errNoHeader): not a PROXY header; nothing was consumed.
+//   - (nil, errMalformed / io error): a broken header; bytes were consumed.
+func parseHeader(r *bufio.Reader) (net.Addr, error) {
+	// Peek does not consume, so a non-PROXY stream is left intact for the caller
+	// to pass through untouched.
+	buf, _ := r.Peek(len(v2Signature))
+	switch {
+	case len(buf) >= len(v2Signature) && bytes.Equal(buf, v2Signature):
+		return parseV2(r)
+	case len(buf) >= len(v1Prefix) && bytes.Equal(buf[:len(v1Prefix)], v1Prefix):
+		return parseV1(r)
+	default:
+		return nil, errNoHeader
+	}
+}
+
+// parseV1 parses a human-readable v1 header line:
+//
+//	PROXY TCP4 <src> <dst> <sport> <dport>\r\n
+//	PROXY TCP6 <src> <dst> <sport> <dport>\r\n
+//	PROXY UNKNOWN ...\r\n
+func parseV1(r *bufio.Reader) (net.Addr, error) {
+	// ReadSlice is bounded by the bufio buffer, so a trusted peer that never
+	// sends a newline can't grow an unbounded line (it yields ErrBufferFull).
+	line, err := r.ReadSlice('\n')
+	if err != nil {
+		if errors.Is(err, bufio.ErrBufferFull) {
+			return nil, errMalformed
+		}
+		return nil, err
+	}
+	if len(line) > maxV1Line || !bytes.HasSuffix(line, []byte("\r\n")) {
+		return nil, errMalformed
+	}
+
+	fields := strings.Split(string(line[:len(line)-2]), " ")
+	if len(fields) < 2 || fields[0] != "PROXY" {
+		return nil, errMalformed
+	}
+
+	switch fields[1] {
+	case "TCP4", "TCP6":
+		if len(fields) != 6 {
+			return nil, errMalformed
+		}
+		ip := net.ParseIP(fields[2])
+		port, err := strconv.Atoi(fields[4])
+		if ip == nil || err != nil || port < 0 || port > 65535 {
+			return nil, errMalformed
+		}
+		return &net.TCPAddr{IP: ip, Port: port}, nil
+	case "UNKNOWN":
+		// Connection from an unknown source (e.g. a health check); keep the real
+		// peer but still consume the header.
+		return nil, nil
+	default:
+		return nil, errMalformed
+	}
+}
+
+// PROXY protocol v2 constants.
+const (
+	v2VersionPROXY = 0x2 // high nibble of byte 12
+
+	v2CmdLocal = 0x0 // health check / no address
+	v2CmdProxy = 0x1 // addresses follow
+
+	v2FamUnspec = 0x0
+	v2FamInet   = 0x1 // AF_INET  (IPv4)
+	v2FamInet6  = 0x2 // AF_INET6 (IPv6)
+	v2FamUnix   = 0x3
+
+	v2AddrLenInet  = 12 // 4 + 4 + 2 + 2
+	v2AddrLenInet6 = 36 // 16 + 16 + 2 + 2
+)
+
+// parseV2 parses the binary v2 header. The 16-byte fixed header (12-byte
+// signature + version/command + family/protocol + 2-byte length) is followed by
+// length bytes of address block and optional TLVs, which are discarded.
+func parseV2(r *bufio.Reader) (net.Addr, error) {
+	var hdr [16]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+
+	verCmd := hdr[12]
+	if verCmd>>4 != v2VersionPROXY {
+		return nil, errMalformed
+	}
+	cmd := verCmd & 0x0F
+	family := hdr[13] >> 4
+	length := int(binary.BigEndian.Uint16(hdr[14:16]))
+
+	switch cmd {
+	case v2CmdLocal:
+		// No address; the real peer stands. Discard any payload.
+		return nil, discard(r, length)
+	case v2CmdProxy:
+		// handled below
+	default:
+		return nil, errMalformed
+	}
+
+	var src net.Addr
+	consumed := 0
+	switch family {
+	case v2FamInet:
+		if length < v2AddrLenInet {
+			return nil, errMalformed
+		}
+		var b [v2AddrLenInet]byte
+		if _, err := io.ReadFull(r, b[:]); err != nil {
+			return nil, err
+		}
+		consumed = v2AddrLenInet
+		src = &net.TCPAddr{
+			IP:   append(net.IP(nil), b[0:4]...),
+			Port: int(binary.BigEndian.Uint16(b[8:10])),
+		}
+	case v2FamInet6:
+		if length < v2AddrLenInet6 {
+			return nil, errMalformed
+		}
+		var b [v2AddrLenInet6]byte
+		if _, err := io.ReadFull(r, b[:]); err != nil {
+			return nil, err
+		}
+		consumed = v2AddrLenInet6
+		src = &net.TCPAddr{
+			IP:   append(net.IP(nil), b[0:16]...),
+			Port: int(binary.BigEndian.Uint16(b[32:34])),
+		}
+	case v2FamUnspec, v2FamUnix:
+		// No IP override; consume the whole block below.
+	default:
+		return nil, errMalformed
+	}
+
+	// Discard the remainder of the address block (TLVs, or the full body for
+	// AF_UNSPEC/AF_UNIX).
+	if err := discard(r, length-consumed); err != nil {
+		return nil, err
+	}
+	return src, nil
+}
+
+func discard(r *bufio.Reader, n int) error {
+	if n <= 0 {
+		return nil
+	}
+	_, err := r.Discard(n)
+	return err
+}

--- a/pkg/proxyprotocol/proxyprotocol.go
+++ b/pkg/proxyprotocol/proxyprotocol.go
@@ -1,0 +1,173 @@
+// Package proxyprotocol reads the HAProxy PROXY protocol (v1 and v2) header
+// from accepted connections and rewrites their RemoteAddr to the real client
+// address. Mount it on a Server with Server.ModifyConnection so that middleware
+// reading the client IP — ratelimit, waf, logger, and the X-Forwarded-* trust
+// logic — sees the actual client instead of the L4 load balancer in front.
+//
+//	m := proxyprotocol.New("10.0.0.0/8") // your load balancer's range
+//	s := parapet.NewFrontend()
+//	s.ModifyConnection(m.ModifyConnection)
+//
+// Only a connection whose immediate peer is within the trusted CIDRs may set a
+// client address; a direct attacker outside them is passed through untouched
+// and cannot spoof a client IP. The header is parsed lazily on the connection's
+// first read, off the accept loop.
+package proxyprotocol
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// DefaultHeaderTimeout bounds how long a trusted connection has to deliver its
+// PROXY header before the read fails.
+const DefaultHeaderTimeout = 10 * time.Second
+
+// Modifier wraps accepted connections to honor the PROXY protocol. Create it
+// with New and pass its ModifyConnection method to Server.ModifyConnection.
+//
+//nolint:govet
+type Modifier struct {
+	trusted []*net.IPNet
+
+	// Require rejects a trusted connection that does not begin with a valid
+	// PROXY header (its first read fails, so the server drops it). By default a
+	// trusted connection without a header is passed through with its real peer
+	// address — enable Require when every connection from the load balancer is
+	// guaranteed to carry the header.
+	Require bool
+
+	// HeaderTimeout bounds reading the PROXY header from a trusted connection.
+	// Zero uses DefaultHeaderTimeout; a negative value disables the deadline.
+	HeaderTimeout time.Duration
+}
+
+// New creates a Modifier that trusts the given load-balancer CIDRs to supply a
+// client address via the PROXY header. It panics on an invalid CIDR, matching
+// parapet's fail-fast trust configuration — a silently-empty trust list is a
+// security footgun.
+//
+// With no CIDRs every peer is trusted; use that only when the listener is
+// reachable exclusively through your load balancer.
+func New(trustedCIDRs ...string) *Modifier {
+	trusted := make([]*net.IPNet, 0, len(trustedCIDRs))
+	for _, s := range trustedCIDRs {
+		_, n, err := net.ParseCIDR(s)
+		if err != nil {
+			panic("proxyprotocol: invalid CIDR " + strconv.Quote(s) + ": " + err.Error())
+		}
+		trusted = append(trusted, n)
+	}
+	return &Modifier{trusted: trusted}
+}
+
+// ModifyConnection wraps c so its PROXY header (if any) is parsed on first read.
+// Pass it to Server.ModifyConnection. It performs no I/O itself, so it never
+// blocks the accept loop.
+func (m *Modifier) ModifyConnection(c net.Conn) net.Conn {
+	if !m.trusts(c.RemoteAddr()) {
+		// Untrusted peer: leave the connection (and its bytes) untouched.
+		return c
+	}
+	return &conn{
+		Conn:          c,
+		r:             bufio.NewReader(c),
+		require:       m.Require,
+		headerTimeout: m.headerTimeout(),
+	}
+}
+
+func (m *Modifier) headerTimeout() time.Duration {
+	if m.HeaderTimeout == 0 {
+		return DefaultHeaderTimeout
+	}
+	return m.HeaderTimeout
+}
+
+func (m *Modifier) trusts(addr net.Addr) bool {
+	if len(m.trusted) == 0 {
+		return true
+	}
+	ip := addrIP(addr)
+	if ip == nil {
+		return false
+	}
+	for _, n := range m.trusted {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func addrIP(a net.Addr) net.IP {
+	switch v := a.(type) {
+	case *net.TCPAddr:
+		return v.IP
+	case *net.UDPAddr:
+		return v.IP
+	}
+	host, _, err := net.SplitHostPort(a.String())
+	if err != nil {
+		return nil
+	}
+	return net.ParseIP(host)
+}
+
+// conn lazily reads a PROXY header from the wrapped connection on the first Read
+// or RemoteAddr call, then transparently serves the remaining bytes.
+//
+//nolint:govet
+type conn struct {
+	net.Conn
+	r             *bufio.Reader
+	once          sync.Once
+	remoteAddr    net.Addr // overridden client address, nil until parsed/none
+	parseErr      error
+	require       bool
+	headerTimeout time.Duration
+}
+
+func (c *conn) parse() {
+	if c.headerTimeout > 0 {
+		// Bound the header read on the underlying conn, then clear it so the
+		// HTTP server can manage its own per-request deadlines.
+		_ = c.SetReadDeadline(time.Now().Add(c.headerTimeout))
+		defer c.SetReadDeadline(time.Time{})
+	}
+
+	src, err := parseHeader(c.r)
+	switch {
+	case errors.Is(err, errNoHeader):
+		// Not a PROXY header. The bytes are still buffered for passthrough.
+		if c.require {
+			c.parseErr = errNoHeader
+		}
+	case err != nil:
+		// Identified but broken, or an I/O error: the stream is desynced.
+		c.parseErr = err
+	default:
+		// src is nil for LOCAL/UNKNOWN/UNSPEC — keep the real peer.
+		c.remoteAddr = src
+	}
+}
+
+func (c *conn) Read(p []byte) (int, error) {
+	c.once.Do(c.parse)
+	if c.parseErr != nil {
+		return 0, c.parseErr
+	}
+	return c.r.Read(p)
+}
+
+func (c *conn) RemoteAddr() net.Addr {
+	c.once.Do(c.parse)
+	if c.remoteAddr != nil {
+		return c.remoteAddr
+	}
+	return c.Conn.RemoteAddr()
+}

--- a/pkg/proxyprotocol/proxyprotocol_test.go
+++ b/pkg/proxyprotocol/proxyprotocol_test.go
@@ -1,0 +1,321 @@
+package proxyprotocol
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- header builders -------------------------------------------------------
+
+func v1Line(proto, src, dst string, sport, dport int) []byte {
+	return []byte(fmt.Sprintf("PROXY %s %s %s %d %d\r\n", proto, src, dst, sport, dport))
+}
+
+func v2Header(cmd, family byte, block []byte) []byte {
+	var b bytes.Buffer
+	b.Write(v2Signature)
+	b.WriteByte(v2VersionPROXY<<4 | cmd)
+	b.WriteByte(family<<4 | 0x1) // STREAM (TCP)
+	var l [2]byte
+	binary.BigEndian.PutUint16(l[:], uint16(len(block)))
+	b.Write(l[:])
+	b.Write(block)
+	return b.Bytes()
+}
+
+func be16(v uint16) []byte {
+	var b [2]byte
+	binary.BigEndian.PutUint16(b[:], v)
+	return b[:]
+}
+
+func v2Inet(src, dst net.IP, sport, dport uint16, tlv []byte) []byte {
+	block := make([]byte, 0, v2AddrLenInet+len(tlv))
+	block = append(block, src.To4()...)
+	block = append(block, dst.To4()...)
+	block = append(block, be16(sport)...)
+	block = append(block, be16(dport)...)
+	block = append(block, tlv...)
+	return v2Header(v2CmdProxy, v2FamInet, block)
+}
+
+func v2Inet6(src, dst net.IP, sport, dport uint16) []byte {
+	block := make([]byte, 0, v2AddrLenInet6)
+	block = append(block, src.To16()...)
+	block = append(block, dst.To16()...)
+	block = append(block, be16(sport)...)
+	block = append(block, be16(dport)...)
+	return v2Header(v2CmdProxy, v2FamInet6, block)
+}
+
+// --- parseHeader -----------------------------------------------------------
+
+func TestParseHeader(t *testing.T) {
+	t.Parallel()
+
+	const payload = "GET / HTTP/1.1\r\nHost: x\r\n\r\n"
+
+	type want struct {
+		addr      string // "" means nil (no override)
+		err       error  // sentinel to match with ErrorIs; nil = no error
+		remainder string // what should still be readable after the header
+	}
+	cases := []struct {
+		name string
+		in   []byte
+		want want
+	}{
+		{
+			name: "v1 TCP4",
+			in:   v1Line("TCP4", "192.0.2.1", "10.0.0.9", 56324, 443),
+			want: want{addr: "192.0.2.1:56324", remainder: payload},
+		},
+		{
+			name: "v1 TCP6",
+			in:   v1Line("TCP6", "2001:db8::1", "2001:db8::2", 4321, 443),
+			want: want{addr: "[2001:db8::1]:4321", remainder: payload},
+		},
+		{
+			name: "v1 UNKNOWN keeps peer",
+			in:   []byte("PROXY UNKNOWN\r\n"),
+			want: want{addr: "", remainder: payload},
+		},
+		{
+			name: "v1 bad port",
+			in:   []byte("PROXY TCP4 192.0.2.1 10.0.0.9 notaport 443\r\n"),
+			want: want{err: errMalformed},
+		},
+		{
+			name: "v2 INET",
+			in:   v2Inet(net.ParseIP("192.0.2.7"), net.ParseIP("10.0.0.9"), 51000, 443, nil),
+			want: want{addr: "192.0.2.7:51000", remainder: payload},
+		},
+		{
+			name: "v2 INET6",
+			in:   v2Inet6(net.ParseIP("2001:db8::a"), net.ParseIP("2001:db8::b"), 6000, 443),
+			want: want{addr: "[2001:db8::a]:6000", remainder: payload},
+		},
+		{
+			name: "v2 INET with trailing TLV discarded",
+			in:   v2Inet(net.ParseIP("192.0.2.7"), net.ParseIP("10.0.0.9"), 51000, 443, []byte{0x03, 0x00, 0x02, 0xAA, 0xBB}),
+			want: want{addr: "192.0.2.7:51000", remainder: payload},
+		},
+		{
+			name: "v2 LOCAL keeps peer",
+			in:   v2Header(v2CmdLocal, v2FamUnspec, nil),
+			want: want{addr: "", remainder: payload},
+		},
+		{
+			name: "v2 UNSPEC keeps peer",
+			in:   v2Header(v2CmdProxy, v2FamUnspec, []byte{0x01, 0x02}),
+			want: want{addr: "", remainder: payload},
+		},
+		{
+			name: "not a proxy header",
+			in:   []byte(payload),
+			want: want{err: errNoHeader, remainder: payload},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := append(append([]byte(nil), tc.in...), []byte(payload)...)
+			r := bufio.NewReader(bytes.NewReader(in))
+
+			addr, err := parseHeader(r)
+
+			if tc.want.err != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.want.err)
+				if tc.want.err == errNoHeader {
+					// Nothing consumed: the whole stream is still readable.
+					rest, _ := io.ReadAll(r)
+					assert.Equal(t, in, rest)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			if tc.want.addr == "" {
+				assert.Nil(t, addr)
+			} else {
+				require.NotNil(t, addr)
+				assert.Equal(t, tc.want.addr, addr.String())
+			}
+			rest, _ := io.ReadAll(r)
+			assert.Equal(t, tc.want.remainder, string(rest))
+		})
+	}
+}
+
+func TestParseHeader_v2Truncated(t *testing.T) {
+	t.Parallel()
+	// AF_INET declared but the address block is short.
+	hdr := v2Header(v2CmdProxy, v2FamInet, []byte{1, 2, 3})
+	_, err := parseHeader(bufio.NewReader(bytes.NewReader(hdr)))
+	assert.ErrorIs(t, err, errMalformed)
+}
+
+func TestParseHeader_v1TooLong(t *testing.T) {
+	t.Parallel()
+	// A complete line (has CRLF) but longer than the v1 maximum.
+	line := "PROXY TCP4 192.0.2.1 10.0.0.9 1 1" + strings.Repeat(" ", 100) + "\r\n"
+	_, err := parseHeader(bufio.NewReader(bytes.NewReader([]byte(line))))
+	assert.ErrorIs(t, err, errMalformed)
+}
+
+func TestParseHeader_v1NoNewline(t *testing.T) {
+	t.Parallel()
+	// "PROXY " prefix then a flood with no newline must not grow unbounded; it
+	// overruns the bufio buffer and is rejected as malformed.
+	in := append([]byte("PROXY TCP4 "), bytes.Repeat([]byte("9"), 8192)...)
+	_, err := parseHeader(bufio.NewReader(bytes.NewReader(in)))
+	assert.ErrorIs(t, err, errMalformed)
+}
+
+// --- fakeConn --------------------------------------------------------------
+
+type fakeConn struct {
+	r       io.Reader
+	remote  net.Addr
+	written bytes.Buffer
+	closed  bool
+}
+
+func tcpAddr(ip string, port int) *net.TCPAddr {
+	return &net.TCPAddr{IP: net.ParseIP(ip), Port: port}
+}
+
+func (c *fakeConn) Read(p []byte) (int, error)       { return c.r.Read(p) }
+func (c *fakeConn) Write(p []byte) (int, error)      { return c.written.Write(p) }
+func (c *fakeConn) Close() error                     { c.closed = true; return nil }
+func (c *fakeConn) LocalAddr() net.Addr              { return tcpAddr("127.0.0.1", 80) }
+func (c *fakeConn) RemoteAddr() net.Addr             { return c.remote }
+func (c *fakeConn) SetDeadline(time.Time) error      { return nil }
+func (c *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+func newFakeConn(peerIP string, data []byte) *fakeConn {
+	return &fakeConn{r: bytes.NewReader(data), remote: tcpAddr(peerIP, 40000)}
+}
+
+// --- Modifier --------------------------------------------------------------
+
+func TestModifier_TrustedOverridesRemoteAddr(t *testing.T) {
+	t.Parallel()
+	const payload = "ping"
+	in := append(v1Line("TCP4", "192.0.2.55", "10.0.0.9", 12345, 443), payload...)
+	fc := newFakeConn("10.1.2.3", in)
+
+	c := New("10.0.0.0/8").ModifyConnection(fc)
+
+	assert.Equal(t, "192.0.2.55:12345", c.RemoteAddr().String())
+	got, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(got))
+}
+
+func TestModifier_UntrustedPeerPassthrough(t *testing.T) {
+	t.Parallel()
+	in := append(v1Line("TCP4", "192.0.2.55", "10.0.0.9", 12345, 443), "ping"...)
+	fc := newFakeConn("203.0.113.9", in) // not in 10.0.0.0/8
+
+	c := New("10.0.0.0/8").ModifyConnection(fc)
+
+	// Returned untouched: same object, real peer, header NOT consumed.
+	assert.Same(t, fc, c)
+	assert.Equal(t, "203.0.113.9:40000", c.RemoteAddr().String())
+	got, _ := io.ReadAll(c)
+	assert.Equal(t, string(in), string(got))
+}
+
+func TestModifier_TrustAllWithV2(t *testing.T) {
+	t.Parallel()
+	const payload = "data"
+	in := append(v2Inet(net.ParseIP("198.51.100.7"), net.ParseIP("10.0.0.9"), 33333, 443, nil), payload...)
+	fc := newFakeConn("10.9.9.9", in)
+
+	c := New().ModifyConnection(fc) // no CIDRs => trust all
+
+	got, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(got))
+	assert.Equal(t, "198.51.100.7:33333", c.RemoteAddr().String())
+}
+
+func TestModifier_RequireRejectsMissingHeader(t *testing.T) {
+	t.Parallel()
+	fc := newFakeConn("10.1.2.3", []byte("GET / HTTP/1.1\r\n\r\n"))
+
+	m := New("10.0.0.0/8")
+	m.Require = true
+	c := m.ModifyConnection(fc)
+
+	_, err := io.ReadAll(c)
+	assert.ErrorIs(t, err, errNoHeader)
+	// RemoteAddr falls back to the real peer.
+	assert.Equal(t, "10.1.2.3:40000", c.RemoteAddr().String())
+}
+
+func TestModifier_OptionalPassesThroughMissingHeader(t *testing.T) {
+	t.Parallel()
+	const req = "GET / HTTP/1.1\r\n\r\n"
+	fc := newFakeConn("10.1.2.3", []byte(req))
+
+	c := New("10.0.0.0/8").ModifyConnection(fc) // Require defaults to false
+
+	got, err := io.ReadAll(c)
+	require.NoError(t, err)
+	assert.Equal(t, req, string(got))
+	assert.Equal(t, "10.1.2.3:40000", c.RemoteAddr().String())
+}
+
+func TestModifier_UnknownKeepsPeer(t *testing.T) {
+	t.Parallel()
+	const payload = "x"
+	in := append([]byte("PROXY UNKNOWN\r\n"), payload...)
+	fc := newFakeConn("10.1.2.3", in)
+
+	c := New("10.0.0.0/8").ModifyConnection(fc)
+
+	assert.Equal(t, "10.1.2.3:40000", c.RemoteAddr().String())
+	got, _ := io.ReadAll(c)
+	assert.Equal(t, payload, string(got))
+}
+
+func TestNew_InvalidCIDRPanics(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { New("not-a-cidr") })
+}
+
+// Exercises the wrapper over a real net.Conn (net.Pipe) so the SetReadDeadline
+// path and bufio interplay run against a genuine connection.
+func TestModifier_OverRealConn(t *testing.T) {
+	t.Parallel()
+	const payload = "hello-body"
+	client, server := net.Pipe()
+	defer server.Close()
+
+	go func() {
+		defer client.Close()
+		_, _ = client.Write(v1Line("TCP4", "192.0.2.200", "10.0.0.9", 9999, 443))
+		_, _ = client.Write([]byte(payload))
+	}()
+
+	c := New().ModifyConnection(server) // trust all (pipe addr is opaque)
+	assert.Equal(t, "192.0.2.200:9999", c.RemoteAddr().String())
+
+	buf := make([]byte, len(payload))
+	_, err := io.ReadFull(c, buf)
+	require.NoError(t, err)
+	assert.Equal(t, payload, string(buf))
+}


### PR DESCRIPTION
## What

New `pkg/proxyprotocol` recovers the **real client IP** behind an L4 load balancer (AWS NLB, HAProxy in TCP mode, …). Such a balancer terminates the TCP connection and adds no `X-Forwarded-For`, so the proxy otherwise sees only the balancer's address. This package reads the HAProxy **PROXY protocol** header (v1 text and v2 binary) that the balancer prepends and rewrites the connection's `RemoteAddr` to the client — so `ratelimit`, `waf`, `logger`, and the `X-Forwarded-*` trust logic all key off the right address.

```go
// Only the listed CIDRs (your load balancer) may set a client address.
pp := proxyprotocol.New("10.0.0.0/8")

s := parapet.NewFrontend()
s.ModifyConnection(pp.ModifyConnection)
```

## How

- **Mounts at the existing `Server.ModifyConnection` seam.** The modifier only wraps the conn (no I/O), so it never blocks the accept loop; the header is parsed **lazily on the connection's first read/`RemoteAddr`**, in the per-conn goroutine.
- **Trust is on the immediate TCP peer.** Only a connection whose real peer is within the configured load-balancer CIDRs may set a client address. A peer outside them is returned **untouched — the header is not even consumed** — so a direct attacker cannot spoof a client IP. `New(...)` panics on an invalid CIDR, matching parapet's fail-fast trust config.
- **`Require`** (opt-in) rejects a trusted connection that arrives without a PROXY header; by default such a connection is served with its real peer address.
- **Composes with TLS**: the modifier wraps the raw conn, so the PROXY header is read before the TLS handshake, and `tls.Conn.RemoteAddr()` delegates through to the overridden client address.

## Protocol coverage

- **v1** (text): `TCP4`/`TCP6` → client addr; `UNKNOWN` → keep real peer.
- **v2** (binary): `PROXY` cmd with `AF_INET`/`AF_INET6` → client addr; `LOCAL` and `AF_UNSPEC`/`AF_UNIX` → keep real peer; trailing **TLVs are skipped**.
- **Hardened reads**: v1 line is bounded by the bufio buffer (`ReadSlice` → `ErrBufferFull` on a no-newline flood, not unbounded growth); v2 body is bounded by its own length field; a `HeaderTimeout` (default 10s) guards a slow header. Malformed headers from a trusted peer fail the first read so the server drops the connection.

## Tests

`pkg/proxyprotocol/proxyprotocol_test.go` (81.5% coverage) covers v1 TCP4/TCP6/UNKNOWN, v2 INET/INET6/LOCAL/UNSPEC, TLV skipping, truncated/over-long/no-newline malformed cases, non-PROXY passthrough (nothing consumed), trusted override, untrusted passthrough (same conn, bytes intact), `Require` rejection, and a real `net.Pipe` end-to-end. `make` passes clean (vet + lint 0 issues + `-race`).

## Docs

README packages table + a "PROXY protocol" section, CLAUDE.md package table, and runnable examples (`ExampleNew`, `ExampleModifier_require`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)