### PR TITLE
feat(cache): observable cache via OnResult hook (prom metrics + log field)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -81,6 +81,17 @@ type Options struct {
 	// precedence — an excluded request is never forced.
 	Override func(r *http.Request, status int, header http.Header) *Override
 
+	// OnResult, when non-nil, is called once per request the cache serves, after it
+	// decides how it was served, with the request and a ResultInfo (the outcome —
+	// HIT/MISS/STALE/STALE_ERROR/BYPASS — and, on a fill, its duration). It makes
+	// the cache observable without changing behavior: see prom.Cache for Prometheus
+	// metrics and cache.LogResult for a structured-log field, or compose your own
+	// ResultFunc. It runs synchronously on the foreground serving path only, never
+	// from the background stale-while-revalidate goroutine; a panic unwinding from
+	// the origin handler during a fill is not reported. nil disables it (zero
+	// overhead). The callee owns its own concurrency.
+	OnResult ResultFunc
+
 	// MaxFileSize caps a cacheable response's body. A GET response larger than
 	// this (by Content-Length, or mid-stream) is not cached but still served in
 	// full. Defaults to 8 MiB when <= 0.
@@ -197,6 +208,7 @@ type Cache struct {
 	invalidatedAfter func(r *http.Request, m Meta) int64
 	cacheable        func(r *http.Request) bool
 	override         func(r *http.Request, status int, header http.Header) *Override
+	onResult         ResultFunc
 	primaryVary      map[string][]string  // primaryHex -> Vary header names learned from a stored response
 	locks            map[string]*fillLock // variantHex -> in-flight fill
 	maxFileSize       int64
@@ -245,6 +257,7 @@ func New(storage Storage, opts Options) *Cache {
 		invalidatedAfter:  opts.InvalidatedAfter,
 		cacheable:         opts.Cacheable,
 		override:          opts.Override,
+		onResult:          opts.OnResult,
 		decoupleFill:      opts.DecoupleFill,
 		primaryVary:       map[string][]string{},
 		locks:             map[string]*fillLock{},
@@ -282,6 +295,7 @@ func (c *Cache) serve(w http.ResponseWriter, r *http.Request, next http.Handler)
 	// so it must not answer a Range request with a stored full 200 (let the origin
 	// serve 206). They are also not used to fill the cache.
 	if !cacheableMethod(r.Method) || isUpgrade(r) || r.Header.Get("Range") != "" || (c.cacheable != nil && !c.cacheable(r)) {
+		c.report(r, ResultInfo{Result: ResultBypass})
 		next.ServeHTTP(w, r) // never cache these; no X-Cache header
 		return
 	}
@@ -290,25 +304,35 @@ func (c *Cache) serve(w http.ResponseWriter, r *http.Request, next http.Handler)
 	if m, body, ok := c.storage.Get(key); ok {
 		switch c.classify(m, r, time.Now()) {
 		case stateFresh:
+			c.report(r, ResultInfo{Result: ResultHit})
 			writeStored(w, r, m, body, "HIT")
 			return
 		case stateStaleRevalidate:
 			// RFC 5861 stale-while-revalidate: serve the stale entry now and refresh
 			// it in the background (single-flighted), so the client never waits on the
 			// origin.
+			c.report(r, ResultInfo{Result: ResultStale})
 			writeStored(w, r, m, body, "STALE")
 			c.revalidate(r, next, primaryHex)
 			return
 		case stateStaleIfError:
 			// RFC 5861 stale-if-error: try the origin, but fall back to this stale
 			// entry if the revalidation returns a server error.
-			c.fillWithStale(w, r, next, primaryHex, m, body)
+			c.report(r, c.fillWithStale(w, r, next, primaryHex, m, body))
 			return
 		case stateExpired:
 			c.storage.Delete(key)
 		}
 	}
-	c.fillAndServe(w, r, next, primaryHex)
+	c.report(r, c.fillAndServe(w, r, next, primaryHex))
+}
+
+// report invokes the OnResult hook, if any. It is nil-cheap so an unobserved
+// cache pays nothing.
+func (c *Cache) report(r *http.Request, info ResultInfo) {
+	if c.onResult != nil {
+		c.onResult(r, info)
+	}
 }
 
 // tryServeHit serves key from storage if present and fresh, returning true. It is
@@ -344,13 +368,12 @@ func (c *Cache) tryServeHit(w http.ResponseWriter, r *http.Request, key string) 
 // origin fetch and is cached, instead of every differing follower fetching
 // uncached. The loop runs at most twice: once on the pre-Vary key, once on the
 // learned-Vary key (which is stable thereafter).
-func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex string) {
+func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex string) ResultInfo {
 	for attempt := 0; attempt < 2; attempt++ {
 		variantHex := c.variantHash(primaryHex, r)
 		lock, leader := c.acquire(variantHex)
 		if leader {
-			c.fill(w, r, next, primaryHex, variantHex, lock)
-			return
+			return c.fill(w, r, next, primaryHex, variantHex, lock)
 		}
 		lock.waiters.Add(1)
 		select {
@@ -362,7 +385,7 @@ func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.H
 		// primary's Vary, so our key now matches the stored entry IF our varied
 		// values match the leader's. A wrong-Vary variant is never served.
 		if c.tryServeHit(w, r, c.variantHash(primaryHex, r)) {
-			return
+			return ResultInfo{Result: ResultHit} // served from the leader's just-filled entry
 		}
 		// Still a miss. If the leader learned a Vary we differ on, our key changed —
 		// loop to lead/join the fill for our own variant. If the key is unchanged
@@ -373,13 +396,15 @@ func (c *Cache) fillAndServe(w http.ResponseWriter, r *http.Request, next http.H
 		}
 	}
 	w.Header().Set("X-Cache", "MISS")
+	start := time.Now()
 	next.ServeHTTP(w, r)
+	return ResultInfo{Result: ResultMiss, FillDuration: time.Since(start)}
 }
 
 // fill is the leader path: stream the response to the client through a teeWriter
 // that also writes the cacheable body to storage, commit on completion, then
 // release the fill lock so waiting followers find the committed entry.
-func (c *Cache) fill(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex, variantHex string, lock *fillLock) {
+func (c *Cache) fill(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex, variantHex string, lock *fillLock) ResultInfo {
 	released := false
 	release := func() {
 		if !released {
@@ -391,8 +416,12 @@ func (c *Cache) fill(w http.ResponseWriter, r *http.Request, next http.Handler, 
 
 	tw := &teeWriter{rw: w, r: r, c: c, method: r.Method, primaryHex: primaryHex, lock: lock}
 	defer tw.cleanup() // panic-safe: abort an uncommitted entry if finish never ran
+	start := time.Now()
 	next.ServeHTTP(tw, r)
 	tw.finish()
+	// The fill is the origin round-trip + store; the leader's own client write (below,
+	// under DecoupleFill) is serve time, not fill time, so stamp the duration here.
+	dur := time.Since(start)
 
 	// DecoupleFill: the cacheable body was streamed to storage, not the client, so
 	// release the lock now (waiting followers find the committed entry) and only then
@@ -402,6 +431,7 @@ func (c *Cache) fill(w http.ResponseWriter, r *http.Request, next http.Handler, 
 		release()
 		tw.serveLeader()
 	}
+	return ResultInfo{Result: ResultMiss, FillDuration: dur}
 }
 
 func (c *Cache) acquire(variantHex string) (*fillLock, bool) {

--- a/pkg/cache/example_test.go
+++ b/pkg/cache/example_test.go
@@ -28,6 +28,15 @@ func ExampleNew() {
 	// s.Use(upstream.SingleHost(...)) — the handler whose responses get cached.
 }
 
+// Make the cache observable: record the per-request outcome (HIT/MISS/STALE/
+// STALE_ERROR/BYPASS) as a "cacheStatus" field in the structured access log. Pair
+// with prom.Cache() for Prometheus metrics (see that function's example).
+func ExampleLogResult() {
+	cache.New(cache.NewMemory(256<<20), cache.Options{
+		OnResult: cache.LogResult,
+	})
+}
+
 // Force caching for an origin that sends no cache headers, deciding on both the
 // request and the origin's response — here, only successful image responses.
 func ExampleOverride() {

--- a/pkg/cache/logresult.go
+++ b/pkg/cache/logresult.go
@@ -1,0 +1,20 @@
+package cache
+
+import (
+	"net/http"
+
+	"github.com/moonrhythm/parapet/pkg/logger"
+)
+
+// LogResult is a ResultFunc that records the cache outcome on the request's
+// structured-logger record as the field "cacheStatus" (HIT, MISS, STALE,
+// STALE_ERROR, or BYPASS), so it appears in access logs alongside the upstream,
+// status, and timing fields. It is a no-op when no logger middleware is mounted
+// ahead of the cache (logger.Set ignores a request with no record).
+//
+// Wire it via Options.OnResult, alone or composed with prom.Cache:
+//
+//	cache.New(store, cache.Options{OnResult: cache.LogResult})
+func LogResult(r *http.Request, info ResultInfo) {
+	logger.Set(r.Context(), "cacheStatus", string(info.Result))
+}

--- a/pkg/cache/result.go
+++ b/pkg/cache/result.go
@@ -1,0 +1,59 @@
+package cache
+
+import (
+	"net/http"
+	"time"
+)
+
+// Result is the cache outcome for one request, reported to Options.OnResult. Its
+// string value matches the X-Cache response header where one is sent (HIT, MISS,
+// STALE) and additionally names the two states X-Cache cannot distinguish: a
+// stale-if-error fallback (vs a stale-while-revalidate serve, both "STALE" on the
+// wire) and a bypass (which sends no X-Cache header at all).
+type Result string
+
+const (
+	// ResultHit: served from a fresh stored entry (X-Cache: HIT).
+	ResultHit Result = "HIT"
+
+	// ResultMiss: not served from a stored entry; the origin was contacted and, if
+	// the response was cacheable, stored (X-Cache: MISS).
+	ResultMiss Result = "MISS"
+
+	// ResultStale: served a stale stored entry under RFC 5861
+	// stale-while-revalidate and refreshed it in the background (X-Cache: STALE).
+	ResultStale Result = "STALE"
+
+	// ResultStaleError: served a stale stored entry under RFC 5861 stale-if-error
+	// because revalidating with the origin failed (its X-Cache is also "STALE").
+	ResultStaleError Result = "STALE_ERROR"
+
+	// ResultBypass: the request was ineligible for caching — a non-cacheable method,
+	// a protocol upgrade, a Range request, or Options.Cacheable returned false — and
+	// was proxied straight to the origin. This path sends no X-Cache header, so the
+	// hook is the only way to observe it.
+	ResultBypass Result = "BYPASS"
+)
+
+// ResultInfo carries the details of one request's cache outcome to a ResultFunc.
+type ResultInfo struct {
+	// Result is the cache decision (HIT, MISS, STALE, STALE_ERROR, BYPASS).
+	Result Result
+
+	// FillDuration is how long the foreground origin fetch took, set only when this
+	// request actually contacted the origin on the serving path: a MISS fill and a
+	// stale-if-error revalidation attempt. It is zero for a HIT, for a
+	// stale-while-revalidate STALE (served from cache; the background refresh runs
+	// detached and is never reported), and for a BYPASS.
+	FillDuration time.Duration
+}
+
+// ResultFunc observes a cache outcome. Assign one to Options.OnResult to make the
+// cache observable — see prom.Cache for Prometheus metrics and cache.LogResult for
+// a structured-log field. It is invoked once per request the cache serves,
+// synchronously on the foreground serving path, and never from the background
+// stale-while-revalidate goroutine (which has no client request to attribute and
+// must not touch request-scoped state such as the logger record). A panic
+// propagating out of the origin handler during a fill is not reported (it unwinds
+// past the hook); every request that returns normally is.
+type ResultFunc func(r *http.Request, info ResultInfo)

--- a/pkg/cache/result_test.go
+++ b/pkg/cache/result_test.go
@@ -1,0 +1,153 @@
+package cache
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resultRecorder captures every ResultInfo the OnResult hook reports, safely
+// across the foreground request and any background goroutine.
+type resultRecorder struct {
+	mu    sync.Mutex
+	infos []ResultInfo
+}
+
+func (rr *resultRecorder) fn() ResultFunc {
+	return func(_ *http.Request, info ResultInfo) {
+		rr.mu.Lock()
+		rr.infos = append(rr.infos, info)
+		rr.mu.Unlock()
+	}
+}
+
+func (rr *resultRecorder) all() []ResultInfo {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	return append([]ResultInfo(nil), rr.infos...)
+}
+
+func (rr *resultRecorder) results() []Result {
+	out := make([]Result, 0)
+	for _, i := range rr.all() {
+		out = append(out, i.Result)
+	}
+	return out
+}
+
+func newRecordedCache(opts Options, rr *resultRecorder) *Cache {
+	opts.OnResult = rr.fn()
+	if opts.MaxFileSize == 0 {
+		opts.MaxFileSize = 1024
+	}
+	return New(NewMemory(1<<20), opts)
+}
+
+func TestCache_OnResult_Bypass(t *testing.T) {
+	t.Run("non-cacheable method", func(t *testing.T) {
+		var rr resultRecorder
+		c := newRecordedCache(Options{}, &rr)
+		o := origin(originSpec{body: []byte("x"), header: hdr("Cache-Control", "max-age=60")}, new(int32))
+
+		do(c, o, "POST", "http://acme.com/a", nil)
+
+		assert.Equal(t, []Result{ResultBypass}, rr.results())
+		assert.Zero(t, rr.all()[0].FillDuration, "bypass is not a fill")
+	})
+
+	t.Run("Cacheable returns false", func(t *testing.T) {
+		var rr resultRecorder
+		c := newRecordedCache(Options{Cacheable: func(*http.Request) bool { return false }}, &rr)
+		o := origin(originSpec{body: []byte("x"), header: hdr("Cache-Control", "max-age=60")}, new(int32))
+
+		do(c, o, "GET", "http://acme.com/a", nil)
+
+		assert.Equal(t, []Result{ResultBypass}, rr.results())
+	})
+}
+
+func TestCache_OnResult_MissThenHit(t *testing.T) {
+	var rr resultRecorder
+	c := newRecordedCache(Options{}, &rr)
+	o := origin(originSpec{body: []byte("hello"), header: hdr("Cache-Control", "max-age=60"), sleep: time.Millisecond}, new(int32))
+
+	do(c, o, "GET", "http://acme.com/a", nil)
+	do(c, o, "GET", "http://acme.com/a", nil)
+
+	infos := rr.all()
+	require.Len(t, infos, 2)
+	assert.Equal(t, ResultMiss, infos[0].Result)
+	assert.Positive(t, infos[0].FillDuration, "a miss reports the origin-fill duration")
+	assert.Equal(t, ResultHit, infos[1].Result)
+	assert.Zero(t, infos[1].FillDuration, "a hit contacts no origin")
+}
+
+func TestCache_OnResult_StaleWhileRevalidate(t *testing.T) {
+	var rr resultRecorder
+	c := newRecordedCache(Options{}, &rr)
+	seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 300*time.Second, 0), []byte("old"))
+
+	var calls int32
+	o := origin(originSpec{body: []byte("new"), header: hdr("Cache-Control", "max-age=300")}, &calls)
+
+	rec := do(c, o, "GET", "/x", nil)
+	require.Equal(t, "STALE", rec.Header().Get("X-Cache"))
+
+	// The single foreground serve reports exactly one STALE with no fill duration —
+	// the refresh is detached.
+	infos := rr.all()
+	require.Len(t, infos, 1)
+	assert.Equal(t, ResultStale, infos[0].Result)
+	assert.Zero(t, infos[0].FillDuration)
+
+	// The background revalidation contacts the origin but must NOT report — it has no
+	// client request to attribute. After it lands, still exactly one recorded result.
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&calls) == 1 }, 2*time.Second, 5*time.Millisecond)
+	time.Sleep(20 * time.Millisecond) // let any (erroneous) report settle
+	assert.Len(t, rr.all(), 1, "the detached revalidation goroutine never reports a result")
+}
+
+func TestCache_OnResult_StaleIfError(t *testing.T) {
+	t.Run("origin errors -> STALE_ERROR", func(t *testing.T) {
+		var rr resultRecorder
+		c := newRecordedCache(Options{}, &rr)
+		seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 0, 300*time.Second), []byte("old"))
+
+		o := origin(originSpec{status: http.StatusInternalServerError, body: []byte("boom"), sleep: time.Millisecond}, new(int32))
+		rec := do(c, o, "GET", "/x", nil)
+		require.Equal(t, "old", rec.Body.String())
+
+		infos := rr.all()
+		require.Len(t, infos, 1)
+		assert.Equal(t, ResultStaleError, infos[0].Result)
+		assert.Positive(t, infos[0].FillDuration, "the failed origin attempt is still a fill")
+	})
+
+	t.Run("origin recovers -> MISS", func(t *testing.T) {
+		var rr resultRecorder
+		c := newRecordedCache(Options{}, &rr)
+		seedStale(t, c, "GET", "/x", staleMeta(5*time.Second, 0, 300*time.Second), []byte("old"))
+
+		o := origin(originSpec{body: []byte("new"), header: hdr("Cache-Control", "max-age=300")}, new(int32))
+		rec := do(c, o, "GET", "/x", nil)
+		require.Equal(t, "new", rec.Body.String())
+
+		assert.Equal(t, []Result{ResultMiss}, rr.results(), "a successful revalidation is a normal miss")
+	})
+}
+
+// A nil OnResult must be a no-op on every path (the zero-overhead default).
+func TestCache_OnResult_NilIsNoOp(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024})
+	o := origin(originSpec{body: []byte("x"), header: hdr("Cache-Control", "max-age=60")}, new(int32))
+	assert.NotPanics(t, func() {
+		do(c, o, "GET", "http://acme.com/a", nil) // miss
+		do(c, o, "GET", "http://acme.com/a", nil) // hit
+		do(c, o, "POST", "http://acme.com/a", nil) // bypass
+	})
+}

--- a/pkg/cache/stale.go
+++ b/pkg/cache/stale.go
@@ -99,14 +99,21 @@ func (c *Cache) revalidate(r *http.Request, next http.Handler, primaryHex string
 // normal fill (so single-flight, Vary learning, and caching all apply) but routes
 // the client write through a staleGate. If the origin's revalidation produces a
 // server error (status >= 500), the gate suppresses it and the stale entry is
-// served instead.
-func (c *Cache) fillWithStale(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex string, m Meta, body []byte) {
+// served instead. It returns the request's cache outcome: ResultStaleError when it
+// fell back to the stale entry (carrying the failed fetch's duration), otherwise
+// the inner fill's own result (a MISS that successfully revalidated, or a HIT
+// served from a concurrent leader's fill through the gate).
+func (c *Cache) fillWithStale(w http.ResponseWriter, r *http.Request, next http.Handler, primaryHex string, m Meta, body []byte) ResultInfo {
 	// gate.m points at this stack-local m; finalize runs synchronously below
 	// (before this frame returns), so the pointer never escapes. fillAndServe and
 	// the teeWriter it builds keep the gate stack-local and do not retain it.
 	gate := &staleGate{rw: w, r: r, m: &m, body: body}
-	c.fillAndServe(gate, r, next, primaryHex)
+	info := c.fillAndServe(gate, r, next, primaryHex)
 	gate.finalize()
+	if gate.fellBack {
+		return ResultInfo{Result: ResultStaleError, FillDuration: info.FillDuration}
+	}
+	return info
 }
 
 // staleGate wraps the client ResponseWriter during a stale-if-error fill. It

--- a/pkg/prom/cache.go
+++ b/pkg/prom/cache.go
@@ -1,0 +1,81 @@
+package prom
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+)
+
+//nolint:govet
+type cacheMetrics struct {
+	once  sync.Once
+	total *prometheus.CounterVec
+	fill  *prometheus.HistogramVec
+}
+
+var _cache cacheMetrics
+
+func (p *cacheMetrics) init() {
+	p.once.Do(func() {
+		p.total = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "cache_total",
+		}, []string{"host", "result"})
+		p.fill = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "cache_fill_duration_seconds",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"host"})
+		reg.MustRegister(p.total, p.fill)
+	})
+}
+
+func (p *cacheMetrics) observe(r *http.Request, info cache.ResultInfo) {
+	if counter, err := p.total.GetMetricWith(prometheus.Labels{
+		"host":   r.Host,
+		"result": string(info.Result),
+	}); err == nil {
+		counter.Inc()
+	}
+	// FillDuration is non-zero only when the origin was actually contacted on the
+	// serving path (a MISS or a stale-if-error attempt), so the histogram holds
+	// origin-fill latency and is not diluted by instant cache hits.
+	if info.FillDuration > 0 {
+		if h, err := p.fill.GetMetricWith(prometheus.Labels{"host": r.Host}); err == nil {
+			h.Observe(info.FillDuration.Seconds())
+		}
+	}
+}
+
+// Cache returns a cache.ResultFunc that records cache observability metrics on the
+// shared registry, for wiring into cache.Options.OnResult:
+//
+//	store := cache.NewMemory(256 << 20)
+//	c := cache.New(store, cache.Options{OnResult: prom.Cache()})
+//
+// It registers two metrics (lazily, once per process):
+//
+//	{namespace}_cache_total{host,result}             counter of cache outcomes
+//	    (result = HIT|MISS|STALE|STALE_ERROR|BYPASS — a hit ratio is
+//	     sum(HIT) / sum(all), the otherwise-invisible BYPASS path included)
+//	{namespace}_cache_fill_duration_seconds{host}    histogram of origin-fill latency
+//	    (observed only when the origin was contacted, i.e. MISS and stale-if-error)
+//
+// The host label matches prom.Requests so the two can be joined. Keeping the metric
+// wiring here leaves pkg/cache free of any Prometheus dependency. Compose it with
+// cache.LogResult to also emit a per-request cacheStatus log field:
+//
+//	metrics := prom.Cache()
+//	c := cache.New(store, cache.Options{
+//		OnResult: func(r *http.Request, info cache.ResultInfo) {
+//			metrics(r, info)
+//			cache.LogResult(r, info)
+//		},
+//	})
+func Cache() cache.ResultFunc {
+	_cache.init()
+	return _cache.observe
+}

--- a/pkg/prom/cache_test.go
+++ b/pkg/prom/cache_test.go
@@ -1,0 +1,105 @@
+package prom_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/cache"
+	. "github.com/moonrhythm/parapet/pkg/prom"
+)
+
+// counterValue returns the gathered counter sample whose labels include want, or
+// -1 if absent — found without naming the prometheus client_model types.
+func counterValue(t *testing.T, name string, want map[string]string) float64 {
+	t.Helper()
+	mfs, err := Registry().Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, p := range m.GetLabel() {
+				got[p.GetName()] = p.GetValue()
+			}
+			if subset(want, got) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return -1
+}
+
+func histogramCount(t *testing.T, name string, want map[string]string) uint64 {
+	t.Helper()
+	mfs, err := Registry().Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, p := range m.GetLabel() {
+				got[p.GetName()] = p.GetValue()
+			}
+			if subset(want, got) {
+				return m.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+func subset(want, got map[string]string) bool {
+	for k, v := range want {
+		if got[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func TestCache(t *testing.T) {
+	observe := Cache()
+	require.NotNil(t, observe)
+
+	// A unique host isolates these assertions from any other test sharing the
+	// process-global registry.
+	const host = "prom-cache-test.example"
+	r := httptest.NewRequest("GET", "http://"+host+"/x", nil)
+
+	observe(r, cache.ResultInfo{Result: cache.ResultHit})
+	observe(r, cache.ResultInfo{Result: cache.ResultMiss, FillDuration: 7 * time.Millisecond})
+	observe(r, cache.ResultInfo{Result: cache.ResultBypass})
+
+	assert.EqualValues(t, 1, counterValue(t, "parapet_cache_total", map[string]string{"host": host, "result": "HIT"}))
+	assert.EqualValues(t, 1, counterValue(t, "parapet_cache_total", map[string]string{"host": host, "result": "MISS"}))
+	assert.EqualValues(t, 1, counterValue(t, "parapet_cache_total", map[string]string{"host": host, "result": "BYPASS"}),
+		"the otherwise-invisible bypass path is counted")
+
+	// Only the MISS carried a fill duration, so the histogram saw exactly one sample.
+	assert.EqualValues(t, 1, histogramCount(t, "parapet_cache_fill_duration_seconds", map[string]string{"host": host}),
+		"a hit/bypass contributes no fill-latency sample")
+}
+
+// Cache observability: count outcomes and fill latency, and tag access logs.
+func ExampleCache() {
+	store := cache.NewMemory(256 << 20)
+
+	metrics := Cache() // prom.Cache()
+	_ = cache.New(store, cache.Options{
+		// Compose metrics with the cacheStatus log field; pass prom.Cache() alone if
+		// you only want metrics.
+		OnResult: func(r *http.Request, info cache.ResultInfo) {
+			metrics(r, info)
+			cache.LogResult(r, info)
+		},
+	})
+}


### PR DESCRIPTION
## What

Makes the response cache observable. The cache grew five features — stale-while-revalidate, stale-if-error, forced `Override`, and tag/host/url/prefix purge — but emitted only the `X-Cache` header, and **nothing at all on the bypass path**. Operators couldn't answer *"is my cache helping?"*: no hit ratio, no stale-serve rate, no bypass volume, no fill-latency distribution.

This adds one classification hook and two consumers. **Purely additive — no behavior change** (the hook is nil by default, so existing callers are byte-for-byte unchanged).

## How

**`Options.OnResult ResultFunc`** — called once per request the cache serves, on the foreground path only, with the request and a `ResultInfo`:

| `Result` | meaning |
|---|---|
| `HIT` | served a fresh stored entry |
| `MISS` | contacted the origin and (if cacheable) stored |
| `STALE` | served stale under stale-while-revalidate, refreshed in background |
| `STALE_ERROR` | served stale under stale-if-error (revalidation failed) |
| `BYPASS` | ineligible for caching — sends no `X-Cache`, so the hook is the only way to see it |

`ResultInfo` also carries `FillDuration` — the origin-fill time, set only when the origin was actually contacted on the serving path (MISS and the stale-if-error attempt), zero for HIT/STALE/BYPASS.

The result is threaded up as a return value from `fill`/`fillAndServe`/`fillWithStale`, so `serve()` is the **single reporter** — reported exactly once per served request, and **never** from the detached stale-while-revalidate goroutine (which has no client request to attribute and must not touch the request-scoped logger record).

**Two consumers:**
- **`prom.Cache() cache.ResultFunc`** — `parapet_cache_total{host,result}` counter + `parapet_cache_fill_duration_seconds{host}` histogram. Keeps `pkg/cache` free of any Prometheus dependency (the `prom.X()-returns-a-thing-you-wire-in` convention); `host` label matches `prom.Requests()` so the two join.
- **`cache.LogResult`** — sets a `cacheStatus` field on the structured-log record, mirroring the existing `upstream` `logger.Set` pattern.

```go
metrics := prom.Cache()
c := cache.New(store, cache.Options{
    OnResult: func(r *http.Request, info cache.ResultInfo) {
        metrics(r, info)
        cache.LogResult(r, info)
    },
})
```

`STALE` (stale-while-revalidate) and `STALE_ERROR` (stale-if-error) — indistinguishable on the wire (both `X-Cache: STALE`) — and `BYPASS` (no header) become visible for the first time.

## Tests

- `pkg/cache/result_test.go` — all five outcomes, `FillDuration` correctness (positive on MISS/STALE_ERROR, zero on HIT), the detached revalidation goroutine reporting **no** result, and nil-`OnResult` being a no-op on every path.
- `pkg/prom/cache_test.go` — counter + histogram values via the registry gatherer, including the bypass counter.
- Examples: `ExampleCache` (prom) and `ExampleLogResult` (cache).

`make` (vet + golangci-lint + `go test -race ./...`) passes. Reviewed with `/scrutinize`: confirmed exactly-once on all six `serve()` branches, the background-silent path, race-freedom, and corrected one doc overstatement about the panic seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)