### PR TITLE
feat(upstream): observable origin via OnRoundTrip hook (prom per-backend metrics)

### DIFF
--- a/pkg/prom/upstream.go
+++ b/pkg/prom/upstream.go
@@ -1,0 +1,77 @@
+package prom
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+//nolint:govet
+type upstreamMetrics struct {
+	once     sync.Once
+	requests *prometheus.CounterVec
+	duration *prometheus.HistogramVec
+}
+
+var _upstream upstreamMetrics
+
+func (p *upstreamMetrics) init() {
+	p.once.Do(func() {
+		p.requests = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "upstream_requests",
+		}, []string{"host", "status"})
+		p.duration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "upstream_request_duration_seconds",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"host"})
+		reg.MustRegister(p.requests, p.duration)
+	})
+}
+
+func (p *upstreamMetrics) observe(_ *http.Request, info upstream.RoundTripInfo) {
+	// A transport-level failure (no response) is labelled "error"; otherwise the
+	// origin's numeric status, so 5xx counts fall out of the same metric.
+	status := strconv.Itoa(info.Status)
+	if info.Err != nil {
+		status = "error"
+	}
+	if c, err := p.requests.GetMetricWith(prometheus.Labels{
+		"host":   info.Host,
+		"status": status,
+	}); err == nil {
+		c.Inc()
+	}
+	if h, err := p.duration.GetMetricWith(prometheus.Labels{"host": info.Host}); err == nil {
+		h.Observe(info.Duration.Seconds())
+	}
+}
+
+// Upstream returns an upstream.RoundTripFunc that records per-backend origin
+// metrics on the shared registry, for wiring into Upstream.OnRoundTrip:
+//
+//	u := upstream.New(lb)
+//	u.OnRoundTrip = prom.Upstream()
+//	s.Use(u)
+//
+// It registers two metrics (lazily, once per process):
+//
+//	{namespace}_upstream_requests{host,status}                  counter of attempts
+//	    (status = the origin's numeric code, or "error" for a transport failure;
+//	     an origin-error rate is sum(status=~"5..") + sum(status="error"))
+//	{namespace}_upstream_request_duration_seconds{host}         histogram of TTFB
+//	    (transport round-trip latency: connect + send + time to response headers)
+//
+// It fires once per attempt, so retries are counted individually. The host label is
+// the resolved upstream target (operator-configured, bounded), distinct from the
+// client-facing host of prom.Requests. Keeping the wiring here leaves pkg/upstream
+// free of any Prometheus dependency.
+func Upstream() upstream.RoundTripFunc {
+	_upstream.init()
+	return _upstream.observe
+}

--- a/pkg/prom/upstream_test.go
+++ b/pkg/prom/upstream_test.go
@@ -1,0 +1,50 @@
+package prom_test
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/upstream"
+
+	. "github.com/moonrhythm/parapet/pkg/prom"
+)
+
+func TestUpstream(t *testing.T) {
+	observe := Upstream()
+	require.NotNil(t, observe)
+
+	// A unique target host isolates these assertions from any other test sharing the
+	// process-global registry.
+	const host = "prom-upstream-test.backend"
+	r := httptest.NewRequest("GET", "/", nil)
+
+	observe(r, upstream.RoundTripInfo{Host: host, Status: 200, Duration: 5 * time.Millisecond})
+	observe(r, upstream.RoundTripInfo{Host: host, Status: 502, Duration: 3 * time.Millisecond})
+	observe(r, upstream.RoundTripInfo{Host: host, Err: errors.New("dial fail"), Duration: time.Millisecond})
+
+	assert.EqualValues(t, 1, counterValue(t, "parapet_upstream_requests", map[string]string{"host": host, "status": "200"}))
+	assert.EqualValues(t, 1, counterValue(t, "parapet_upstream_requests", map[string]string{"host": host, "status": "502"}),
+		"an origin 5xx is countable by status")
+	assert.EqualValues(t, 1, counterValue(t, "parapet_upstream_requests", map[string]string{"host": host, "status": "error"}),
+		"a transport failure is countable as error")
+
+	// Every attempt — success or failure — contributes a TTFB sample.
+	assert.EqualValues(t, 3, histogramCount(t, "parapet_upstream_request_duration_seconds", map[string]string{"host": host}))
+}
+
+// Per-backend origin metrics: request count by status and time-to-first-byte.
+func ExampleUpstream() {
+	lb := upstream.NewRoundRobinLoadBalancer([]*upstream.Target{
+		{Host: "10.0.0.1:8080", Transport: &upstream.HTTPTransport{}},
+		{Host: "10.0.0.2:8080", Transport: &upstream.HTTPTransport{}},
+	})
+
+	u := upstream.New(lb)
+	u.OnRoundTrip = Upstream() // prom.Upstream(): count by host+status, observe TTFB
+	_ = u                      // s.Use(u)
+}

--- a/pkg/upstream/observe.go
+++ b/pkg/upstream/observe.go
@@ -1,0 +1,39 @@
+package upstream
+
+import (
+	"net/http"
+	"time"
+)
+
+// RoundTripInfo reports one upstream round-trip — a single attempt to a backend,
+// so a retried request produces one per attempt — to a RoundTripFunc.
+//
+//nolint:govet // fields ordered for readability, not pointer-packing
+type RoundTripInfo struct {
+	// Host is the resolved upstream target the request was sent to (r.URL.Host after
+	// load balancing). Unlike the client Host header, it is operator-configured and
+	// therefore bounded, so it is safe as a metric label. It may be empty when the
+	// load balancer rejected the request before choosing a target (ErrUnavailable).
+	Host string
+
+	// Duration is the time to the response headers: the transport round-trip
+	// (connect + send request + time-to-first-byte), measured before the body is
+	// streamed on to the client. It is set on both success and error.
+	Duration time.Duration
+
+	// Status is the upstream response's status code, or 0 when the round-trip failed
+	// before any response (Err is then non-nil).
+	Status int
+
+	// Err is the transport error — connection refused, timeout, ErrUnavailable when
+	// the load balancer had no target, etc. — or nil once a response was received,
+	// regardless of that response's status code.
+	Err error
+}
+
+// RoundTripFunc observes an upstream round-trip. Assign one to Upstream.OnRoundTrip
+// to make the origin observable — see prom.Upstream for Prometheus metrics. It is
+// invoked once per attempt (including each retry), synchronously on the request
+// goroutine, right after the transport returns and before the response unwinds back
+// through the proxy. The callee owns its own concurrency.
+type RoundTripFunc func(r *http.Request, info RoundTripInfo)

--- a/pkg/upstream/observe_test.go
+++ b/pkg/upstream/observe_test.go
@@ -1,0 +1,89 @@
+package upstream_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+func appendInfo(dst *[]RoundTripInfo) RoundTripFunc {
+	// The proxy runs RoundTrip (and any retries) synchronously on the serving
+	// goroutine, so no lock is needed.
+	return func(_ *http.Request, info RoundTripInfo) { *dst = append(*dst, info) }
+}
+
+func TestUpstream_OnRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success captures host, status, duration", func(t *testing.T) {
+		var infos []RoundTripInfo
+		u := Upstream{
+			Transport: &mockTransport{roundTripFunc: func(r *http.Request) (*http.Response, error) {
+				r.URL.Host = "backend-1" // the load balancer resolves the target here
+				time.Sleep(time.Millisecond)
+				w := httptest.NewRecorder()
+				w.WriteHeader(http.StatusBadGateway) // a real origin 5xx, err==nil -> no retry
+				return w.Result(), nil
+			}},
+			OnRoundTrip: appendInfo(&infos),
+		}
+		u.ServeHandler(nil).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+
+		require.Len(t, infos, 1)
+		assert.Equal(t, "backend-1", infos[0].Host)
+		assert.Equal(t, http.StatusBadGateway, infos[0].Status, "an origin 5xx is captured, not retried")
+		assert.NoError(t, infos[0].Err)
+		assert.Positive(t, infos[0].Duration, "TTFB is measured")
+	})
+
+	t.Run("transport error reports Err and zero Status", func(t *testing.T) {
+		var infos []RoundTripInfo
+		u := Upstream{
+			Transport: &mockTransport{roundTripFunc: func(r *http.Request) (*http.Response, error) {
+				r.URL.Host = "backend-2"
+				return nil, fmt.Errorf("dial fail")
+			}},
+			OnRoundTrip: appendInfo(&infos),
+			// Retries left at 0: exactly one attempt.
+		}
+		u.ServeHandler(nil).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+
+		require.Len(t, infos, 1)
+		assert.Equal(t, "backend-2", infos[0].Host)
+		assert.Zero(t, infos[0].Status)
+		assert.Error(t, infos[0].Err)
+	})
+
+	t.Run("fires once per attempt including retries", func(t *testing.T) {
+		var infos []RoundTripInfo
+		u := Upstream{
+			Transport: &mockTransport{roundTripFunc: func(r *http.Request) (*http.Response, error) {
+				return nil, fmt.Errorf("dial fail")
+			}},
+			OnRoundTrip:   appendInfo(&infos),
+			Retries:       2,
+			BackoffFactor: time.Millisecond,
+		}
+		u.ServeHandler(nil).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+
+		assert.Len(t, infos, 3, "1 initial attempt + 2 retries, each observed")
+		for _, info := range infos {
+			assert.Error(t, info.Err)
+		}
+	})
+
+	t.Run("nil OnRoundTrip is a no-op", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			Upstream{Transport: &mockTransport{roundTripFunc: func(r *http.Request) (*http.Response, error) {
+				return httptest.NewRecorder().Result(), nil
+			}}}.ServeHandler(nil).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+		})
+	})
+}

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -23,8 +23,9 @@ var (
 type Upstream struct {
 	Transport     http.RoundTripper
 	ErrorLog      *log.Logger
-	Host          string // override host
-	Path          string // target prefix path
+	OnRoundTrip   RoundTripFunc // observe each origin round-trip (nil disables); see prom.Upstream
+	Host          string        // override host
+	Path          string        // target prefix path
 	Retries       int
 	BackoffFactor time.Duration
 }
@@ -119,8 +120,18 @@ func (m Upstream) ServeHandler(h http.Handler) http.Handler {
 
 // RoundTrip wraps transport round-trip
 func (m *Upstream) RoundTrip(r *http.Request) (*http.Response, error) {
+	start := time.Now()
 	resp, err := m.Transport.RoundTrip(r)
 	logger.Set(r.Context(), "upstream", r.URL.Host)
+	if m.OnRoundTrip != nil {
+		// r.URL.Host is the target the load balancer / single-host transport just
+		// resolved; Duration is the time to response headers, before the body streams.
+		info := RoundTripInfo{Host: r.URL.Host, Duration: time.Since(start), Err: err}
+		if resp != nil {
+			info.Status = resp.StatusCode
+		}
+		m.OnRoundTrip(r, info)
+	}
 	return resp, err
 }
 


### PR DESCRIPTION
## What

Makes the origin observable. `pkg/upstream` had **zero metrics** — operators couldn't see per-backend request volume, origin 5xx rates, transport failures, or upstream latency, which is the proxy's most operationally important signal. This is the natural follow-on to #215 (cache observability): with the cache now measurable, instrument the backend it sits in front of.

**Purely additive — no behavior change** (the hook is nil by default, so existing callers are byte-for-byte unchanged).

## How

**`Upstream.OnRoundTrip RoundTripFunc`** — fired once per origin **attempt** (so retries are counted individually) at the existing `RoundTrip` observation point, right after the load balancer resolves the target. It carries a `RoundTripInfo`:

| field | meaning |
|---|---|
| `Host` | the resolved upstream target (`r.URL.Host` after load balancing) |
| `Duration` | time to response headers — connect + send + TTFB, before the body streams |
| `Status` | the origin's status code, or `0` when the round-trip failed before a response |
| `Err` | the transport error (dial refused, timeout, `ErrUnavailable`), or nil |

**`prom.Upstream() upstream.RoundTripFunc`** consumes it, keeping `pkg/upstream` free of any Prometheus dependency (the `prom.X()-returns-a-thing-you-wire-in` convention):

```go
u := upstream.New(lb)
u.OnRoundTrip = prom.Upstream()
s.Use(u)
```

- `parapet_upstream_requests{host,status}` — counter. `status` is the origin's numeric code, or `"error"` for a transport failure, so an **origin-error rate** is `sum(status=~"5..") + sum(status="error")` and **5xx counts** fall out of the same metric.
- `parapet_upstream_request_duration_seconds{host}` — **TTFB histogram** (transport round-trip latency, measured before the body streams to the client).

The `host` label is the **operator-configured upstream target** — bounded, low cardinality — distinct from the client-facing host of `prom.Requests`. Per-attempt, so a retry storm shows up as elevated counts + errors.

## Tests

- `pkg/upstream/observe_test.go` — drives the real ReverseProxy path: success captures host/status/TTFB (incl. an origin 502, which is captured-not-retried), a transport error reports `Err` + zero `Status`, the hook fires once per attempt across retries (`1 + Retries`), and nil-`OnRoundTrip` is a no-op.
- `pkg/prom/upstream_test.go` — counter values for `200` / `502` / `error` and the TTFB histogram count via the registry gatherer; `ExampleUpstream`.

`make` (vet + golangci-lint `0 issues` + `go test -race ./...`) passes. Reviewed with `/scrutinize`: traced the full `Director → Upstream.RoundTrip → LB → target` graph and the retry path through `ErrorHandler` — confirmed once-per-attempt, resolved-host (with the documented empty-host `ErrUnavailable` edge), TTFB correctness, status/error labeling, bounded cardinality, and race-freedom. Findings were nits only.

## Sequencing

This is item #1 of the post-#215 ranking. It deliberately lands **before** the riskier reliability work (passive health checks / outlier ejection, weighted & least-conn balancing) — those carry real behavioral risk and are far easier to validate once these per-backend metrics exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)