### PR TITLE
feat(upstream): add weighted round-robin and least-connection load balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,29 @@ go func() { for range time.Tick(5 * time.Minute) { pt.Reap(store) } }() // proac
 
 `Snapshot`/`Restore` serialize the table so purges survive a restart (persist however you like). It's the engine [parapet-ingress-controller](https://github.com/moonrhythm/parapet-ingress-controller) builds its control-plane purge distribution on top of.
 
+## Weighted and least-connection load balancing
+
+`upstream.NewRoundRobinLoadBalancer` weights every target equally. Two strategies
+bias by a per-`Target` `Weight` (values `<= 0` count as 1), each optimizing a
+different axis:
+
+- `upstream.NewWeightedRoundRobinLoadBalancer` distributes request **count** in
+  proportion to weight, using smooth weighted round-robin (the nginx algorithm),
+  so a heavy target's picks are interleaved rather than dealt in a burst. With
+  equal weights it is plain round-robin.
+- `upstream.NewLeastConnLoadBalancer` routes each request to the target with the
+  fewest in-flight requests (weighted: lowest `active/Weight`), so it tracks
+  **concurrency** rather than count — which adapts to slow backends and
+  long-lived requests a count-based balancer misses. A request stays counted
+  until its response body is closed, which parapet's reverse proxy always does.
+
+```go
+s.Use(upstream.New(upstream.NewWeightedRoundRobinLoadBalancer([]*upstream.Target{
+	{Host: "10.0.0.1:8080", Transport: &upstream.HTTPTransport{}, Weight: 3},
+	{Host: "10.0.0.2:8080", Transport: &upstream.HTTPTransport{}, Weight: 1},
+})))
+```
+
 ## Load balancing with passive health checks
 
 `upstream.NewRoundRobinLoadBalancer` spreads requests evenly but keeps routing to

--- a/pkg/upstream/leastconn.go
+++ b/pkg/upstream/leastconn.go
@@ -1,0 +1,152 @@
+package upstream
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+// NewLeastConnLoadBalancer creates a least-connection load balancer. Configuration
+// fields are read once, before the first request; set them before serving.
+func NewLeastConnLoadBalancer(targets []*Target) *LeastConnLoadBalancer {
+	return &LeastConnLoadBalancer{Targets: targets}
+}
+
+// LeastConnLoadBalancer routes each request to the target holding the fewest
+// in-flight requests, weighted by Weight: it minimizes active/Weight, so a target
+// with twice the weight is kept at roughly twice the concurrency. Targets with
+// equal load are served round-robin. It balances by concurrent CONNECTIONS (use
+// WeightedRoundRobinLoadBalancer to balance by request count instead), which
+// adapts to slow backends and long-lived requests that a round-robin count misses.
+//
+// A request stays counted as in-flight until its response body is closed, so it
+// must be driven by something that closes the body — parapet's reverse proxy does.
+// Used as a bare http.RoundTripper, the caller must close every response Body (the
+// standard RoundTripper contract) or the target's active count leaks.
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
+type LeastConnLoadBalancer struct {
+	once  sync.Once
+	i     atomic.Uint32 // rotation cursor for breaking equal-load ties
+	peers []lcPeer
+
+	// Targets is the set of upstreams to balance across.
+	Targets []*Target
+}
+
+// lcPeer holds one target's least-connection state.
+type lcPeer struct {
+	target *Target
+	weight int64        // effective weight, >= 1
+	active atomic.Int64 // in-flight requests
+}
+
+func (l *LeastConnLoadBalancer) init() {
+	l.peers = make([]lcPeer, len(l.Targets))
+	for i, t := range l.Targets {
+		l.peers[i].target = t
+		l.peers[i].weight = effectiveWeight(t)
+	}
+}
+
+// RoundTrip sends a request to the least-loaded target and keeps it counted as
+// in-flight until the response body is closed.
+func (l *LeastConnLoadBalancer) RoundTrip(r *http.Request) (*http.Response, error) {
+	l.once.Do(l.init)
+	n := len(l.peers)
+	if n == 0 {
+		return nil, ErrUnavailable
+	}
+
+	p := l.pick(n)
+	p.active.Add(1)
+
+	var once sync.Once
+	dec := func() { once.Do(func() { p.active.Add(-1) }) }
+
+	// Panic-safety: the increment above must be unwound on every exit. transferred
+	// is set only once the decrement is handed off to the response body's Close, so
+	// the defer releases the count on a transport panic (e.g. a nil Transport) or an
+	// early return. dec is sync.Once-guarded, so the defer can never double-decrement
+	// even when an inline branch also called it.
+	transferred := false
+	defer func() {
+		if !transferred {
+			dec()
+		}
+	}()
+
+	r.URL.Host = p.target.Host
+	resp, err := p.target.Transport.RoundTrip(r)
+
+	if err != nil || resp == nil || resp.Body == nil {
+		// No body to own (resp is nil on a real transport error); balance now. The
+		// inline path and the wrapper path are mutually exclusive per attempt and
+		// share one sync.Once, so exactly-once holds even for a misbehaving transport.
+		dec()
+		return resp, err
+	}
+
+	// Success: headers arrived but the upstream connection is held until the proxy
+	// finishes streaming and closes the body, so hand the decrement to Body.Close.
+	// Preserve the body's interface set: httputil.ReverseProxy type-asserts
+	// res.Body.(io.ReadWriteCloser) on a 101 Switching Protocols upgrade, so a plain
+	// io.ReadCloser wrapper would break WebSocket/upgrade traffic.
+	if rwc, ok := resp.Body.(io.ReadWriteCloser); ok {
+		resp.Body = &lcRWCBody{ReadWriteCloser: rwc, dec: dec}
+	} else {
+		resp.Body = &lcBody{ReadCloser: resp.Body, dec: dec}
+	}
+	transferred = true
+	return resp, nil
+}
+
+// pick scans for the target with the lowest active/weight, starting from a
+// rotating cursor so equal-load targets are served round-robin. The comparison
+// cross-multiplies (a/c.weight < bestA/best.weight  <=>  a*best.weight <
+// bestA*c.weight) to stay integer-only; with realistic weights and concurrency the
+// int64 products have ample headroom. It does atomic loads only — a momentary
+// near-tie that misroutes self-corrects on the next pick.
+func (l *LeastConnLoadBalancer) pick(n int) *lcPeer {
+	start := l.i.Add(1) - 1
+	best := &l.peers[start%uint32(n)]
+	bestA := best.active.Load()
+	for k := uint32(1); k < uint32(n); k++ {
+		c := &l.peers[(start+k)%uint32(n)]
+		a := c.active.Load()
+		if a*best.weight < bestA*c.weight {
+			best, bestA = c, a
+		}
+	}
+	return best
+}
+
+// lcBody decrements the target's active count when the response body is closed.
+type lcBody struct {
+	io.ReadCloser
+	dec func() // already sync.Once-guarded
+}
+
+func (b *lcBody) Close() error {
+	err := b.ReadCloser.Close() // close underlying first (returns the conn to the pool)
+	b.dec()
+	return err
+}
+
+// lcRWCBody is lcBody for a body that is also writable, preserving the
+// io.ReadWriteCloser interface so the 101 upgrade path in httputil.ReverseProxy
+// still type-asserts the body successfully. Embedding only the interface erases
+// the underlying conn's io.ReaderFrom, so io.Copy on the raw upgrade tunnel can't
+// splice — a marginal throughput cost on WebSocket/upgrade traffic only, never on
+// normal response bodies (which are copied via Read).
+type lcRWCBody struct {
+	io.ReadWriteCloser
+	dec func() // already sync.Once-guarded
+}
+
+func (b *lcRWCBody) Close() error {
+	err := b.ReadWriteCloser.Close()
+	b.dec()
+	return err
+}

--- a/pkg/upstream/leastconn_test.go
+++ b/pkg/upstream/leastconn_test.go
@@ -1,0 +1,186 @@
+package upstream
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// funcTransport adapts a function to http.RoundTripper, for returning crafted
+// responses (fresh per call).
+type funcTransport func(*http.Request) (*http.Response, error)
+
+func (f funcTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// errTransport always fails before a response (no body to own).
+type errTransport struct{}
+
+func (errTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("dial tcp: connection refused")
+}
+
+// countingBody is an io.ReadCloser that counts its Close calls.
+type countingBody struct{ closes atomic.Int32 }
+
+func (b *countingBody) Read([]byte) (int, error) { return 0, io.EOF }
+func (b *countingBody) Close() error             { b.closes.Add(1); return nil }
+
+// rwcBody is an io.ReadWriteCloser, as the body of a 101 Switching Protocols
+// upgrade response is (httputil.ReverseProxy type-asserts it).
+type rwcBody struct{ closed atomic.Bool }
+
+func (b *rwcBody) Read([]byte) (int, error)    { return 0, io.EOF }
+func (b *rwcBody) Write(p []byte) (int, error) { return len(p), nil }
+func (b *rwcBody) Close() error                { b.closed.Store(true); return nil }
+
+func bodyResp(status int, body io.ReadCloser) funcTransport {
+	return func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: status, Body: body, Header: http.Header{}}, nil
+	}
+}
+
+func TestLeastConnLoadBalancer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Empty", func(t *testing.T) {
+		l := NewLeastConnLoadBalancer(nil)
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Nil(t, resp)
+		assert.Equal(t, ErrUnavailable, err)
+	})
+
+	t.Run("SingleTargetBalancesToZero", func(t *testing.T) {
+		rec := &recordingTransport{}
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: rec}})
+		driveLB(l, 5)
+		assert.Equal(t, map[string]int{"t0": 5}, rec.counts())
+		assert.EqualValues(t, 0, l.peers[0].active.Load(), "every request closed -> no in-flight")
+	})
+
+	t.Run("EqualLoadIsRoundRobin", func(t *testing.T) {
+		rec := &recordingTransport{}
+		l := NewLeastConnLoadBalancer([]*Target{
+			{Host: "t0", Transport: rec}, {Host: "t1", Transport: rec}, {Host: "t2", Transport: rec},
+		})
+		driveLB(l, 6) // each body closed, so every pick sees all-zero load
+		assert.Equal(t, []string{"t0", "t1", "t2", "t0", "t1", "t2"}, rec.hits)
+	})
+
+	t.Run("WeightedConcurrencyShare", func(t *testing.T) {
+		// weight 2 vs 1, three requests held in-flight: the heavy target carries 2x.
+		l := NewLeastConnLoadBalancer([]*Target{
+			{Host: "heavy", Transport: bodyResp(200, &countingBody{}), Weight: 2},
+			{Host: "light", Transport: bodyResp(200, &countingBody{}), Weight: 1},
+		})
+		var held []*http.Response
+		for range 3 {
+			resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			require.NoError(t, err)
+			held = append(held, resp) // do NOT close: keep it in-flight
+		}
+		assert.EqualValues(t, 2, l.peers[0].active.Load(), "weight-2 holds two in-flight")
+		assert.EqualValues(t, 1, l.peers[1].active.Load(), "weight-1 holds one in-flight")
+
+		for _, resp := range held {
+			resp.Body.Close()
+		}
+		assert.EqualValues(t, 0, l.peers[0].active.Load())
+		assert.EqualValues(t, 0, l.peers[1].active.Load())
+	})
+
+	t.Run("ExactlyOnceOnSuccessDoubleClose", func(t *testing.T) {
+		body := &countingBody{}
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: bodyResp(200, body)}})
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, l.peers[0].active.Load())
+
+		require.NoError(t, resp.Body.Close())
+		_ = resp.Body.Close() // double close
+		assert.EqualValues(t, 0, l.peers[0].active.Load(), "active decremented once despite double close")
+		assert.EqualValues(t, 2, body.closes.Load(), "underlying Close forwarded each time")
+	})
+
+	t.Run("ExactlyOnceOnError", func(t *testing.T) {
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: errTransport{}}})
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Nil(t, resp)
+		assert.Error(t, err)
+		assert.EqualValues(t, 0, l.peers[0].active.Load(), "error path decremented inline, no leak")
+	})
+
+	t.Run("PreservesReadWriteCloserFor101", func(t *testing.T) {
+		// The WebSocket/upgrade regression guard: the default recorder body is NOT an
+		// io.ReadWriteCloser, so this MUST supply one, or the lcRWCBody path is never
+		// exercised and the guard tests nothing.
+		body := &rwcBody{}
+		l := NewLeastConnLoadBalancer([]*Target{
+			{Host: "t0", Transport: bodyResp(http.StatusSwitchingProtocols, body)},
+		})
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		require.NoError(t, err)
+
+		_, ok := resp.Body.(io.ReadWriteCloser)
+		assert.True(t, ok, "101 upgrade body must stay an io.ReadWriteCloser for ReverseProxy")
+		assert.EqualValues(t, 1, l.peers[0].active.Load())
+
+		require.NoError(t, resp.Body.Close())
+		assert.True(t, body.closed.Load(), "underlying upgrade conn closed")
+		assert.EqualValues(t, 0, l.peers[0].active.Load())
+	})
+
+	t.Run("NilBodyGuard", func(t *testing.T) {
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: bodyResp(204, nil)}})
+		assert.NotPanics(t, func() {
+			resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+		})
+		assert.EqualValues(t, 0, l.peers[0].active.Load(), "nil-body response decremented inline")
+	})
+
+	t.Run("PanicSafetyReleasesActive", func(t *testing.T) {
+		// A nil Transport panics inside RoundTrip after the increment; the deferred
+		// release must unwind it, or least-conn would progressively black-hole the peer.
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: nil}})
+		assert.Panics(t, func() {
+			_, _ = l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		})
+		assert.EqualValues(t, 0, l.peers[0].active.Load(), "panic must not leak the in-flight count")
+	})
+
+	t.Run("NoLeakUnderConcurrencyMixedErrors", func(t *testing.T) {
+		// Mixed success and error targets, heavy concurrency, every body closed: each
+		// attempt balances its own inc/dec (this also covers the retry re-entry path),
+		// so all counters return to zero.
+		l := NewLeastConnLoadBalancer([]*Target{
+			{Host: "ok", Transport: &recordingTransport{}},
+			{Host: "bad", Transport: errTransport{}},
+		})
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				driveLB(l, 50)
+			}()
+		}
+		wg.Wait()
+		assert.EqualValues(t, 0, l.peers[0].active.Load(), "ok target balanced")
+		assert.EqualValues(t, 0, l.peers[1].active.Load(), "error target balanced")
+	})
+}
+
+func TestEffectiveWeight(t *testing.T) {
+	t.Parallel()
+	assert.EqualValues(t, 1, effectiveWeight(&Target{Weight: 0}), "unset weight defaults to 1")
+	assert.EqualValues(t, 1, effectiveWeight(&Target{Weight: -5}), "negative weight defaults to 1")
+	assert.EqualValues(t, 3, effectiveWeight(&Target{Weight: 3}))
+}

--- a/pkg/upstream/loadbalancer.go
+++ b/pkg/upstream/loadbalancer.go
@@ -9,6 +9,24 @@ import (
 type Target struct {
 	Transport http.RoundTripper
 	Host      string
+
+	// Weight biases the weighted balancers toward this target:
+	// WeightedRoundRobinLoadBalancer gives it a proportionally larger share of the
+	// request COUNT; LeastConnLoadBalancer lets it hold a proportionally larger
+	// share of concurrent in-flight requests. Values <= 0 are treated as 1.
+	// RoundRobinLoadBalancer and EjectingLoadBalancer ignore this field and weight
+	// every target equally.
+	Weight int
+}
+
+// effectiveWeight normalizes a target's weight for the weighted balancers: a
+// non-positive Weight means "unset" and counts as 1. It is the single source of
+// the default rule, applied once at init so the hot path never re-reads Weight.
+func effectiveWeight(t *Target) int64 {
+	if t.Weight <= 0 {
+		return 1
+	}
+	return int64(t.Weight)
 }
 
 // NewRoundRobinLoadBalancer creates new round-robin load balancer

--- a/pkg/upstream/weighted.go
+++ b/pkg/upstream/weighted.go
@@ -1,0 +1,84 @@
+package upstream
+
+import (
+	"net/http"
+	"sync"
+)
+
+// NewWeightedRoundRobinLoadBalancer creates a weighted round-robin load balancer
+// using smooth weighted round-robin (SWRR). Each target receives a share of
+// requests proportional to its Weight; targets with equal weight are served in
+// plain round-robin order. Configuration fields are read once, before the first
+// request; set them before serving.
+func NewWeightedRoundRobinLoadBalancer(targets []*Target) *WeightedRoundRobinLoadBalancer {
+	return &WeightedRoundRobinLoadBalancer{Targets: targets}
+}
+
+// WeightedRoundRobinLoadBalancer distributes requests across targets in
+// proportion to their Weight, using smooth weighted round-robin (the nginx
+// algorithm): a heavy target's picks are interleaved with the others rather than
+// dealt in a burst, and the long-run share is exactly Weight/sum(Weight). With
+// all weights equal it degenerates to plain index-order round-robin.
+//
+// It balances by request COUNT (use LeastConnLoadBalancer to balance by
+// concurrent in-flight requests instead).
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
+type WeightedRoundRobinLoadBalancer struct {
+	once  sync.Once
+	mu    sync.Mutex
+	total int64
+	peers []swrrPeer
+
+	// Targets is the set of upstreams to balance across.
+	Targets []*Target
+}
+
+// swrrPeer holds one target's smooth-weighted-round-robin state.
+type swrrPeer struct {
+	target  *Target
+	weight  int64 // effective weight, >= 1; immutable after init
+	current int64 // running currentWeight, guarded by the balancer's mu
+}
+
+func (l *WeightedRoundRobinLoadBalancer) init() {
+	l.peers = make([]swrrPeer, len(l.Targets))
+	for i, t := range l.Targets {
+		w := effectiveWeight(t)
+		l.peers[i] = swrrPeer{target: t, weight: w}
+		l.total += w // int64; realistic weights (≤ thousands) leave ample headroom
+	}
+}
+
+// RoundTrip sends a request to the next weighted target.
+func (l *WeightedRoundRobinLoadBalancer) RoundTrip(r *http.Request) (*http.Response, error) {
+	l.once.Do(l.init)
+	if len(l.peers) == 0 {
+		return nil, ErrUnavailable
+	}
+
+	t := l.pick()
+	r.URL.Host = t.Host
+	return t.Transport.RoundTrip(r)
+}
+
+// pick runs one SWRR step under the lock and returns the chosen target. Each peer
+// gains its weight, the largest currentWeight wins, and the winner gives back the
+// total; the sum of all currentWeights is invariantly zero across a pick, so the
+// ratios never drift. The lock covers only the integer loop — the network
+// round-trip happens after it is released.
+func (l *WeightedRoundRobinLoadBalancer) pick() *Target {
+	l.mu.Lock()
+	best := -1
+	for i := range l.peers {
+		p := &l.peers[i]
+		p.current += p.weight
+		if best < 0 || p.current > l.peers[best].current {
+			best = i
+		}
+	}
+	l.peers[best].current -= l.total
+	t := l.peers[best].target
+	l.mu.Unlock()
+	return t
+}

--- a/pkg/upstream/weighted_test.go
+++ b/pkg/upstream/weighted_test.go
@@ -1,0 +1,113 @@
+package upstream
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// recordingTransport records the resolved host of every round-trip, across all
+// targets that share it. Safe for concurrent use. Shared by the weighted and
+// least-connection tests.
+type recordingTransport struct {
+	mu   sync.Mutex
+	hits []string
+}
+
+func (t *recordingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	t.hits = append(t.hits, r.URL.Host)
+	t.mu.Unlock()
+	return httptest.NewRecorder().Result(), nil
+}
+
+func (t *recordingTransport) counts() map[string]int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	m := map[string]int{}
+	for _, h := range t.hits {
+		m[h]++
+	}
+	return m
+}
+
+// driveLB issues n requests through a balancer, closing each response body so an
+// in-flight count (least-conn) is released between calls.
+func driveLB(l http.RoundTripper, n int) {
+	for range n {
+		resp, _ := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}
+}
+
+// weightedTargets builds targets host "t0","t1",... sharing one recording transport.
+func weightedTargets(rec *recordingTransport, weights ...int) []*Target {
+	targets := make([]*Target, len(weights))
+	for i, w := range weights {
+		targets[i] = &Target{Host: fmt.Sprintf("t%d", i), Transport: rec, Weight: w}
+	}
+	return targets
+}
+
+func TestWeightedRoundRobinLoadBalancer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Empty", func(t *testing.T) {
+		l := NewWeightedRoundRobinLoadBalancer(nil)
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Nil(t, resp)
+		assert.Equal(t, ErrUnavailable, err)
+	})
+
+	t.Run("SingleTarget", func(t *testing.T) {
+		rec := &recordingTransport{}
+		l := NewWeightedRoundRobinLoadBalancer(weightedTargets(rec, 0))
+		driveLB(l, 5)
+		assert.Equal(t, map[string]int{"t0": 5}, rec.counts())
+	})
+
+	t.Run("EqualWeightsIsPlainRoundRobin", func(t *testing.T) {
+		rec := &recordingTransport{}
+		l := NewWeightedRoundRobinLoadBalancer(weightedTargets(rec, 0, 0, 0)) // 0 -> 1
+		driveLB(l, 6)
+		assert.Equal(t, []string{"t0", "t1", "t2", "t0", "t1", "t2"}, rec.hits)
+	})
+
+	t.Run("DistributionAndSmoothness", func(t *testing.T) {
+		rec := &recordingTransport{}
+		l := NewWeightedRoundRobinLoadBalancer(weightedTargets(rec, 5, 1, 1))
+
+		driveLB(l, 7) // one full SWRR cycle
+		assert.Equal(t, []string{"t0", "t0", "t1", "t0", "t2", "t0", "t0"}, rec.hits,
+			"heavy target is interleaved, not dealt in a burst")
+
+		driveLB(l, 693) // 700 total = 100 cycles
+		assert.Equal(t, map[string]int{"t0": 500, "t1": 100, "t2": 100}, rec.counts(),
+			"exact long-run ratio 5:1:1")
+	})
+
+	t.Run("Concurrent", func(t *testing.T) {
+		rec := &recordingTransport{}
+		l := NewWeightedRoundRobinLoadBalancer(weightedTargets(rec, 3, 2, 1))
+		var wg sync.WaitGroup
+		for range 50 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				driveLB(l, 60)
+			}()
+		}
+		wg.Wait()
+		total := 0
+		for _, c := range rec.counts() {
+			total += c
+		}
+		assert.Equal(t, 3000, total, "every pick recorded; no lost/duplicated pick under -race")
+	})
+}


### PR DESCRIPTION
## What

`RoundRobinLoadBalancer` weights every target equally. This adds two strategies that bias by a per-`Target` `Weight` (values `<= 0` count as 1), each optimizing a **different axis** — completing the upstream load-balancing surface after passive health checks (#217).

**Purely additive**: `Target` gains one `Weight` field; `RoundRobinLoadBalancer` and `EjectingLoadBalancer` ignore it and are byte-for-byte unaffected.

## The two strategies

- **`WeightedRoundRobinLoadBalancer`** — distributes request **count** in proportion to weight, using **smooth weighted round-robin** (the nginx algorithm): a heavy target's picks are *interleaved* (`a,a,b,a,c,a,a` for `{5,1,1}`), not dealt in a burst, and the long-run ratio is exact. Equal weights degenerate to plain round-robin. The pick is an O(n) integer loop under a short mutex, released before the network call.
- **`LeastConnLoadBalancer`** — routes to the target with the fewest in-flight requests (weighted: lowest `active/Weight`), tracking **concurrency** rather than count, so it adapts to slow backends and long-lived requests a count-based balancer misses. Per-target `active` counts are atomics; the pick is a lock-free min scan via integer cross-multiplication with a rotating tie-break cursor.

```go
s.Use(upstream.New(upstream.NewWeightedRoundRobinLoadBalancer([]*upstream.Target{
    {Host: "10.0.0.1:8080", Transport: &upstream.HTTPTransport{}, Weight: 3},
    {Host: "10.0.0.2:8080", Transport: &upstream.HTTPTransport{}, Weight: 1},
})))
```

## The load-bearing detail: least-conn exactly-once accounting

A least-conn request must stay counted from selection until the **connection's true end** — which outlives `RoundTrip`'s return (that happens at *headers*; the conn is held until `ReverseProxy` closes the body). The decrement is **exactly-once** across every exit, all collapsed through one `sync.Once`:

- **success** → handed to a `Body.Close` wrapper;
- **transport error / nil body** → fired inline;
- **panic** (e.g. a nil `Transport`) → released by a `defer`/`transferred` guard so the counter can't leak and progressively black-hole the peer;
- **double-close** → `sync.Once` makes it idempotent.

The `Body.Close` wrapper **preserves the body's `io.ReadWriteCloser` interface** so **101 Switching Protocols** (WebSocket/upgrade) traffic — which `httputil.ReverseProxy` type-asserts — keeps working; a plain `io.ReadCloser` wrapper would break upgrades with "non-writable body".

## Tests

`weighted_test.go` / `leastconn_test.go` (package-internal, `-race`): empty/single/equal-weights-is-round-robin for both; exact SWRR distribution (the `5,1,1` smooth cycle + 500/100/100 over 700) and concurrency; least-conn weighted concurrency share (held-open in-flight requests → heavy target carries 2×), double-close, transport-error and nil-body exit paths, **panic-safety** (nil `Transport` → `active` returns to 0), a **real 101-upgrade regression guard** (custom `io.ReadWriteCloser` body — the default recorder body isn't one, so the guard would otherwise silently pass), and a mixed-error concurrency no-leak sweep.

## How it was built

A **design workflow** (3 independent proposals → synthesis → 2 adversarial critiques) produced the spec and caught two things before any code: the **panic-leak** (now fixed with the `defer` guard) and that the **101 test must supply a custom RWC body** or it tests nothing. `/scrutinize` then traced the implementation's six decrement exits and the SWRR zero-sum invariant and returned **ship**; its two doc nits are applied.

`make` (vet + golangci-lint `0 issues` + `go test -race ./...`) passes; `Target`'s new field is `fieldalignment`-clean with no `//nolint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)