### PR TITLE
feat(upstream): add EjectingLoadBalancer with passive health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each subdirectory under `pkg/` is a self-contained middleware:
 
 | Package | What it does |
 |---|---|
-| [`upstream`](pkg/upstream) | Reverse proxy and load balancing (round-robin) over HTTP, H2C, or HTTPS |
+| [`upstream`](pkg/upstream) | Reverse proxy and load balancing (round-robin, or round-robin with passive health checks) over HTTP, H2C, or HTTPS |
 | [`host`](pkg/host) | Virtual-host routing on the `Host` header, with wildcard prefixes |
 | [`location`](pkg/location) | Path routing — exact, prefix, and regexp matchers |
 | [`router`](pkg/router) | Simple URL router |
@@ -360,6 +360,39 @@ go func() { for range time.Tick(5 * time.Minute) { pt.Reap(store) } }() // proac
 ```
 
 `Snapshot`/`Restore` serialize the table so purges survive a restart (persist however you like). It's the engine [parapet-ingress-controller](https://github.com/moonrhythm/parapet-ingress-controller) builds its control-plane purge distribution on top of.
+
+## Load balancing with passive health checks
+
+`upstream.NewRoundRobinLoadBalancer` spreads requests evenly but keeps routing to
+a dead backend. `upstream.NewEjectingLoadBalancer` adds passive health checking
+(outlier ejection): after a target returns `MaxFails` consecutive failures it is
+ejected from rotation for `EjectTimeout` (doubling on each repeat ejection, up to
+`MaxEjectTimeout`), then allowed back with no background probing. A single
+success clears its failure count. If every target is ejected the balancer fails
+open and keeps routing, so a transient outage cannot black-hole all traffic.
+
+```go
+lb := upstream.NewEjectingLoadBalancer([]*upstream.Target{
+	{Host: "10.0.0.1:8080", Transport: &upstream.HTTPTransport{}},
+	{Host: "10.0.0.2:8080", Transport: &upstream.HTTPTransport{}},
+})
+lb.MaxFails = 3                      // consecutive failures before ejection
+lb.EjectTimeout = 30 * time.Second   // base cooldown
+s.Use(upstream.New(lb))
+```
+
+By default only transport errors (other than a client-canceled request) count as
+failures. Set `lb.IsFailure` to also treat responses such as 5xx as failures:
+
+```go
+lb.IsFailure = func(resp *http.Response, err error) bool {
+	return err != nil || (resp != nil && resp.StatusCode >= 500)
+}
+```
+
+Pair it with `prom.Upstream()` (wired into `Upstream.OnRoundTrip`) to watch
+ejections take effect: traffic shifts off a failing backend in
+`parapet_upstream_requests{host,status}`.
 
 ## Trusted proxies
 

--- a/pkg/upstream/ejecting.go
+++ b/pkg/upstream/ejecting.go
@@ -1,0 +1,189 @@
+package upstream
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Ejecting load balancer defaults
+const (
+	defaultMaxFails        = 3
+	defaultEjectTimeout    = 30 * time.Second
+	defaultMaxEjectTimeout = 5 * time.Minute
+)
+
+// NewEjectingLoadBalancer creates a round-robin load balancer with passive
+// health checking (outlier ejection).
+func NewEjectingLoadBalancer(targets []*Target) *EjectingLoadBalancer {
+	return &EjectingLoadBalancer{Targets: targets}
+}
+
+// EjectingLoadBalancer is a round-robin load balancer that passively tracks
+// per-target failures and temporarily ejects targets that fail repeatedly.
+//
+// A target is ejected once it returns MaxFails consecutive failures, and stays
+// ejected for EjectTimeout (doubling on each repeat ejection up to
+// MaxEjectTimeout). Ejected targets are skipped during selection; when their
+// cooldown expires they become selectable again with no background probing.
+// A single successful response clears a target's failure count and backoff.
+//
+// If every target is ejected the balancer fails open and routes anyway, so a
+// transient outage cannot black-hole all traffic.
+//
+// Configuration fields are read once, before the first request; set them
+// before serving.
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
+type EjectingLoadBalancer struct {
+	once    sync.Once
+	i       atomic.Uint32
+	targets []*ejectTarget
+
+	// Targets is the set of upstreams to balance across.
+	Targets []*Target
+
+	// MaxFails is the number of consecutive failures that ejects a target.
+	// Defaults to 3.
+	MaxFails int
+
+	// EjectTimeout is the base cooldown a target stays ejected. It doubles on
+	// each consecutive ejection, capped at MaxEjectTimeout. Defaults to 30s.
+	EjectTimeout time.Duration
+
+	// MaxEjectTimeout caps the ejection cooldown. Defaults to 5m.
+	MaxEjectTimeout time.Duration
+
+	// IsFailure decides whether a round-trip result counts as a failure. When
+	// nil, any transport error other than a client-canceled request counts.
+	// Set it to also treat responses such as 5xx as failures.
+	IsFailure func(resp *http.Response, err error) bool
+}
+
+// ejectTarget holds the passive-health state for a single target.
+type ejectTarget struct {
+	target       *Target
+	fails        atomic.Int32
+	ejections    atomic.Int32
+	ejectedUntil atomic.Int64 // unix nanos; <= now means selectable
+}
+
+func (l *EjectingLoadBalancer) init() {
+	if l.MaxFails <= 0 {
+		l.MaxFails = defaultMaxFails
+	}
+	if l.EjectTimeout <= 0 {
+		l.EjectTimeout = defaultEjectTimeout
+	}
+	if l.MaxEjectTimeout <= 0 {
+		l.MaxEjectTimeout = defaultMaxEjectTimeout
+	}
+	if l.MaxEjectTimeout < l.EjectTimeout {
+		l.MaxEjectTimeout = l.EjectTimeout
+	}
+
+	l.targets = make([]*ejectTarget, len(l.Targets))
+	for i, t := range l.Targets {
+		l.targets[i] = &ejectTarget{target: t}
+	}
+}
+
+// RoundTrip sends a request to a healthy upstream server.
+func (l *EjectingLoadBalancer) RoundTrip(r *http.Request) (*http.Response, error) {
+	l.once.Do(l.init)
+
+	n := len(l.targets)
+	if n == 0 {
+		return nil, ErrUnavailable
+	}
+
+	t := l.pick(n)
+	r.URL.Host = t.target.Host
+	resp, err := t.target.Transport.RoundTrip(r)
+	l.record(t, resp, err)
+	return resp, err
+}
+
+// pick selects the next selectable target in round-robin order, skipping
+// ejected ones. If all targets are ejected it falls open to the round-robin
+// pick so traffic is never fully black-holed.
+func (l *EjectingLoadBalancer) pick(n int) *ejectTarget {
+	start := l.i.Add(1) - 1
+	now := time.Now().UnixNano()
+	for k := uint32(0); k < uint32(n); k++ {
+		t := l.targets[(start+k)%uint32(n)]
+		if t.ejectedUntil.Load() <= now {
+			return t
+		}
+	}
+	return l.targets[start%uint32(n)]
+}
+
+// record updates a target's health from a round-trip result.
+func (l *EjectingLoadBalancer) record(t *ejectTarget, resp *http.Response, err error) {
+	if l.failed(resp, err) {
+		if int(t.fails.Add(1)) >= l.MaxFails {
+			l.eject(t)
+		}
+		return
+	}
+
+	// Success: clear any failure/ejection state. Guard the writes behind reads so
+	// the common all-healthy path only loads (shared cache lines) and never stores
+	// (which would bounce the line exclusive across cores on every request).
+	if t.fails.Load() != 0 || t.ejections.Load() != 0 || t.ejectedUntil.Load() != 0 {
+		t.fails.Store(0)
+		t.ejections.Store(0)
+		t.ejectedUntil.Store(0)
+	}
+}
+
+func (l *EjectingLoadBalancer) failed(resp *http.Response, err error) bool {
+	if l.IsFailure != nil {
+		return l.IsFailure(resp, err)
+	}
+	return err != nil && !errors.Is(err, context.Canceled)
+}
+
+// eject takes a target out of rotation for an exponentially backed-off cooldown.
+//
+// Concurrent in-flight failures all cross the threshold at once, so this counts
+// at most one ejection per down-window: it CAS-transitions ejectedUntil from a
+// past value (selectable) to a future one, and whoever loses the race sees the
+// window already open and returns without re-counting. So a burst of N
+// simultaneous failures is one ejection, not N — the backoff exponent only grows
+// when a cooldown expires and the target fails afresh.
+func (l *EjectingLoadBalancer) eject(t *ejectTarget) {
+	t.fails.Store(0) // threshold handled; reset the consecutive counter
+	now := time.Now()
+	for {
+		prev := t.ejectedUntil.Load()
+		if prev > now.UnixNano() {
+			return // already ejected for this window
+		}
+		e := t.ejections.Load() + 1
+		until := now.Add(l.ejectionTimeout(e)).UnixNano()
+		if t.ejectedUntil.CompareAndSwap(prev, until) {
+			t.ejections.Store(e)
+			return
+		}
+		// Lost the CAS to a concurrent ejector; re-read — its value is now in the
+		// future, so the next iteration returns.
+	}
+}
+
+// ejectionTimeout returns EjectTimeout doubled for each prior ejection, capped
+// at MaxEjectTimeout. e is the 1-based ejection count.
+func (l *EjectingLoadBalancer) ejectionTimeout(e int32) time.Duration {
+	d := l.EjectTimeout
+	for i := int32(1); i < e && d < l.MaxEjectTimeout; i++ {
+		d *= 2
+	}
+	if d <= 0 || d > l.MaxEjectTimeout {
+		return l.MaxEjectTimeout
+	}
+	return d
+}

--- a/pkg/upstream/ejecting_test.go
+++ b/pkg/upstream/ejecting_test.go
@@ -1,0 +1,256 @@
+package upstream
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeUpstream is a transport whose health can be toggled at runtime.
+type fakeUpstream struct {
+	calls  atomic.Int64
+	down   atomic.Bool
+	status int // response status when up; 0 means 200
+}
+
+func (t *fakeUpstream) RoundTrip(*http.Request) (*http.Response, error) {
+	t.calls.Add(1)
+	if t.down.Load() {
+		return nil, errors.New("dial tcp: connection refused")
+	}
+	w := httptest.NewRecorder()
+	if t.status != 0 {
+		w.WriteHeader(t.status)
+	}
+	return w.Result(), nil
+}
+
+func newEjectTargets(trs ...*fakeUpstream) []*Target {
+	targets := make([]*Target, len(trs))
+	for i, tr := range trs {
+		targets[i] = &Target{Host: fmt.Sprintf("upstream%d", i), Transport: tr}
+	}
+	return targets
+}
+
+func drive(l *EjectingLoadBalancer, n int) {
+	for range n {
+		r := httptest.NewRequest("GET", "/", nil)
+		resp, _ := l.RoundTrip(r)
+		if resp != nil {
+			resp.Body.Close()
+		}
+	}
+}
+
+func TestEjectingLoadBalancer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		l := NewEjectingLoadBalancer(nil)
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Nil(t, resp)
+		assert.Equal(t, ErrUnavailable, err)
+	})
+
+	t.Run("Defaults", func(t *testing.T) {
+		t.Parallel()
+		l := NewEjectingLoadBalancer(newEjectTargets(&fakeUpstream{}))
+		drive(l, 1)
+		assert.Equal(t, defaultMaxFails, l.MaxFails)
+		assert.Equal(t, defaultEjectTimeout, l.EjectTimeout)
+		assert.Equal(t, defaultMaxEjectTimeout, l.MaxEjectTimeout)
+	})
+
+	t.Run("RoundRobinWhenHealthy", func(t *testing.T) {
+		t.Parallel()
+		t0, t1 := &fakeUpstream{}, &fakeUpstream{}
+		l := NewEjectingLoadBalancer(newEjectTargets(t0, t1))
+		drive(l, 10)
+		assert.Equal(t, int64(5), t0.calls.Load())
+		assert.Equal(t, int64(5), t1.calls.Load())
+	})
+
+	t.Run("EjectsAfterMaxFails", func(t *testing.T) {
+		t.Parallel()
+		t0, t1 := &fakeUpstream{}, &fakeUpstream{}
+		t0.down.Store(true)
+		l := &EjectingLoadBalancer{Targets: newEjectTargets(t0, t1), MaxFails: 3}
+
+		// 6 round-robin calls hit t0 three times, ejecting it.
+		drive(l, 6)
+		assert.Equal(t, int64(3), t0.calls.Load())
+
+		// once ejected, t0 is skipped and all traffic goes to t1.
+		before := t0.calls.Load()
+		drive(l, 10)
+		assert.Equal(t, before, t0.calls.Load(), "ejected target must receive no traffic")
+		assert.Equal(t, int64(13), t1.calls.Load())
+	})
+
+	t.Run("RecoversAfterCooldown", func(t *testing.T) {
+		t.Parallel()
+		t0, t1 := &fakeUpstream{}, &fakeUpstream{}
+		t0.down.Store(true)
+		l := &EjectingLoadBalancer{
+			Targets:      newEjectTargets(t0, t1),
+			MaxFails:     3,
+			EjectTimeout: 20 * time.Millisecond,
+		}
+
+		drive(l, 6) // eject t0
+		ejected := t0.calls.Load()
+		drive(l, 4)
+		assert.Equal(t, ejected, t0.calls.Load(), "still ejected")
+
+		t0.down.Store(false)
+		time.Sleep(40 * time.Millisecond) // let the cooldown expire
+		drive(l, 6)
+		assert.Greater(t, t0.calls.Load(), ejected, "target back in rotation after cooldown")
+	})
+
+	t.Run("SuccessResetsFailures", func(t *testing.T) {
+		t.Parallel()
+		t0 := &fakeUpstream{}
+		t0.down.Store(true)
+		l := &EjectingLoadBalancer{Targets: newEjectTargets(t0), MaxFails: 3}
+
+		drive(l, 2) // two failures, not yet ejected
+		t0.down.Store(false)
+		drive(l, 1) // success resets the counter
+		t0.down.Store(true)
+		drive(l, 2) // two more failures: still below threshold
+
+		assert.Equal(t, int64(0), l.targets[0].ejectedUntil.Load(), "should not be ejected")
+		assert.Equal(t, int32(2), l.targets[0].fails.Load())
+	})
+
+	t.Run("FailsOpenWhenAllEjected", func(t *testing.T) {
+		t.Parallel()
+		t0, t1 := &fakeUpstream{}, &fakeUpstream{}
+		t0.down.Store(true)
+		t1.down.Store(true)
+		l := &EjectingLoadBalancer{Targets: newEjectTargets(t0, t1), MaxFails: 2}
+
+		drive(l, 4) // eject both
+		c0, c1 := t0.calls.Load(), t1.calls.Load()
+
+		// with everything ejected the balancer must still route, not 503.
+		drive(l, 4)
+		assert.Greater(t, t0.calls.Load()+t1.calls.Load(), c0+c1, "must keep routing when all ejected")
+	})
+
+	t.Run("IgnoresClientCancel", func(t *testing.T) {
+		t.Parallel()
+		l := &EjectingLoadBalancer{
+			Targets:  newEjectTargets(&fakeUpstream{}),
+			MaxFails: 3,
+			IsFailure: func(_ *http.Response, err error) bool {
+				// emulate default behavior
+				return err != nil && !errors.Is(err, context.Canceled)
+			},
+		}
+		l.once.Do(l.init)
+		for range 10 {
+			l.record(l.targets[0], nil, fmt.Errorf("canceled: %w", context.Canceled))
+		}
+		assert.Equal(t, int32(0), l.targets[0].fails.Load())
+		assert.Equal(t, int64(0), l.targets[0].ejectedUntil.Load())
+	})
+
+	t.Run("IsFailureHookCountsStatus", func(t *testing.T) {
+		t.Parallel()
+		t0, t1 := &fakeUpstream{status: 500}, &fakeUpstream{}
+		l := &EjectingLoadBalancer{
+			Targets:  newEjectTargets(t0, t1),
+			MaxFails: 3,
+			IsFailure: func(resp *http.Response, err error) bool {
+				return err != nil || (resp != nil && resp.StatusCode >= 500)
+			},
+		}
+		drive(l, 6) // t0 returns 500 three times -> ejected
+		before := t0.calls.Load()
+		drive(l, 8)
+		assert.Equal(t, before, t0.calls.Load(), "5xx target ejected via IsFailure hook")
+	})
+
+	t.Run("ConcurrentBurstIsOneEjection", func(t *testing.T) {
+		t.Parallel()
+		// A burst of simultaneous in-flight failures all cross the threshold; they
+		// must collapse to a single ejection, not inflate the backoff exponent.
+		t0 := &fakeUpstream{}
+		t0.down.Store(true)
+		l := &EjectingLoadBalancer{Targets: newEjectTargets(t0), MaxFails: 3}
+		l.once.Do(l.init)
+		et := l.targets[0]
+
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				l.record(et, nil, errors.New("connection refused"))
+			}()
+		}
+		wg.Wait()
+
+		assert.Positive(t, et.ejectedUntil.Load(), "target is ejected")
+		assert.Equal(t, int32(1), et.ejections.Load(), "a concurrent failure burst counts as exactly one ejection")
+	})
+
+	t.Run("RepeatEjectionGrowsBackoffPerWindow", func(t *testing.T) {
+		t.Parallel()
+		l := &EjectingLoadBalancer{Targets: newEjectTargets(&fakeUpstream{}), MaxFails: 1, EjectTimeout: time.Hour}
+		l.once.Do(l.init)
+		et := l.targets[0]
+
+		l.eject(et)
+		assert.Equal(t, int32(1), et.ejections.Load())
+
+		l.eject(et) // still within the window
+		assert.Equal(t, int32(1), et.ejections.Load(), "re-ejecting within the cooldown does not bump the backoff")
+
+		et.ejectedUntil.Store(0) // simulate the cooldown expiring
+		l.eject(et)
+		assert.Equal(t, int32(2), et.ejections.Load(), "a fresh ejection after cooldown bumps the backoff")
+	})
+}
+
+func TestEjectingLoadBalancerConcurrent(t *testing.T) {
+	t.Parallel()
+	t0, t1 := &fakeUpstream{}, &fakeUpstream{}
+	t0.down.Store(true)
+	l := &EjectingLoadBalancer{Targets: newEjectTargets(t0, t1), MaxFails: 3, EjectTimeout: time.Millisecond}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			drive(l, 50)
+		}()
+	}
+	wg.Wait()
+	// t1 is always healthy, so it must have served traffic.
+	assert.Positive(t, t1.calls.Load())
+}
+
+func TestEjectionTimeoutBackoff(t *testing.T) {
+	t.Parallel()
+	l := &EjectingLoadBalancer{EjectTimeout: time.Second, MaxEjectTimeout: 5 * time.Second}
+	l.once.Do(l.init)
+	assert.Equal(t, time.Second, l.ejectionTimeout(1))
+	assert.Equal(t, 2*time.Second, l.ejectionTimeout(2))
+	assert.Equal(t, 4*time.Second, l.ejectionTimeout(3))
+	assert.Equal(t, 5*time.Second, l.ejectionTimeout(4), "capped at MaxEjectTimeout")
+	assert.Equal(t, 5*time.Second, l.ejectionTimeout(100), "no overflow on large counts")
+}


### PR DESCRIPTION
## What

Adds `upstream.EjectingLoadBalancer` — a round-robin load balancer with **passive health checking (outlier ejection)**. Today `RoundRobinLoadBalancer` keeps sending its 1/N share to a dead target forever; the retry path only papers over this for idempotent, body-less requests. This closes that reliability gap, and it's the natural next step after the new upstream metrics (#216) — which now make ejection *observable*.

Resurrects and hardens closed PR #176 (its branch was deleted). `RoundRobinLoadBalancer` is untouched; this is a drop-in `http.RoundTripper` for `upstream.New(lb)` with no changes elsewhere.

## Behavior

- After `MaxFails` (default 3) **consecutive** failures a target is **ejected** and skipped during selection.
- Ejection lasts `EjectTimeout` (default 30s), **doubling on each repeat ejection** up to `MaxEjectTimeout` (default 5m), so a flapping host isn't hammered.
- When the cooldown expires the target becomes selectable again — **no background goroutine, no lifecycle** (self-healing on the request path).
- A single successful response clears the target's failure count and backoff.
- **Fail-open**: if *every* target is ejected the balancer ignores health and keeps routing, so a transient outage can't black-hole all traffic.
- Failure = transport error other than client `context.Canceled` by default. The optional `IsFailure(resp, err) bool` hook lets callers also count responses such as 5xx.

Per-target state uses atomics, so the hot path stays lock-free; the healthy success path only *loads* (no per-request stores to bounce a cache line).

## Change from #176

The original counted ejections with plain stores on a `>=` threshold, so a **burst of concurrent in-flight failures** to a fresh target each crossed the threshold and each bumped the backoff exponent — one outage could snap the cooldown straight to `MaxEjectTimeout`. `eject()` is now **CAS-gated**: it transitions `ejectedUntil` from a past value to a future one, and whoever loses the race sees the window already open and returns without re-counting. So the backoff grows **once per cooldown window**, not once per failed request. The success-path reset is also read-guarded to keep the healthy hot path store-free.

## Usage

```go
lb := upstream.NewEjectingLoadBalancer([]*upstream.Target{
    {Host: "10.0.0.1:8080", Transport: &upstream.HTTPTransport{}},
    {Host: "10.0.0.2:8080", Transport: &upstream.HTTPTransport{}},
})
lb.MaxFails = 3
lb.EjectTimeout = 30 * time.Second
s.Use(upstream.New(lb))
```

Pair with `prom.Upstream()` (wired into `Upstream.OnRoundTrip`, #216) to watch ejection take effect — traffic shifts off a failing backend in `parapet_upstream_requests{host,status}`.

## Tests

`ejecting_test.go` covers empty targets, defaults, healthy round-robin, ejection after `MaxFails`, recovery after cooldown, success resetting failures, fail-open when all ejected, ignoring client cancellation, the `IsFailure` status hook, and backoff math. Two new tests pin the hardening: **`ConcurrentBurstIsOneEjection`** (50 concurrent failures → `ejections == 1`, deterministic via the CAS) and **`RepeatEjectionGrowsBackoffPerWindow`** (no re-count within a window, +1 after the cooldown expires), plus a concurrent `-race` exercise.

`make` (vet + golangci-lint `0 issues` + `go test -race ./...`) passes. Reviewed with `/scrutinize`: traced the ejection state machine and confirmed it can't under-eject a dead target (`fails` climbs monotonically until `MaxFails` and the CAS gates only the *counter*, not whether ejection happens) and can't double-count across windows; clean interaction with the retry `ErrorHandler` and the `OnRoundTrip` hook. Findings were nits only (passive-health-without-active-probing trade-offs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)