### PR TITLE
feat(cache): serve stale per RFC 5861 (stale-while-revalidate, stale-if-error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,23 @@ When the origin sets `Cache-Control: stale-while-revalidate=<s>` or `stale-if-er
 
 `must-revalidate`/`proxy-revalidate` suppress both. The client's request `Cache-Control` is ignored (only the origin's response directives are honored), consistent with the rest of the cache. Note that an entry offering these windows is retained in storage until it is past the larger window (not just past freshness), so stale-if-error still has something to fall back to — total size remains bounded by the backend's LRU cap.
 
+**Forcing stale serving for an origin you don't control.** Set `Options.DefaultStaleWhileRevalidate` / `Options.DefaultStaleIfError` to apply a window to any cacheable response that doesn't carry the directive itself. An explicit directive on the response still wins, and `must-revalidate`/`proxy-revalidate` still suppress it. These stay **private to this cache** — the served `Cache-Control` remains the origin's, so the policy doesn't propagate to downstream clients or caches.
+
+```go
+cache.New(store, cache.Options{
+    DefaultStaleWhileRevalidate: 30 * time.Second,
+    DefaultStaleIfError:         24 * time.Hour,
+})
+```
+
+Alternatively, inject the directive with a `headers` middleware mounted **below** the cache (so the cache sees it on the response). The cache parses every `Cache-Control` header, so this adds the windows without clobbering the origin's `max-age` — but unlike the options above, the injected directive **is** served to clients:
+
+```go
+h.Use(cache.New(store, cache.Options{}))                                       // outer
+h.Use(headers.AddResponse("Cache-Control", "stale-while-revalidate=30"))       // below the cache
+h.Use(upstream.SingleHost("origin...", &upstream.HTTPTransport{}))             // inner
+```
+
 ## Trusted proxies
 
 Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes from a trusted CIDR. Configure trust with `TrustCIDRs(...)` or accept the defaults from `Trusted()` (standard private and loopback ranges). Servers created with `NewFrontend()` start with no trusted proxies by default.

--- a/README.md
+++ b/README.md
@@ -281,6 +281,15 @@ s.Use(h)
 
 `Options` also exposes `Cacheable` (a per-request predicate to exclude vetted paths), `InvalidatedAfter` (out-of-band purge), `LockTimeout`, and `DecoupleFill` (keep a slow client from stalling waiting followers). Because only origin-opted-in public content is cached, mark per-user or authorization-sensitive responses uncacheable at the origin.
 
+### Stale serving (RFC 5861)
+
+When the origin sets `Cache-Control: stale-while-revalidate=<s>` or `stale-if-error=<s>` on a cacheable response, the cache may serve the entry **after** it goes stale:
+
+- **`stale-while-revalidate`** — within the window, a stale entry is served immediately (`X-Cache: STALE`) while a single background revalidation refreshes it, so the client never waits on the origin. The detached fetch is bounded by `Options.RevalidateTimeout` (default 30s).
+- **`stale-if-error`** — past any `stale-while-revalidate` window, the cache contacts the origin and, only if it answers with a server error (5xx), serves the stale entry instead of the error (`X-Cache: STALE`).
+
+`must-revalidate`/`proxy-revalidate` suppress both. The client's request `Cache-Control` is ignored (only the origin's response directives are honored), consistent with the rest of the cache. Note that an entry offering these windows is retained in storage until it is past the larger window (not just past freshness), so stale-if-error still has something to fall back to — total size remains bounded by the backend's LRU cap.
+
 ## Trusted proxies
 
 Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes from a trusted CIDR. Configure trust with `TrustCIDRs(...)` or accept the defaults from `Trusted()` (standard private and loopback ranges). Servers created with `NewFrontend()` start with no trusted proxies by default.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -77,6 +77,18 @@ type Options struct {
 	// not apply to a normal (foreground) fill. Defaults to 30s when <= 0.
 	RevalidateTimeout time.Duration
 
+	// DefaultStaleWhileRevalidate and DefaultStaleIfError force RFC 5861 stale
+	// serving for a cacheable response that does not carry the matching directive,
+	// so an origin you don't control still gets stale-while-revalidate /
+	// stale-if-error behavior. An explicit directive on the response wins; a
+	// response marked must-revalidate / proxy-revalidate is never served stale,
+	// regardless of these. Unlike injecting the directive with a headers
+	// middleware, these stay private to this cache: the served Cache-Control is
+	// the origin's, so the policy does not propagate to downstream clients/caches.
+	// Zero (the default) forces nothing. Each is clamped to ~10y.
+	DefaultStaleWhileRevalidate time.Duration
+	DefaultStaleIfError         time.Duration
+
 	// DecoupleFill, when true, stops a slow leader client (or a slow disk) from
 	// holding the fill lock — and thus stalling waiting followers — while its response
 	// streams to that client. It engages only when the fill is CONTENDED, i.e. at
@@ -112,6 +124,8 @@ type Cache struct {
 	maxFileSize       int64
 	lockTimeout       time.Duration
 	revalidateTimeout time.Duration
+	defaultSWR        time.Duration // Options.DefaultStaleWhileRevalidate, clamped
+	defaultSIE        time.Duration // Options.DefaultStaleIfError, clamped
 	decoupleFill      bool
 
 	pvMu sync.RWMutex
@@ -148,6 +162,8 @@ func New(storage Storage, opts Options) *Cache {
 		maxFileSize:       mfs,
 		lockTimeout:       lt,
 		revalidateTimeout: rt,
+		defaultSWR:        clampStaleWindow(opts.DefaultStaleWhileRevalidate),
+		defaultSIE:        clampStaleWindow(opts.DefaultStaleIfError),
 		invalidatedAfter:  opts.InvalidatedAfter,
 		cacheable:         opts.Cacheable,
 		decoupleFill:      opts.DecoupleFill,

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -26,6 +26,10 @@ const defaultLockTimeout = 2 * time.Second
 // defaultMaxFileSize is the per-object cap when Options.MaxFileSize <= 0.
 const defaultMaxFileSize = 8 << 20 // 8 MiB
 
+// defaultRevalidateTimeout bounds a background stale-while-revalidate fetch when
+// Options.RevalidateTimeout <= 0.
+const defaultRevalidateTimeout = 30 * time.Second
+
 // maxPrimaryVary bounds the in-memory primary->Vary map so a long-tail URL space
 // can't grow it without limit (the storage backend bounds bytes, not this map).
 // When the cap is hit the map is reset; a dropped entry just costs one re-learn
@@ -67,6 +71,12 @@ type Options struct {
 	// fast (more origin fetches under load). Defaults to 2s when <= 0.
 	LockTimeout time.Duration
 
+	// RevalidateTimeout bounds a background stale-while-revalidate fetch (RFC
+	// 5861): the detached request to the origin is cancelled after this long so a
+	// hung origin can't pin the single-flight lock or leak a goroutine. It does
+	// not apply to a normal (foreground) fill. Defaults to 30s when <= 0.
+	RevalidateTimeout time.Duration
+
 	// DecoupleFill, when true, stops a slow leader client (or a slow disk) from
 	// holding the fill lock — and thus stalling waiting followers — while its response
 	// streams to that client. It engages only when the fill is CONTENDED, i.e. at
@@ -99,9 +109,10 @@ type Cache struct {
 	cacheable        func(r *http.Request) bool
 	primaryVary      map[string][]string  // primaryHex -> Vary header names learned from a stored response
 	locks            map[string]*fillLock // variantHex -> in-flight fill
-	maxFileSize      int64
-	lockTimeout      time.Duration
-	decoupleFill     bool
+	maxFileSize       int64
+	lockTimeout       time.Duration
+	revalidateTimeout time.Duration
+	decoupleFill      bool
 
 	pvMu sync.RWMutex
 
@@ -128,15 +139,20 @@ func New(storage Storage, opts Options) *Cache {
 	if lt <= 0 {
 		lt = defaultLockTimeout
 	}
+	rt := opts.RevalidateTimeout
+	if rt <= 0 {
+		rt = defaultRevalidateTimeout
+	}
 	return &Cache{
-		storage:          storage,
-		maxFileSize:      mfs,
-		lockTimeout:      lt,
-		invalidatedAfter: opts.InvalidatedAfter,
-		cacheable:        opts.Cacheable,
-		decoupleFill:     opts.DecoupleFill,
-		primaryVary:      map[string][]string{},
-		locks:            map[string]*fillLock{},
+		storage:           storage,
+		maxFileSize:       mfs,
+		lockTimeout:       lt,
+		revalidateTimeout: rt,
+		invalidatedAfter:  opts.InvalidatedAfter,
+		cacheable:         opts.Cacheable,
+		decoupleFill:      opts.DecoupleFill,
+		primaryVary:       map[string][]string{},
+		locks:             map[string]*fillLock{},
 	}
 }
 
@@ -158,34 +174,49 @@ func (c *Cache) serve(w http.ResponseWriter, r *http.Request, next http.Handler)
 		return
 	}
 	primaryHex := c.primaryHash(r)
-	if c.tryServeHit(w, r, c.variantHash(primaryHex, r)) {
-		return
+	key := c.variantHash(primaryHex, r)
+	if m, body, ok := c.storage.Get(key); ok {
+		switch c.classify(m, r, time.Now()) {
+		case stateFresh:
+			writeStored(w, r, m, body, "HIT")
+			return
+		case stateStaleRevalidate:
+			// RFC 5861 stale-while-revalidate: serve the stale entry now and refresh
+			// it in the background (single-flighted), so the client never waits on the
+			// origin.
+			writeStored(w, r, m, body, "STALE")
+			c.revalidate(r, next, primaryHex)
+			return
+		case stateStaleIfError:
+			// RFC 5861 stale-if-error: try the origin, but fall back to this stale
+			// entry if the revalidation returns a server error.
+			c.fillWithStale(w, r, next, primaryHex, m, body)
+			return
+		case stateExpired:
+			c.storage.Delete(key)
+		}
 	}
 	c.fillAndServe(w, r, next, primaryHex)
 }
 
-// tryServeHit serves key from storage if present and fresh, returning true. An
-// expired entry is reaped and reported as a miss (fail-static: a storage error
-// reads as a miss).
+// tryServeHit serves key from storage if present and fresh, returning true. It is
+// the follower re-read after a fill: an expired entry is reaped and reported as a
+// miss, while a stale-but-still-serveable entry (within an RFC 5861 window) is
+// kept (so stale-if-error can still fall back to it) and reported as a miss here.
+// Fail-static: a storage error reads as a miss.
 func (c *Cache) tryServeHit(w http.ResponseWriter, r *http.Request, key string) bool {
 	m, body, ok := c.storage.Get(key)
 	if !ok {
 		return false
 	}
-	if time.Now().After(time.Unix(0, m.FreshUntil)) {
+	switch c.classify(m, r, time.Now()) {
+	case stateFresh:
+		writeStored(w, r, m, body, "HIT")
+		return true
+	case stateExpired:
 		c.storage.Delete(key)
-		return false
 	}
-	// Out-of-band invalidation (cache purge): an entry created at or before the
-	// invalidation epoch is reaped and served as a miss, just like a passed
-	// FreshUntil. Checked after freshness so the common (no-purge) path is one nil
-	// compare.
-	if c.invalidatedAfter != nil && m.Created <= c.invalidatedAfter(r, m) {
-		c.storage.Delete(key)
-		return false
-	}
-	writeStored(w, r, m, body, "HIT")
-	return true
+	return false
 }
 
 // fillAndServe handles a miss with single-flight. The first arrival for a variant

--- a/pkg/cache/disk.go
+++ b/pkg/cache/disk.go
@@ -287,10 +287,13 @@ func (s *DiskStorage) scan(now time.Time) {
 				reapIfStale(mp, now) // meta without body (torn)
 				continue
 			}
-			if now.After(time.Unix(0, m.FreshUntil)) {
-				// Age-gated like the other reap paths so a concurrent in-flight commit
-				// (mtime ~now) is never destroyed; a genuinely expired-on-disk entry is
-				// older than reapMinAge, and any expired entry is reaped on access too.
+			if now.After(m.serveableUntil()) {
+				// Past every serveable window (FreshUntil plus the larger RFC 5861
+				// stale window), matching classify so a stale-but-serveable entry is
+				// not reaped out from under stale-if-error. Age-gated like the other
+				// reap paths so a concurrent in-flight commit (mtime ~now) is never
+				// destroyed; a genuinely expired-on-disk entry is older than reapMinAge,
+				// and any expired entry is reaped on access too.
 				reapIfStale(mp, now)
 				reapIfStale(filepath.Join(shardPath, key+".body"), now)
 				continue

--- a/pkg/cache/policy.go
+++ b/pkg/cache/policy.go
@@ -46,7 +46,12 @@ func cacheableStatus(code int) bool {
 type decision struct {
 	freshUntil time.Time
 	vary       []string // lowercased Vary header names (nil when no Vary)
-	cacheable  bool
+	// staleWhileRevalidate and staleIfError are the RFC 5861 windows past
+	// freshUntil during which a stale entry may be served (while revalidating, or
+	// on a revalidation error). Zero when not offered.
+	staleWhileRevalidate time.Duration
+	staleIfError         time.Duration
+	cacheable            bool
 }
 
 // decide applies the honor-origin policy to an origin response. method is the
@@ -100,7 +105,26 @@ func decide(method string, status int, h http.Header, reqAuthorized bool, maxFil
 			return no
 		}
 	}
-	return decision{cacheable: true, freshUntil: now.Add(ttl), vary: vary}
+	swr, sie := staleWindows(cc)
+	return decision{cacheable: true, freshUntil: now.Add(ttl), vary: vary, staleWhileRevalidate: swr, staleIfError: sie}
+}
+
+// staleWindows derives the RFC 5861 stale-serving windows from the response
+// Cache-Control. must-revalidate / proxy-revalidate forbid serving stale at all
+// (RFC 9111 §4.2.4), so they suppress both windows. Each is clamped to maxTTL so
+// FreshUntil+window stays within time.UnixNano's range.
+func staleWindows(cc cacheControl) (swr, sie time.Duration) {
+	if cc.mustRevalidate || cc.proxyRevalidate {
+		return 0, 0
+	}
+	clamp := func(seconds int64) time.Duration {
+		d := time.Duration(seconds) * time.Second
+		if d > maxTTL {
+			d = maxTTL
+		}
+		return d
+	}
+	return clamp(cc.staleWhileRevalidate), clamp(cc.staleIfError)
 }
 
 // parseVary returns the lowercased, de-duplicated Vary header names and whether
@@ -127,15 +151,18 @@ func parseVary(h http.Header) (names []string, star bool) {
 }
 
 type cacheControl struct {
-	maxAge         int64
-	sMaxAge        int64
-	private        bool
-	noStore        bool
-	noCache        bool
-	public         bool
-	mustRevalidate bool
-	hasMax         bool
-	hasSMax        bool
+	maxAge               int64
+	sMaxAge              int64
+	staleWhileRevalidate int64
+	staleIfError         int64
+	private              bool
+	noStore              bool
+	noCache              bool
+	public               bool
+	mustRevalidate       bool
+	proxyRevalidate      bool
+	hasMax               bool
+	hasSMax              bool
 }
 
 // parseCacheControl parses the response Cache-Control directives the policy
@@ -162,6 +189,8 @@ func parseCacheControl(h http.Header) cacheControl {
 				cc.public = true
 			case "must-revalidate":
 				cc.mustRevalidate = true
+			case "proxy-revalidate":
+				cc.proxyRevalidate = true
 			case "max-age":
 				if n, err := strconv.ParseInt(val, 10, 64); err == nil {
 					cc.maxAge = n
@@ -171,6 +200,14 @@ func parseCacheControl(h http.Header) cacheControl {
 				if n, err := strconv.ParseInt(val, 10, 64); err == nil {
 					cc.sMaxAge = n
 					cc.hasSMax = true
+				}
+			case "stale-while-revalidate":
+				if n, err := strconv.ParseInt(val, 10, 64); err == nil && n >= 0 {
+					cc.staleWhileRevalidate = n
+				}
+			case "stale-if-error":
+				if n, err := strconv.ParseInt(val, 10, 64); err == nil && n >= 0 {
+					cc.staleIfError = n
 				}
 			}
 		}

--- a/pkg/cache/policy.go
+++ b/pkg/cache/policy.go
@@ -52,6 +52,9 @@ type decision struct {
 	staleWhileRevalidate time.Duration
 	staleIfError         time.Duration
 	cacheable            bool
+	// noStale reports that the response forbids serving stale (must-revalidate /
+	// proxy-revalidate), so operator-configured default windows must not apply.
+	noStale bool
 }
 
 // decide applies the honor-origin policy to an origin response. method is the
@@ -105,8 +108,9 @@ func decide(method string, status int, h http.Header, reqAuthorized bool, maxFil
 			return no
 		}
 	}
+	noStale := cc.mustRevalidate || cc.proxyRevalidate
 	swr, sie := staleWindows(cc)
-	return decision{cacheable: true, freshUntil: now.Add(ttl), vary: vary, staleWhileRevalidate: swr, staleIfError: sie}
+	return decision{cacheable: true, freshUntil: now.Add(ttl), vary: vary, staleWhileRevalidate: swr, staleIfError: sie, noStale: noStale}
 }
 
 // staleWindows derives the RFC 5861 stale-serving windows from the response
@@ -117,14 +121,20 @@ func staleWindows(cc cacheControl) (swr, sie time.Duration) {
 	if cc.mustRevalidate || cc.proxyRevalidate {
 		return 0, 0
 	}
-	clamp := func(seconds int64) time.Duration {
-		d := time.Duration(seconds) * time.Second
-		if d > maxTTL {
-			d = maxTTL
-		}
-		return d
+	return clampStaleWindow(time.Duration(cc.staleWhileRevalidate) * time.Second),
+		clampStaleWindow(time.Duration(cc.staleIfError) * time.Second)
+}
+
+// clampStaleWindow bounds a stale window to [0, maxTTL] so FreshUntil+window
+// stays within time.UnixNano's range; a negative duration is dropped to zero.
+func clampStaleWindow(d time.Duration) time.Duration {
+	if d < 0 {
+		return 0
 	}
-	return clamp(cc.staleWhileRevalidate), clamp(cc.staleIfError)
+	if d > maxTTL {
+		return maxTTL
+	}
+	return d
 }
 
 // parseVary returns the lowercased, de-duplicated Vary header names and whether

--- a/pkg/cache/stale.go
+++ b/pkg/cache/stale.go
@@ -1,0 +1,182 @@
+package cache
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// freshState classifies a stored entry at serve time.
+type freshState int
+
+const (
+	stateExpired         freshState = iota // past every window (or invalidated): not serveable
+	stateFresh                             // within FreshUntil: serve as a normal HIT
+	stateStaleRevalidate                   // stale, within stale-while-revalidate: serve stale + refresh
+	stateStaleIfError                      // stale, within stale-if-error only: serve stale on a failed revalidation
+)
+
+// classify decides how a stored entry may be served now: fresh until FreshUntil,
+// then — if the origin offered RFC 5861 windows — serveable stale within
+// stale-while-revalidate, then serveable on error within stale-if-error, then
+// fully expired. Out-of-band invalidation (InvalidatedAfter) overrides any
+// serveable state and forces stateExpired, so a purged entry is never served —
+// fresh or stale. The hook is consulted only for an entry that would otherwise be
+// served, so a time-expired entry is reaped without paying for it.
+func (c *Cache) classify(m Meta, r *http.Request, now time.Time) freshState {
+	fresh := time.Unix(0, m.FreshUntil)
+	var state freshState
+	switch {
+	case !now.After(fresh):
+		state = stateFresh
+	case m.StaleWhileRevalidate > 0 && now.Before(fresh.Add(time.Duration(m.StaleWhileRevalidate))):
+		state = stateStaleRevalidate
+	case m.StaleIfError > 0 && now.Before(fresh.Add(time.Duration(m.StaleIfError))):
+		state = stateStaleIfError
+	default:
+		return stateExpired
+	}
+	if c.invalidatedAfter != nil && m.Created <= c.invalidatedAfter(r, m) {
+		return stateExpired
+	}
+	return state
+}
+
+// serveableUntil is the last instant an entry may be served: FreshUntil plus the
+// larger of its RFC 5861 windows. Past it the entry is fully expired and reapable.
+// classify and the disk startup scan share this bound so a stale-but-serveable
+// entry is never reaped out from under stale-if-error.
+func (m Meta) serveableUntil() time.Time {
+	window := m.StaleWhileRevalidate
+	if m.StaleIfError > window {
+		window = m.StaleIfError
+	}
+	return time.Unix(0, m.FreshUntil).Add(time.Duration(window))
+}
+
+// revalidate refreshes a variant in the background (stale-while-revalidate). It
+// is single-flighted through the same fill lock as a foreground fill: if a fill
+// or another revalidation is already in flight for this variant, it does
+// nothing. The fetch runs on a detached, time-bounded context so it is not
+// cancelled when the triggering client's response completes, and a hung origin
+// can't pin the lock or leak the goroutine. The response is streamed only to
+// storage (a discard client writer), reusing the normal store path.
+func (c *Cache) revalidate(r *http.Request, next http.Handler, primaryHex string) {
+	variantHex := c.variantHash(primaryHex, r)
+	lock, leader := c.acquire(variantHex)
+	if !leader {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), c.revalidateTimeout)
+	rr := r.Clone(ctx)
+	rr.Body = http.NoBody // GET/HEAD carry no body; never touch the original
+
+	go func() {
+		defer cancel()
+		defer c.release(variantHex, lock)
+
+		// lock is left nil on the teeWriter so DecoupleFill never engages: there is
+		// no real client to isolate, only the discard writer.
+		tw := &teeWriter{rw: &discardResponseWriter{}, r: rr, c: c, method: rr.Method, primaryHex: primaryHex}
+		defer tw.cleanup()
+		next.ServeHTTP(tw, rr)
+		tw.finish()
+	}()
+}
+
+// fillWithStale serves a miss for a stale-if-error-eligible entry: it runs the
+// normal fill (so single-flight, Vary learning, and caching all apply) but routes
+// the client write through a staleGate. If the origin's revalidation produces a
+// server error (status >= 500), the gate suppresses it and the stale entry is
+// served instead.
+func (c *Cache) fillWithStale(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex string, m Meta, body []byte) {
+	// gate.m points at this stack-local m; finalize runs synchronously below
+	// (before this frame returns), so the pointer never escapes. fillAndServe and
+	// the teeWriter it builds keep the gate stack-local and do not retain it.
+	gate := &staleGate{rw: w, r: r, m: &m, body: body}
+	c.fillAndServe(gate, r, next, primaryHex)
+	gate.finalize()
+}
+
+// staleGate wraps the client ResponseWriter during a stale-if-error fill. It
+// passes a normal (status < 500) response straight through; on the first
+// server-error status it suppresses the origin's output and remembers to serve
+// the stale entry from finalize instead. Only the response headers are gated, so
+// a successful revalidation streams with no added latency.
+type staleGate struct {
+	rw       http.ResponseWriter
+	r        *http.Request
+	m        *Meta
+	body     []byte
+	decided  bool
+	fellBack bool
+}
+
+func (g *staleGate) Header() http.Header { return g.rw.Header() }
+
+func (g *staleGate) WriteHeader(code int) {
+	if g.decided {
+		return
+	}
+	g.decided = true
+	if code >= 500 {
+		g.fellBack = true
+		return
+	}
+	g.rw.WriteHeader(code)
+}
+
+func (g *staleGate) Write(p []byte) (int, error) {
+	if !g.decided {
+		g.WriteHeader(http.StatusOK)
+	}
+	if g.fellBack {
+		return len(p), nil // swallow the origin's error body
+	}
+	return g.rw.Write(p)
+}
+
+// finalize serves the stale entry when the origin errored. Nothing has been
+// written to the client yet (the error status/body were suppressed), so the
+// origin's headers are cleared before writing the stored response.
+func (g *staleGate) finalize() {
+	if !g.fellBack {
+		return
+	}
+	h := g.rw.Header()
+	for k := range h {
+		delete(h, k)
+	}
+	writeStored(g.rw, g.r, *g.m, g.body, "STALE")
+}
+
+func (g *staleGate) Flush() {
+	if g.fellBack {
+		return
+	}
+	if f, ok := g.rw.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Unwrap exposes the underlying writer to http.ResponseController.
+func (g *staleGate) Unwrap() http.ResponseWriter { return g.rw }
+
+// discardResponseWriter is the client side of a background revalidation: the
+// response body is streamed to storage by the teeWriter, never to a client, so
+// every write here is dropped. Its Header map is stable across calls (lazily
+// created) so the origin's response headers reach the teeWriter's cacheability
+// decision.
+type discardResponseWriter struct{ h http.Header }
+
+func (d *discardResponseWriter) Header() http.Header {
+	if d.h == nil {
+		d.h = http.Header{}
+	}
+	return d.h
+}
+
+func (d *discardResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func (*discardResponseWriter) WriteHeader(int) {}

--- a/pkg/cache/stale.go
+++ b/pkg/cache/stale.go
@@ -68,12 +68,22 @@ func (c *Cache) revalidate(r *http.Request, next http.Handler, primaryHex string
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(r.Context()), c.revalidateTimeout)
+	// Detach from the request entirely: a fresh context, NOT WithoutCancel of
+	// r.Context(). The background fetch outlives the client request and runs
+	// concurrently with its teardown, so it must not share request-scoped mutable
+	// state — e.g. the logger's per-request record, which the original request is
+	// finalizing as this goroutine writes to it. It also must not pollute that
+	// request's log/trace with the revalidation's own fields.
+	ctx, cancel := context.WithTimeout(context.Background(), c.revalidateTimeout)
 	rr := r.Clone(ctx)
 	rr.Body = http.NoBody // GET/HEAD carry no body; never touch the original
 
 	go func() {
 		defer cancel()
+		// This goroutine runs outside the http.Server's per-request recover, so a
+		// panic in next would crash the process. Contain it: a failed refresh just
+		// leaves the stale entry for the next request to retry.
+		defer func() { _ = recover() }()
 		defer c.release(variantHex, lock)
 
 		// lock is left nil on the teeWriter so DecoupleFill never engages: there is

--- a/pkg/cache/stale_test.go
+++ b/pkg/cache/stale_test.go
@@ -334,6 +334,86 @@ func TestCache_InvalidatedAfter_NotCalledOnExpired(t *testing.T) {
 	assert.Equal(t, int32(0), atomic.LoadInt32(&hookCalls), "hook must not run on a time-expired entry")
 }
 
+// storedMeta returns the Meta the cache stored for (method, target).
+func storedMeta(t *testing.T, c *Cache, method, target string) (Meta, bool) {
+	t.Helper()
+	req := httptest.NewRequest(method, target, nil)
+	m, _, ok := c.storage.Get(c.variantHash(c.primaryHash(req), req))
+	return m, ok
+}
+
+func TestCache_DefaultStaleWindows(t *testing.T) {
+	t.Run("applied when origin omits them, and not leaked to the client", func(t *testing.T) {
+		c := New(NewMemory(1<<20), Options{
+			MaxFileSize:                 1024,
+			DefaultStaleWhileRevalidate: 300 * time.Second,
+			DefaultStaleIfError:         600 * time.Second,
+		})
+		o := origin(originSpec{body: []byte("hi"), header: http.Header{"Cache-Control": {"max-age=60"}}}, new(int32))
+
+		rec := do(c, o, "GET", "/x", nil)
+		require.Equal(t, "MISS", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "max-age=60", rec.Header().Get("Cache-Control"), "forced windows must not appear in the served header")
+
+		m, ok := storedMeta(t, c, "GET", "/x")
+		require.True(t, ok)
+		assert.Equal(t, int64(300*time.Second), m.StaleWhileRevalidate)
+		assert.Equal(t, int64(600*time.Second), m.StaleIfError)
+
+		rec = do(c, o, "GET", "/x", nil)
+		require.Equal(t, "HIT", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "max-age=60", rec.Header().Get("Cache-Control"))
+	})
+
+	t.Run("explicit origin directive wins", func(t *testing.T) {
+		c := New(NewMemory(1<<20), Options{MaxFileSize: 1024, DefaultStaleWhileRevalidate: 300 * time.Second})
+		o := origin(originSpec{body: []byte("hi"), header: http.Header{"Cache-Control": {"max-age=60, stale-while-revalidate=10"}}}, new(int32))
+
+		do(c, o, "GET", "/x", nil)
+		m, ok := storedMeta(t, c, "GET", "/x")
+		require.True(t, ok)
+		assert.Equal(t, int64(10*time.Second), m.StaleWhileRevalidate, "origin's window wins over the default")
+	})
+
+	t.Run("must-revalidate suppresses the default", func(t *testing.T) {
+		c := New(NewMemory(1<<20), Options{
+			MaxFileSize:                 1024,
+			DefaultStaleWhileRevalidate: 300 * time.Second,
+			DefaultStaleIfError:         600 * time.Second,
+		})
+		o := origin(originSpec{body: []byte("hi"), header: http.Header{"Cache-Control": {"max-age=60, must-revalidate"}}}, new(int32))
+
+		do(c, o, "GET", "/x", nil)
+		m, ok := storedMeta(t, c, "GET", "/x")
+		require.True(t, ok)
+		assert.Zero(t, m.StaleWhileRevalidate)
+		assert.Zero(t, m.StaleIfError)
+	})
+}
+
+// End-to-end: a default stale-if-error window (origin sends none) drives the
+// serve-stale-on-error behavior.
+func TestCache_DefaultStaleIfError_ServesStaleOnError(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024, DefaultStaleIfError: 300 * time.Second})
+
+	fill := origin(originSpec{body: []byte("old"), header: http.Header{"Cache-Control": {"max-age=60"}}}, new(int32))
+	do(c, fill, "GET", "/x", nil) // MISS, stored with the default SIE window
+
+	// Age the stored entry into staleness (keep its windows) without waiting.
+	req := httptest.NewRequest("GET", "/x", nil)
+	key := c.variantHash(c.primaryHash(req), req)
+	m, body, ok := c.storage.Get(key)
+	require.True(t, ok)
+	require.Equal(t, int64(300*time.Second), m.StaleIfError)
+	m.FreshUntil = time.Now().Add(-5 * time.Second).UnixNano()
+	storePut(t, c.storage, key, m, body)
+
+	bad := origin(originSpec{status: http.StatusInternalServerError, body: []byte("boom")}, new(int32))
+	rec := do(c, bad, "GET", "/x", nil)
+	assert.Equal(t, "STALE", rec.Header().Get("X-Cache"))
+	assert.Equal(t, "old", rec.Body.String())
+}
+
 func TestPolicy_StaleWindows(t *testing.T) {
 	now := time.Now()
 	h := func(cc string) http.Header {

--- a/pkg/cache/stale_test.go
+++ b/pkg/cache/stale_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"io/fs"
 	"net/http"
 	"net/http/httptest"
@@ -74,6 +75,72 @@ func TestCache_StaleWhileRevalidate(t *testing.T) {
 		assert.Equal(t, "new", rec.Body.String())
 		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "revalidation must be single-flighted")
 	})
+}
+
+// The background revalidation must run on a context detached from the original
+// request, so it does not share (and race) request-scoped mutable state such as
+// the logger's per-request record.
+func TestCache_StaleWhileRevalidate_DetachedContext(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024})
+	seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 300*time.Second, 0), []byte("old"))
+
+	type ctxKey struct{}
+	var sawValue atomic.Bool
+	var calls int32
+	o := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Context().Value(ctxKey{}) != nil {
+			sawValue.Store(true)
+		}
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Cache-Control", "max-age=300")
+		w.Header().Set("Content-Length", "3")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("new"))
+	})
+
+	mw := c.ServeHandler(o)
+	req := httptest.NewRequest("GET", "/x", nil).
+		WithContext(context.WithValue(context.Background(), ctxKey{}, "sentinel"))
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	require.Equal(t, "STALE", rec.Header().Get("X-Cache"))
+
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) == 1 },
+		2*time.Second, 5*time.Millisecond)
+	assert.False(t, sawValue.Load(), "background revalidation must not inherit the request context values")
+}
+
+// A panic in the origin during background revalidation must be contained (the
+// http.Server's per-request recover does not cover this detached goroutine), and
+// the fill lock must still be released so the cache keeps working.
+func TestCache_StaleWhileRevalidate_PanicContained(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024})
+	seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 300*time.Second, 0), []byte("old"))
+
+	revaled := make(chan struct{})
+	var once sync.Once
+	bad := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		once.Do(func() { close(revaled) })
+		panic("boom during revalidation")
+	})
+
+	rec := do(c, bad, "GET", "/x", nil)
+	assert.Equal(t, "STALE", rec.Header().Get("X-Cache"), "client is unaffected by the revalidation panic")
+
+	select {
+	case <-revaled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background revalidation never ran")
+	}
+	time.Sleep(50 * time.Millisecond) // let the deferred recover/release finish
+
+	// If the panic were uncontained, the test binary would already have crashed.
+	// Prove the cache still works (the lock was released) via a healthy fill.
+	var calls int32
+	good := origin(originSpec{body: []byte("ok"), header: http.Header{"Cache-Control": {"max-age=300"}}}, &calls)
+	rec = do(c, good, "GET", "/y", nil)
+	assert.Equal(t, "MISS", rec.Header().Get("X-Cache"))
+	assert.Equal(t, "ok", rec.Body.String())
 }
 
 func TestCache_StaleWhileRevalidate_SingleFlight(t *testing.T) {

--- a/pkg/cache/stale_test.go
+++ b/pkg/cache/stale_test.go
@@ -1,0 +1,303 @@
+package cache
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedStale writes an entry directly under the key the cache derives for
+// (method, target), so a test can place an already-stale entry without waiting
+// for real time to pass. body is the stored body; the Meta times/windows are the
+// caller's to set.
+func seedStale(t *testing.T, c *Cache, method, target string, m Meta, body []byte) {
+	t.Helper()
+	req := httptest.NewRequest(method, target, nil)
+	key := c.variantHash(c.primaryHash(req), req)
+	if m.Header == nil {
+		m.Header = http.Header{"Content-Type": {"text/plain"}}
+	}
+	m.Size = int64(len(body))
+	storePut(t, c.storage, key, m, body)
+}
+
+// staleMeta builds Meta for an entry that went stale staleAgo in the past, with
+// the given RFC 5861 windows (seconds past FreshUntil).
+func staleMeta(staleAgo time.Duration, swr, sie time.Duration) Meta {
+	now := time.Now()
+	return Meta{
+		Status:               http.StatusOK,
+		Created:              now.Add(-staleAgo - time.Second).UnixNano(),
+		FreshUntil:           now.Add(-staleAgo).UnixNano(),
+		StaleWhileRevalidate: int64(swr),
+		StaleIfError:         int64(sie),
+	}
+}
+
+func TestCache_StaleWhileRevalidate(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 300*time.Second, 0), []byte("old"))
+
+		var calls int32
+		o := origin(originSpec{
+			body:   []byte("new"),
+			header: http.Header{"Cache-Control": {"max-age=300"}},
+		}, &calls)
+
+		// First request is served the stale body immediately and kicks off a
+		// background revalidation.
+		rec := do(c, o, "GET", "/x", nil)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "STALE", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "old", rec.Body.String())
+
+		// The background revalidation fetches the origin exactly once.
+		require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) == 1 },
+			2*time.Second, 5*time.Millisecond)
+
+		// The cache now holds the fresh entry: a later request HITs it.
+		require.Eventually(t, func() bool {
+			return do(c, o, "GET", "/x", nil).Header().Get("X-Cache") == "HIT"
+		}, 2*time.Second, 5*time.Millisecond)
+
+		rec = do(c, o, "GET", "/x", nil)
+		assert.Equal(t, "HIT", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "new", rec.Body.String())
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "revalidation must be single-flighted")
+	})
+}
+
+func TestCache_StaleWhileRevalidate_SingleFlight(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024})
+	seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 300*time.Second, 0), []byte("old"))
+
+	var calls int32
+	o := origin(originSpec{
+		body:   []byte("new"),
+		header: http.Header{"Cache-Control": {"max-age=300"}},
+		sleep:  30 * time.Millisecond, // hold the revalidation so all requests race it
+	}, &calls)
+
+	const n = 12
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			do(c, o, "GET", "/x", nil) // each served STALE (or HIT once refreshed)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) == 1 },
+		2*time.Second, 5*time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "concurrent stale hits collapse to one revalidation")
+}
+
+func TestCache_StaleWhileRevalidate_PastWindowIsMiss(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		// Stale 10s ago, SWR window only 5s, no SIE -> fully expired.
+		seedStale(t, c, "GET", "/x", staleMeta(10*time.Second, 5*time.Second, 0), []byte("old"))
+
+		var calls int32
+		o := origin(originSpec{
+			body:   []byte("new"),
+			header: http.Header{"Cache-Control": {"max-age=300"}},
+		}, &calls)
+
+		rec := do(c, o, "GET", "/x", nil)
+		assert.Equal(t, "MISS", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "new", rec.Body.String())
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "expired entry is a synchronous miss")
+	})
+}
+
+func TestCache_StaleIfError_ServesStaleOnError(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		// Stale, past any SWR, but within stale-if-error.
+		seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 0, 300*time.Second), []byte("old"))
+
+		var calls int32
+		o := origin(originSpec{status: http.StatusInternalServerError, body: []byte("boom")}, &calls)
+
+		rec := do(c, o, "GET", "/x", nil)
+		assert.Equal(t, http.StatusOK, rec.Code, "origin 5xx is replaced by the stale entry")
+		assert.Equal(t, "STALE", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "old", rec.Body.String())
+		assert.NotContains(t, rec.Body.String(), "boom")
+		assert.Equal(t, "text/plain", rec.Header().Get("Content-Type"), "stale entry's stored headers are served")
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+		// The stale entry survives the failed revalidation: a second error still
+		// serves it (it was not deleted).
+		rec = do(c, o, "GET", "/x", nil)
+		assert.Equal(t, "STALE", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "old", rec.Body.String())
+	})
+}
+
+func TestCache_StaleIfError_ServesFreshOnSuccess(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 0, 300*time.Second), []byte("old"))
+
+		var calls int32
+		o := origin(originSpec{
+			body:   []byte("new"),
+			header: http.Header{"Cache-Control": {"max-age=300"}},
+		}, &calls)
+
+		// A healthy origin: the revalidated response is served and cached.
+		rec := do(c, o, "GET", "/x", nil)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "MISS", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "new", rec.Body.String())
+
+		rec = do(c, o, "GET", "/x", nil)
+		assert.Equal(t, "HIT", rec.Header().Get("X-Cache"))
+		assert.Equal(t, "new", rec.Body.String())
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	})
+}
+
+// backdateFiles sets every file under dir to an mtime old enough that the disk
+// startup scan's age gate (reapMinAge) would permit reaping it.
+func backdateFiles(t *testing.T, dir string, age time.Duration) {
+	t.Helper()
+	old := time.Now().Add(-age)
+	require.NoError(t, filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return os.Chtimes(path, old, old)
+		}
+		return nil
+	}))
+}
+
+// A stale-but-within-SIE entry must survive the disk startup rescan, otherwise
+// stale-if-error silently loses its fallback after a restart. The scan is run
+// synchronously here (NewDisk's is a background goroutine) so the reap decision is
+// deterministic.
+func TestCache_StaleIfError_SurvivesDiskRescan(t *testing.T) {
+	dir := t.TempDir()
+
+	d1, err := NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	c1 := New(d1, Options{MaxFileSize: 1024})
+	req := httptest.NewRequest("GET", "/x", nil)
+	key := c1.variantHash(c1.primaryHash(req), req)
+	// Stale 5s ago, SIE window 300s -> serveable for ~5 more minutes.
+	seedStale(t, c1, "GET", "/x", staleMeta(5*time.Second, 0, 300*time.Second), []byte("old"))
+
+	// Age the files past the reap age-gate so the scan would be free to delete a
+	// genuinely-expired entry, then rescan.
+	backdateFiles(t, dir, 2*time.Minute)
+	d2, err := NewDisk(dir, 1<<20)
+	require.NoError(t, err)
+	d2.scan(time.Now())
+
+	_, _, ok := d2.Get(key)
+	assert.True(t, ok, "a stale-but-within-SIE entry must survive the disk rescan")
+}
+
+func TestCache_StaleIfError_PastWindowPropagatesError(t *testing.T) {
+	eachBackend(t, func(t *testing.T, c *Cache) {
+		// Stale 10s ago, SIE only 5s -> expired; the origin error reaches the client.
+		seedStale(t, c, "GET", "/x", staleMeta(10*time.Second, 0, 5*time.Second), []byte("old"))
+
+		var calls int32
+		o := origin(originSpec{status: http.StatusBadGateway, body: []byte("boom")}, &calls)
+
+		rec := do(c, o, "GET", "/x", nil)
+		assert.Equal(t, http.StatusBadGateway, rec.Code)
+		assert.Equal(t, "boom", rec.Body.String())
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	})
+}
+
+func TestCache_StaleServing_InvalidatedOverrides(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{
+		MaxFileSize:      1024,
+		InvalidatedAfter: func(_ *http.Request, _ Meta) int64 { return time.Now().UnixNano() },
+	})
+	seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 300*time.Second, 300*time.Second), []byte("old"))
+
+	var calls int32
+	o := origin(originSpec{
+		body:   []byte("new"),
+		header: http.Header{"Cache-Control": {"max-age=300"}},
+	}, &calls)
+
+	// Invalidation forces a synchronous miss; the stale entry is never served.
+	rec := do(c, o, "GET", "/x", nil)
+	assert.Equal(t, "MISS", rec.Header().Get("X-Cache"))
+	assert.Equal(t, "new", rec.Body.String())
+}
+
+// The InvalidatedAfter hook is consulted only for an entry that would be served
+// (fresh or stale-serveable), not for a time-expired one being reaped.
+func TestCache_InvalidatedAfter_NotCalledOnExpired(t *testing.T) {
+	var hookCalls int32
+	c := New(NewMemory(1<<20), Options{
+		MaxFileSize: 1024,
+		InvalidatedAfter: func(_ *http.Request, _ Meta) int64 {
+			atomic.AddInt32(&hookCalls, 1)
+			return 0
+		},
+	})
+	seedStale(t, c, "GET", "/x", staleMeta(10*time.Second, 0, 0), []byte("old")) // fully expired
+
+	o := origin(originSpec{body: []byte("new"), header: http.Header{"Cache-Control": {"max-age=300"}}}, new(int32))
+	rec := do(c, o, "GET", "/x", nil)
+	assert.Equal(t, "MISS", rec.Header().Get("X-Cache"))
+	assert.Equal(t, int32(0), atomic.LoadInt32(&hookCalls), "hook must not run on a time-expired entry")
+}
+
+func TestPolicy_StaleWindows(t *testing.T) {
+	now := time.Now()
+	h := func(cc string) http.Header {
+		return http.Header{"Cache-Control": {cc}, "Content-Length": {"3"}}
+	}
+
+	t.Run("parsed", func(t *testing.T) {
+		d := decide("GET", 200, h("max-age=60, stale-while-revalidate=120, stale-if-error=3600"), false, 1<<20, now)
+		require.True(t, d.cacheable)
+		assert.Equal(t, 120*time.Second, d.staleWhileRevalidate)
+		assert.Equal(t, 3600*time.Second, d.staleIfError)
+	})
+
+	t.Run("must-revalidate suppresses both", func(t *testing.T) {
+		d := decide("GET", 200, h("max-age=60, must-revalidate, stale-while-revalidate=120, stale-if-error=3600"), false, 1<<20, now)
+		require.True(t, d.cacheable)
+		assert.Zero(t, d.staleWhileRevalidate)
+		assert.Zero(t, d.staleIfError)
+	})
+
+	t.Run("proxy-revalidate suppresses both", func(t *testing.T) {
+		d := decide("GET", 200, h("s-maxage=60, proxy-revalidate, stale-while-revalidate=120"), false, 1<<20, now)
+		require.True(t, d.cacheable)
+		assert.Zero(t, d.staleWhileRevalidate)
+		assert.Zero(t, d.staleIfError)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		d := decide("GET", 200, h("max-age=60"), false, 1<<20, now)
+		require.True(t, d.cacheable)
+		assert.Zero(t, d.staleWhileRevalidate)
+		assert.Zero(t, d.staleIfError)
+	})
+}

--- a/pkg/cache/storage.go
+++ b/pkg/cache/storage.go
@@ -99,6 +99,12 @@ type Meta struct {
 	Tags       []string    `json:"tags,omitempty"` // surrogate keys from the response Cache-Tag header; for out-of-band tag-scoped Range maintenance
 	Created    int64       `json:"created"`        // unix nanos
 	FreshUntil int64       `json:"fresh"`          // unix nanos; entry is stale after this
-	Size       int64       `json:"size"`           // body bytes (== eviction weight)
-	Status     int         `json:"status"`
+	// StaleWhileRevalidate and StaleIfError are RFC 5861 windows in nanoseconds
+	// PAST FreshUntil: within StaleWhileRevalidate a stale entry may be served
+	// while it is revalidated in the background; within StaleIfError a stale entry
+	// may be served when revalidation fails. 0 means the window is not offered.
+	StaleWhileRevalidate int64 `json:"swr,omitempty"`
+	StaleIfError         int64 `json:"sie,omitempty"`
+	Size                 int64 `json:"size"` // body bytes (== eviction weight)
+	Status               int   `json:"status"`
 }

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -79,6 +79,17 @@ func (tw *teeWriter) WriteHeader(code int) {
 			tw.freshUntil = dec.freshUntil
 			tw.swr = dec.staleWhileRevalidate
 			tw.sie = dec.staleIfError
+			// Apply operator-configured default windows where the origin gave none
+			// (unless the response forbids stale serving). These live only in Meta,
+			// so the served Cache-Control stays the origin's.
+			if !dec.noStale {
+				if tw.swr == 0 {
+					tw.swr = tw.c.defaultSWR
+				}
+				if tw.sie == 0 {
+					tw.sie = tw.c.defaultSIE
+				}
+			}
 			tw.metaHeader = sanitizeHeader(h)
 			if cl, ok := contentLength(h); ok {
 				tw.hasCL = true

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -39,9 +39,11 @@ type teeWriter struct {
 	method     string
 	storeKey   string
 	primaryHex string
-	vary       []string     // sorted, lowercased
-	tags       []string     // surrogate keys parsed from the response Cache-Tag header
-	leaderBuf  bytes.Buffer // DecoupleFill: the leader's own copy of the body, served after the lock is released
+	vary       []string      // sorted, lowercased
+	tags       []string      // surrogate keys parsed from the response Cache-Tag header
+	leaderBuf  bytes.Buffer  // DecoupleFill: the leader's own copy of the body, served after the lock is released
+	swr        time.Duration // RFC 5861 stale-while-revalidate window
+	sie        time.Duration // RFC 5861 stale-if-error window
 	written    int64
 	contentLen int64
 	status     int
@@ -75,6 +77,8 @@ func (tw *teeWriter) WriteHeader(code int) {
 			tw.vary = vary
 			tw.tags = parseCacheTags(h)
 			tw.freshUntil = dec.freshUntil
+			tw.swr = dec.staleWhileRevalidate
+			tw.sie = dec.staleIfError
 			tw.metaHeader = sanitizeHeader(h)
 			if cl, ok := contentLength(h); ok {
 				tw.hasCL = true
@@ -166,16 +170,18 @@ func (tw *teeWriter) finish() {
 		return
 	}
 	meta := Meta{
-		Status:     tw.status,
-		Header:     tw.metaHeader,
-		PrimaryHex: tw.primaryHex,
-		Host:       normalizeHost(tw.r.Host),
-		URI:        tw.r.URL.RequestURI(),
-		Vary:       tw.vary,
-		Tags:       tw.tags,
-		Created:    time.Now().UnixNano(),
-		FreshUntil: tw.freshUntil.UnixNano(),
-		Size:       tw.written,
+		Status:               tw.status,
+		Header:               tw.metaHeader,
+		PrimaryHex:           tw.primaryHex,
+		Host:                 normalizeHost(tw.r.Host),
+		URI:                  tw.r.URL.RequestURI(),
+		Vary:                 tw.vary,
+		Tags:                 tw.tags,
+		Created:              time.Now().UnixNano(),
+		FreshUntil:           tw.freshUntil.UnixNano(),
+		StaleWhileRevalidate: int64(tw.swr),
+		StaleIfError:         int64(tw.sie),
+		Size:                 tw.written,
 	}
 	if err := tw.ew.Commit(meta); err == nil {
 		tw.c.setPrimaryVary(tw.primaryHex, tw.vary)


### PR DESCRIPTION
## What

Honor the origin's RFC 5861 `stale-while-revalidate` and `stale-if-error` response `Cache-Control` directives, so a cacheable entry can be served **after** it goes stale.

- **`stale-while-revalidate=<s>`** — within the window the stale entry is served immediately (`X-Cache: STALE`) while a single background revalidation refreshes it. The client never waits on the origin.
- **`stale-if-error=<s>`** — past any SWR window the origin is contacted, and a server error (5xx) is replaced by the stale entry (`X-Cache: STALE`) instead of being propagated.

```go
// origin response: Cache-Control: max-age=60, stale-while-revalidate=30, stale-if-error=86400
```

## How

- **Serve-time routing** is centralized in `classify()` → fresh / stale-while-revalidate / stale-if-error / expired. The common path (fresh hit, plain miss, plain stale) is unchanged.
- **SWR** serves the stale body, then fires `revalidate()`: a **single-flighted** (same fill lock) background goroutine on a **detached, `RevalidateTimeout`-bounded** context (default 30s), reusing the existing `teeWriter` store path with a discard client writer (no `DecoupleFill`, no client to stall).
- **SIE** routes through the normal `fillAndServe` but wraps the client writer in `staleGate`: it passes a `<500` response straight through and, on the first `>=500` status, suppresses it and serves the stale copy from `finalize()`. Only the response headers are gated, so a healthy revalidation streams with no added latency.
- **Retention**: a stale-but-serveable entry is kept until past the larger window (`serveableUntil`), so `stale-if-error` keeps something to fall back to. Both the live `classify` path **and the disk startup scan** honor this bound (so it survives a restart). Total size stays bounded by the backend LRU cap.
- `must-revalidate`/`proxy-revalidate` suppress both windows; the client's request `Cache-Control` is still ignored (only origin response directives are honored). `maxTTL` clamping keeps `FreshUntil + window` in range.

`Meta` gains `StaleWhileRevalidate`/`StaleIfError` (nanoseconds, JSON-persisted for the disk backend; old entries default to 0).

## Adversarial review

A multi-agent review (4 dimensions → per-finding verification) ran against the diff. Of 6 confirmed findings:

- **[critical] disk startup scan reaped SIE entries early** — real; the scan reaped on `FreshUntil` alone. **Fixed** (`serveableUntil`), with a teeth-verified regression test (`TestCache_StaleIfError_SurvivesDiskRescan`).
- **[high] `InvalidatedAfter` consulted on time-expired entries** — real contract drift; **fixed** by checking freshness before the hook (`classify` now only consults it for an entry that would be served). Locked in by `TestCache_InvalidatedAfter_NotCalledOnExpired`.
- **[critical] `staleGate.finalize` can't serve stale on 5xx** — **false positive**: `finalize` writes to the underlying `g.rw`, not back through the gate, so the `decided`/`fellBack` guards don't apply. `TestCache_StaleIfError_ServesStaleOnError` already proves the client gets 200/STALE/body.
- **[medium] longer stale retention** — intentional (SIE needs the fallback), LRU-bounded; **documented** in the README.
- **[low] `*Meta` stack-pointer fragility** — safe (synchronous `finalize`); added a clarifying comment.
- **[low] nanosecond exclusive window boundary** — defensible/conservative; no change.

## Tests

`pkg/cache/stale_test.go`: SWR serve+background-refresh (both backends), SWR single-flight under concurrency, SWR past-window→miss, SIE serve-stale-on-5xx (+ stored headers + survives a second error), SIE serve-fresh-on-success, SIE past-window→error propagates, invalidation overrides stale, hook-not-called-on-expired, disk rescan survival, and policy parsing (incl. must-revalidate/proxy-revalidate suppression). `make` clean (vet + lint 0 issues + `-race` ×3), 87.7% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)