### PR TITLE
feat(upstream): add LatencyEjectingLoadBalancer (gray-failure outlier ejection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,25 @@ Use `EjectingLoadBalancer` when you want fail-*open* (keep routing during a tota
 outage); use `CircuitBreakingLoadBalancer` when you want fail-*fast* (shed load).
 The same `IsFailure` hook applies. Both ignore `Target.Weight`.
 
+`upstream.NewLatencyEjectingLoadBalancer` catches what those two miss — a **gray
+failure**, a backend still returning 200s but far slower than its peers. A target
+whose decayed mean time-to-first-byte exceeds `EjectionFactor` × the **pool median**
+is ejected and re-probed. Because the test is relative to the pool, it self-tunes: a
+uniform slowdown raises every target and the median together, so no one is an
+outlier (guard rails — a max-ejection cap and a panic threshold — keep a systemic
+slowdown from draining the pool). It is latency-only: pair it with the circuit
+breaker or `EjectingLoadBalancer` for error ejection.
+
+```go
+lb := upstream.NewLatencyEjectingLoadBalancer([]*upstream.Target{
+	{Host: "10.0.0.1:8080", Transport: &upstream.HTTPTransport{}},
+	{Host: "10.0.0.2:8080", Transport: &upstream.HTTPTransport{}},
+	{Host: "10.0.0.3:8080", Transport: &upstream.HTTPTransport{}},
+})
+lb.EjectionFactor = 3 // eject a target 3× slower than the pool median
+s.Use(upstream.New(lb))
+```
+
 ## Trusted proxies
 
 Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes from a trusted CIDR. Configure trust with `TrustCIDRs(...)` or accept the defaults from `Trusted()` (standard private and loopback ranges). Servers created with `NewFrontend()` start with no trusted proxies by default.

--- a/pkg/upstream/ejecting_test.go
+++ b/pkg/upstream/ejecting_test.go
@@ -18,13 +18,17 @@ import (
 type fakeUpstream struct {
 	calls  atomic.Int64
 	down   atomic.Bool
-	status int // response status when up; 0 means 200
+	delay  atomic.Int64 // response delay in nanos (for latency tests); 0 = none
+	status int          // response status when up; 0 means 200
 }
 
 func (t *fakeUpstream) RoundTrip(*http.Request) (*http.Response, error) {
 	t.calls.Add(1)
 	if t.down.Load() {
 		return nil, errors.New("dial tcp: connection refused")
+	}
+	if d := t.delay.Load(); d > 0 {
+		time.Sleep(time.Duration(d))
 	}
 	w := httptest.NewRecorder()
 	if t.status != 0 {

--- a/pkg/upstream/example_test.go
+++ b/pkg/upstream/example_test.go
@@ -114,6 +114,24 @@ func ExampleNewCircuitBreakingLoadBalancer() {
 	s.Use(upstream.New(lb))
 }
 
+// Catch a "gray failure" — a backend still returning 200s but far slower than its
+// peers — that error-based ejection misses. A target whose mean latency exceeds
+// EjectionFactor x the pool median is ejected and re-probed. A uniform slowdown
+// ejects no one (it self-tunes against the pool median).
+func ExampleNewLatencyEjectingLoadBalancer() {
+	tr := &upstream.HTTPTransport{}
+	lb := upstream.NewLatencyEjectingLoadBalancer([]*upstream.Target{
+		{Host: "10.0.0.1:8080", Transport: tr},
+		{Host: "10.0.0.2:8080", Transport: tr},
+		{Host: "10.0.0.3:8080", Transport: tr},
+	})
+	lb.EjectionFactor = 3      // eject a target 3x slower than the pool median
+	lb.HalfLife = 10 * time.Second
+
+	s := parapet.New()
+	s.Use(upstream.New(lb))
+}
+
 // Observe each origin round-trip via OnRoundTrip — invoked once per attempt with
 // the resolved target, status, latency, and error. Wire it to metrics or logging
 // (see prom.Upstream); here it just inspects the info.

--- a/pkg/upstream/latencyejecting.go
+++ b/pkg/upstream/latencyejecting.go
@@ -1,0 +1,363 @@
+package upstream
+
+import (
+	"math"
+	"net/http"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Latency-ejecting load balancer defaults.
+const (
+	defaultEjectionFactor     = 3.0
+	defaultLatMinSamples      = 100
+	defaultLatMinHosts        = 3
+	defaultHalfLife           = 10 * time.Second
+	defaultMinEjectDelta      = 50 * time.Millisecond
+	defaultMaxEjectionPercent = 30
+	defaultPanicThreshold     = 50
+	// EjectTimeout / MaxEjectTimeout reuse ejecting.go's defaultEjectTimeout (30s)
+	// and defaultMaxEjectTimeout (5m).
+)
+
+// NewLatencyEjectingLoadBalancer creates a round-robin load balancer with passive
+// latency-based outlier ejection.
+func NewLatencyEjectingLoadBalancer(targets []*Target) *LatencyEjectingLoadBalancer {
+	return &LatencyEjectingLoadBalancer{Targets: targets}
+}
+
+// LatencyEjectingLoadBalancer is a round-robin load balancer that ejects a "gray
+// failure" — a target that keeps returning 200s but whose mean time-to-first-byte
+// has crept far above its peers, which error-based ejection and the circuit breaker
+// both miss. A target whose decayed mean TTFB exceeds EjectionFactor x the pool
+// median (and a small absolute slack) is taken out of rotation for a backed-off
+// cooldown and passively re-probed, reusing EjectingLoadBalancer's eject mechanics.
+//
+// It is LATENCY-ONLY: a transport error is not timed (a ~0ns connection-refused
+// would falsely lower the mean and make a dead host look fast) and does not eject a
+// target here. An Upstream uses one balancer, so if hard errors are your dominant
+// failure mode use EjectingLoadBalancer or the circuit breaker INSTEAD (they do not
+// catch gray failures) — choose by failure mode. When all targets are ejected, or
+// when more than
+// PanicThreshold% are (a systemic slowdown), it FAILS OPEN and routes to all,
+// including the slow ones: a slow-but-up host beats a 503. This is deliberately the
+// opposite of CircuitBreakingLoadBalancer, which sheds load — appropriate because a
+// latency outlier is still serving.
+//
+// Detection is relative-to-pool, so it self-tunes: a uniform slowdown raises every
+// target and the median together, so no one is an outlier. Two structural limits
+// follow from that: a pool of fewer than MinHosts never latency-ejects (you cannot
+// name an outlier without a baseline), and a slowdown affecting a MAJORITY of the
+// pool is not detected (the slow hosts become the median) — that is a systemic
+// event, handled by failing open, not a per-host outlier. It also tracks the MEAN,
+// so a tail-only regression (healthy median, fat p99) is not caught, and it assumes
+// targets see statistically similar traffic — a target fronting heavier routes can
+// read as a false outlier. Weight is ignored. State is per-target atomics; the hot
+// path is lock-free. Configuration fields are read once; set them before serving.
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
+type LatencyEjectingLoadBalancer struct {
+	once  sync.Once
+	i     atomic.Uint32 // round-robin cursor
+	tau   float64       // HalfLife / ln2, precomputed in init
+	peers []latPeer     // per-target state, built in init
+
+	// Targets is the set of upstreams to balance across.
+	Targets []*Target
+
+	// EjectionFactor ejects a target whose decayed mean TTFB is >= the pool median
+	// times this. Must be > 1 (a factor <= 1 would eject the median itself).
+	// Defaults to 3.0; below ~2.0 is aggressive (ejects on normal tail jitter).
+	EjectionFactor float64
+
+	// MinSamples is the number of measured round-trips a target must accumulate
+	// before it is eligible to be ejected or to count toward the pool median. It
+	// gates cold-start noise (a first request's TLS handshake / cold pool) and, since
+	// a re-probed target's sample count is reset on ejection, also gates re-probes.
+	// Defaults to 100.
+	MinSamples uint64
+
+	// MinHosts is the minimum number of eligible targets for a valid pool median; a
+	// pool with fewer never latency-ejects. Defaults to 3 (a median needs >= ~3 to be
+	// robust to the outlier it is meant to expose).
+	MinHosts int
+
+	// HalfLife is the wall-clock half-life of the time-decayed latency EWMA, so the
+	// effective window is independent of a target's request rate. Defaults to 10s.
+	HalfLife time.Duration
+
+	// MinEjectDelta is an additive floor: a target must also exceed the median by at
+	// least this to be ejected, which kills the ratio instability of a fast pool (3ms
+	// is 3x a 1ms median but operationally irrelevant). Defaults to 50ms.
+	MinEjectDelta time.Duration
+
+	// MinEjectLatency is an absolute floor: a target below it is never ejected,
+	// however slow it is relative to peers. Defaults to 0 (off).
+	MinEjectLatency time.Duration
+
+	// MaxEjectionPercent caps the fraction of the pool that may be latency-ejected at
+	// once, so the pool cannot progressively drain. Defaults to 30. It is a near-hard
+	// cap: a concurrent burst of decisions can transiently overshoot it by the
+	// in-flight concurrency (the counts are lock-free scans), self-correcting as
+	// cooldowns expire — the exact anti-oscillation guarantee comes from the median
+	// being robust, not from this count.
+	MaxEjectionPercent int
+
+	// PanicThreshold: if more than this percent of the pool is ejected, the slowdown
+	// is treated as systemic — no further ejections happen and pick routes to all
+	// targets (including slow ones). Defaults to 50; init raises it above
+	// MaxEjectionPercent so it is never dead code.
+	PanicThreshold int
+
+	// EjectTimeout is the base cooldown a target stays ejected, doubling on each
+	// repeat ejection up to MaxEjectTimeout. Defaults to 30s.
+	EjectTimeout time.Duration
+
+	// MaxEjectTimeout caps the ejection cooldown. Defaults to 5m.
+	MaxEjectTimeout time.Duration
+}
+
+// latPeer holds one target's latency-ejection state. ewmaBits is the single source
+// of truth for the decayed mean TTFB.
+//
+//nolint:govet // fields grouped by role for readability
+type latPeer struct {
+	target       *Target
+	ewmaBits     atomic.Uint64 // math.Float64bits(decayed mean TTFB, ns); 0 = unseeded
+	lastNanos    atomic.Int64  // unix nanos basis of the committed ewma (decay dt)
+	samples      atomic.Uint64 // measured round-trips since (re-)admission; gates eligibility
+	ejections    atomic.Int32  // consecutive ejection episodes -> backoff exponent
+	ejectedUntil atomic.Int64  // unix nanos; <= now means selectable
+}
+
+func (l *LatencyEjectingLoadBalancer) init() {
+	if l.EjectionFactor <= 1 {
+		l.EjectionFactor = defaultEjectionFactor
+	}
+	if l.MinSamples == 0 {
+		l.MinSamples = defaultLatMinSamples
+	}
+	if l.MinHosts < 2 {
+		l.MinHosts = defaultLatMinHosts
+	}
+	if l.HalfLife <= 0 {
+		l.HalfLife = defaultHalfLife
+	}
+	if l.MinEjectDelta <= 0 {
+		l.MinEjectDelta = defaultMinEjectDelta
+	}
+	if l.MaxEjectionPercent <= 0 || l.MaxEjectionPercent > 100 {
+		l.MaxEjectionPercent = defaultMaxEjectionPercent
+	}
+	if l.PanicThreshold <= 0 || l.PanicThreshold > 100 {
+		l.PanicThreshold = defaultPanicThreshold
+	}
+	if l.PanicThreshold <= l.MaxEjectionPercent {
+		l.PanicThreshold = l.MaxEjectionPercent + 1 // panic must sit above the cap, never dead code
+	}
+	if l.EjectTimeout <= 0 {
+		l.EjectTimeout = defaultEjectTimeout
+	}
+	if l.MaxEjectTimeout <= 0 {
+		l.MaxEjectTimeout = defaultMaxEjectTimeout
+	}
+	if l.MaxEjectTimeout < l.EjectTimeout {
+		l.MaxEjectTimeout = l.EjectTimeout
+	}
+	l.tau = float64(l.HalfLife) / math.Ln2
+
+	l.peers = make([]latPeer, len(l.Targets))
+	for i, t := range l.Targets {
+		l.peers[i].target = t
+	}
+}
+
+// RoundTrip picks a target, times the round-trip, and records the latency.
+func (l *LatencyEjectingLoadBalancer) RoundTrip(r *http.Request) (*http.Response, error) {
+	l.once.Do(l.init)
+
+	n := len(l.peers)
+	if n == 0 {
+		return nil, ErrUnavailable
+	}
+
+	p := l.pick(n)
+	r.URL.Host = p.target.Host
+	start := time.Now()
+	resp, err := p.target.Transport.RoundTrip(r)
+	l.record(p, time.Since(start), resp, err)
+	return resp, err
+}
+
+// pick selects the next selectable target round-robin, skipping ejected ones. If
+// more than PanicThreshold% are ejected the slowdown is systemic — it routes to all
+// targets. If somehow every target is ejected it fails open to the round-robin slot
+// (never ErrUnavailable for a non-empty pool: an ejected target here is slow, not
+// dead, so it is a usable fallback).
+func (l *LatencyEjectingLoadBalancer) pick(n int) *latPeer {
+	start := l.i.Add(1) - 1
+	now := time.Now().UnixNano()
+	if l.ejectedCount(now)*100 > l.PanicThreshold*n {
+		return &l.peers[start%uint32(n)] // panic: distrust the signal, spread to all
+	}
+	for k := uint32(0); k < uint32(n); k++ {
+		p := &l.peers[(start+k)%uint32(n)]
+		if p.ejectedUntil.Load() <= now {
+			return p
+		}
+	}
+	return &l.peers[start%uint32(n)] // all ejected -> fail open
+}
+
+// record feeds a completed round-trip's latency into the target's EWMA and runs the
+// relative-to-pool outlier test. A transport error is not a latency sample.
+func (l *LatencyEjectingLoadBalancer) record(p *latPeer, d time.Duration, resp *http.Response, err error) {
+	if err != nil || resp == nil {
+		return // only a real response has a meaningful TTFB; errors are not this balancer's job
+	}
+
+	now := time.Now().UnixNano()
+	cur, n := p.observe(float64(d), now, l.tau)
+	if n < l.MinSamples {
+		return // cold-start / re-probe gate
+	}
+
+	median, eligible := l.poolMedian()
+	if eligible < l.MinHosts {
+		return // no valid baseline: cannot name an outlier; do not heal (preserve backoff)
+	}
+
+	// Within tolerance under a valid baseline => genuine recovery (or never slow).
+	if cur < median*l.EjectionFactor || cur < median+float64(l.MinEjectDelta) || cur < float64(l.MinEjectLatency) {
+		l.maybeHeal(p)
+		return
+	}
+
+	// Outlier. Pool-level guard rails before ejecting.
+	now = time.Now().UnixNano()
+	ej := l.ejectedCount(now)
+	if (ej+1)*100 > l.PanicThreshold*len(l.peers) {
+		return // systemic (panic): eject none
+	}
+	if (ej+1)*100 > l.MaxEjectionPercent*len(l.peers) {
+		return // at the cap: keep it in rotation (slow but serving)
+	}
+	l.eject(p)
+}
+
+// observe applies one sample to the lock-free time-decayed EWMA and returns the new
+// mean and the post-increment sample count.
+func (p *latPeer) observe(sample float64, now int64, tau float64) (cur float64, n uint64) {
+	n = p.samples.Add(1)
+	for {
+		oldBits := p.ewmaBits.Load()
+		var next float64
+		if oldBits == 0 {
+			// Unseeded: seed exactly. math.Float64bits(0)==0 and no real TTFB is 0ns,
+			// so 0 unambiguously means "no value yet" — do not store a computed 0.
+			next = sample
+		} else {
+			dt := float64(now - p.lastNanos.Load())
+			if dt < 0 {
+				dt = 0 // clock stepped backward (NTP); skip decay for this sample
+			}
+			w := math.Exp(-dt / tau)
+			next = w*math.Float64frombits(oldBits) + (1-w)*sample
+		}
+		if p.ewmaBits.CompareAndSwap(oldBits, math.Float64bits(next)) {
+			p.lastNanos.Store(now) // publish the dt basis only for the committed value
+			return next, n
+		}
+		// Lost the race; re-read the winner's value and re-decay from it.
+	}
+}
+
+// poolMedian is the robust pool baseline: the median of the eligible targets'
+// EWMAs. The median (not mean) is unmoved by the minority of slow hosts it exists to
+// expose. It snapshots into a stack buffer (zero-alloc for small pools) off the
+// latency-critical pick path.
+func (l *LatencyEjectingLoadBalancer) poolMedian() (median float64, eligible int) {
+	var buf [16]float64
+	vals := buf[:0]
+	if len(l.peers) > cap(buf) {
+		vals = make([]float64, 0, len(l.peers))
+	}
+	for i := range l.peers {
+		if l.peers[i].samples.Load() < l.MinSamples {
+			continue
+		}
+		if b := l.peers[i].ewmaBits.Load(); b != 0 {
+			vals = append(vals, math.Float64frombits(b))
+		}
+	}
+	if len(vals) == 0 {
+		return 0, 0
+	}
+	sort.Float64s(vals)
+	m := len(vals)
+	if m%2 == 1 {
+		return vals[m/2], m
+	}
+	return (vals[m/2-1] + vals[m/2]) / 2, m
+}
+
+// ejectedCount counts targets currently ejected (a lock-free scan).
+func (l *LatencyEjectingLoadBalancer) ejectedCount(now int64) (c int) {
+	for i := range l.peers {
+		if l.peers[i].ejectedUntil.Load() > now {
+			c++
+		}
+	}
+	return
+}
+
+// maybeHeal clears a target's ejection state on genuine recovery (called only when
+// it is back within tolerance under a valid baseline). It also forgets the backoff
+// exponent — full reset is correct here. The read guard keeps the healthy path
+// load-only. It is NOT called when the baseline is invalid, so a transient pool
+// dropout cannot reset the backoff of a genuinely-slow host.
+func (l *LatencyEjectingLoadBalancer) maybeHeal(p *latPeer) {
+	if p.ejections.Load() != 0 || p.ejectedUntil.Load() != 0 {
+		p.ejections.Store(0)
+		p.ejectedUntil.Store(0)
+	}
+}
+
+// eject takes a target out of rotation for a backed-off cooldown (CAS-once per
+// down-window, like ejecting.go). It also FORGETS the stale latency stats so a
+// recovered host seeds its EWMA fresh from the first post-cooldown sample and must
+// re-accumulate MinSamples before it can be re-ejected — without this a host that
+// was, say, 20x slow would re-eject on its first good sample (the decayed stale
+// value still dominates) and flap.
+func (l *LatencyEjectingLoadBalancer) eject(p *latPeer) {
+	now := time.Now()
+	for {
+		prev := p.ejectedUntil.Load()
+		if prev > now.UnixNano() {
+			return // already ejected for this window
+		}
+		e := p.ejections.Load() + 1
+		until := now.Add(l.ejectionTimeout(e)).UnixNano()
+		if p.ejectedUntil.CompareAndSwap(prev, until) {
+			p.ejections.Store(e)
+			p.ewmaBits.Store(0) // re-probe seeds fresh
+			p.samples.Store(0)  // re-probe must re-accumulate MinSamples before re-eligible
+			return
+		}
+	}
+}
+
+// ejectionTimeout returns EjectTimeout doubled for each prior ejection, capped at
+// MaxEjectTimeout. e is the 1-based ejection count.
+func (l *LatencyEjectingLoadBalancer) ejectionTimeout(e int32) time.Duration {
+	d := l.EjectTimeout
+	for i := int32(1); i < e && d < l.MaxEjectTimeout; i++ {
+		d *= 2
+	}
+	if d <= 0 || d > l.MaxEjectTimeout {
+		return l.MaxEjectTimeout
+	}
+	return d
+}

--- a/pkg/upstream/latencyejecting_test.go
+++ b/pkg/upstream/latencyejecting_test.go
@@ -1,0 +1,275 @@
+package upstream
+
+import (
+	"math"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// latTestLB builds a latency balancer with small, fast-to-exercise thresholds.
+func latTestLB(targets []*Target) *LatencyEjectingLoadBalancer {
+	return &LatencyEjectingLoadBalancer{
+		Targets:       targets,
+		MinSamples:    20,
+		MinEjectDelta: time.Millisecond,
+		HalfLife:      time.Second,
+		EjectTimeout:  30 * time.Millisecond,
+	}
+}
+
+func latEjected(l *LatencyEjectingLoadBalancer, i int) bool {
+	return l.peers[i].ejectedUntil.Load() > time.Now().UnixNano()
+}
+
+func latEjectedCount(l *LatencyEjectingLoadBalancer) (c int) {
+	for i := range l.peers {
+		if latEjected(l, i) {
+			c++
+		}
+	}
+	return
+}
+
+const (
+	latSlow = 5 * time.Millisecond
+	latMild = 2 * time.Millisecond
+)
+
+func TestLatencyEjectingLoadBalancer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Empty", func(t *testing.T) {
+		t.Parallel()
+		l := NewLatencyEjectingLoadBalancer(nil)
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Nil(t, resp)
+		assert.Equal(t, ErrUnavailable, err)
+	})
+
+	t.Run("Defaults", func(t *testing.T) {
+		t.Parallel()
+		l := NewLatencyEjectingLoadBalancer(newEjectTargets(&fakeUpstream{}))
+		driveLB(l, 1)
+		assert.Equal(t, 3.0, l.EjectionFactor)
+		assert.EqualValues(t, 100, l.MinSamples)
+		assert.Equal(t, 3, l.MinHosts)
+		assert.Equal(t, 10*time.Second, l.HalfLife)
+		assert.Equal(t, 50*time.Millisecond, l.MinEjectDelta)
+		assert.Equal(t, 30, l.MaxEjectionPercent)
+		assert.Equal(t, 50, l.PanicThreshold)
+		assert.Equal(t, 30*time.Second, l.EjectTimeout)
+		assert.Equal(t, 5*time.Minute, l.MaxEjectTimeout)
+	})
+
+	t.Run("PanicThresholdClampedAboveCap", func(t *testing.T) {
+		t.Parallel()
+		l := &LatencyEjectingLoadBalancer{Targets: newEjectTargets(&fakeUpstream{}), PanicThreshold: 20, MaxEjectionPercent: 30}
+		driveLB(l, 1)
+		assert.Equal(t, 31, l.PanicThreshold, "panic threshold raised above the cap so it is never dead code")
+	})
+
+	t.Run("DetectsAndEjectsTheSlowOne", func(t *testing.T) {
+		t.Parallel()
+		slow := &fakeUpstream{}
+		slow.delay.Store(int64(latSlow))
+		fast := []*fakeUpstream{slow, {}, {}, {}, {}}
+		l := latTestLB(newEjectTargets(fast...))
+		driveLB(l, 300)
+		assert.True(t, latEjected(l, 0), "the slow target is ejected")
+		for i := 1; i < 5; i++ {
+			assert.False(t, latEjected(l, i), "fast targets stay in rotation")
+		}
+	})
+
+	t.Run("NoEjectionOnUniformSlowdown", func(t *testing.T) {
+		t.Parallel()
+		// THE headline anti-outage-amplifier test: everyone slow by the same amount,
+		// the median rises with them, nobody is an outlier.
+		var trs []*fakeUpstream
+		for range 5 {
+			u := &fakeUpstream{}
+			u.delay.Store(int64(latMild))
+			trs = append(trs, u)
+		}
+		l := latTestLB(newEjectTargets(trs...))
+		driveLB(l, 300)
+		assert.Zero(t, latEjectedCount(l), "a uniform slowdown ejects no one")
+	})
+
+	t.Run("ColdStartNoEject", func(t *testing.T) {
+		t.Parallel()
+		slow := &fakeUpstream{}
+		slow.delay.Store(int64(latSlow))
+		l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		l.MinSamples = 100
+		driveLB(l, 40) // < MinSamples per target
+		assert.Zero(t, latEjectedCount(l), "no ejection before MinSamples")
+	})
+
+	t.Run("TwoNodePoolNeverLatencyEjects", func(t *testing.T) {
+		t.Parallel()
+		slow := &fakeUpstream{}
+		slow.delay.Store(int64(latSlow))
+		l := latTestLB(newEjectTargets(slow, &fakeUpstream{}))
+		driveLB(l, 200)
+		assert.Zero(t, latEjectedCount(l), "a pool below MinHosts cannot name an outlier")
+	})
+
+	t.Run("ErrorsAreNotTimedNorLatencyEjected", func(t *testing.T) {
+		t.Parallel()
+		dead := &fakeUpstream{}
+		dead.down.Store(true)
+		l := latTestLB(newEjectTargets(dead, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		driveLB(l, 200)
+		assert.Zero(t, l.peers[0].samples.Load(), "a transport error never feeds the latency EWMA")
+		assert.False(t, latEjected(l, 0), "this balancer does not error-eject (use the breaker for that)")
+	})
+
+	t.Run("CapBindsAtFloor", func(t *testing.T) {
+		t.Parallel()
+		// n=6, MaxEjectionPercent=30 -> at most floor(6*0.30)=1 ejected even with two outliers.
+		s0, s1 := &fakeUpstream{}, &fakeUpstream{}
+		s0.delay.Store(int64(latSlow))
+		s1.delay.Store(int64(latSlow + time.Millisecond))
+		l := latTestLB(newEjectTargets(s0, s1, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		l.MaxEjectionPercent = 30
+		driveLB(l, 400)
+		assert.LessOrEqual(t, latEjectedCount(l), 1, "the cap blocks the second outlier (no pool drain)")
+	})
+
+	t.Run("NoOscillationCascade", func(t *testing.T) {
+		t.Parallel()
+		// One clear outlier among otherwise-equal targets; removing it must not make a
+		// peer the new outlier (the median is robust).
+		slow := &fakeUpstream{}
+		slow.delay.Store(int64(latSlow))
+		l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		driveLB(l, 300)
+		require.True(t, latEjected(l, 0))
+		driveLB(l, 300)
+		for i := 1; i < 6; i++ {
+			assert.False(t, latEjected(l, i), "no cascade onto the next-slowest")
+		}
+	})
+
+	t.Run("RecoversAfterCooldownNoImmediateReEject", func(t *testing.T) {
+		t.Parallel()
+		// A VERY slow host (the critique's flapping case): it must not re-eject on its
+		// first post-cooldown sample once it has recovered — eject() reseeds the EWMA.
+		slow := &fakeUpstream{}
+		slow.delay.Store(int64(20 * time.Millisecond)) // ~10x the others
+		l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		driveLB(l, 200)
+		require.True(t, latEjected(l, 0), "very-slow host is ejected")
+
+		slow.delay.Store(0) // recovered
+		time.Sleep(40 * time.Millisecond) // past the 30ms cooldown
+		base := slow.calls.Load()
+		driveLB(l, 200) // re-probe + accumulate fresh fast samples
+
+		assert.False(t, latEjected(l, 0), "a recovered host is not re-ejected on stale data")
+		assert.Greater(t, slow.calls.Load(), base, "the recovered host serves traffic again")
+	})
+
+	t.Run("FailOpenAllEjected", func(t *testing.T) {
+		t.Parallel()
+		l := latTestLB(newEjectTargets(&fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		l.once.Do(l.init)
+		future := time.Now().Add(time.Hour).UnixNano()
+		for i := range l.peers {
+			l.peers[i].ejectedUntil.Store(future) // force every target ejected
+		}
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		require.NoError(t, err, "fails open, never ErrUnavailable for a non-empty pool")
+		require.NotNil(t, resp)
+		resp.Body.Close()
+	})
+
+	t.Run("PanicModeRoutesToAll", func(t *testing.T) {
+		t.Parallel()
+		// >PanicThreshold% ejected -> pick routes to ALL targets, including ejected ones
+		// (a latency-ejected host is slow, not dead, so it is a usable fallback).
+		trs := []*fakeUpstream{{}, {}, {}, {}}
+		l := latTestLB(newEjectTargets(trs...))
+		l.once.Do(l.init)
+		future := time.Now().Add(time.Hour).UnixNano()
+		l.peers[0].ejectedUntil.Store(future)
+		l.peers[1].ejectedUntil.Store(future)
+		l.peers[2].ejectedUntil.Store(future) // 3/4 = 75% > 50% panic
+		driveLB(l, 80)
+		for i := range trs {
+			assert.Positive(t, trs[i].calls.Load(), "panic mode routes to every target, ejected or not")
+		}
+	})
+}
+
+func TestLatencyEjectingBackoff(t *testing.T) {
+	t.Parallel()
+	l := &LatencyEjectingLoadBalancer{EjectTimeout: time.Second, MaxEjectTimeout: 5 * time.Second}
+	l.once.Do(l.init)
+	assert.Equal(t, time.Second, l.ejectionTimeout(1))
+	assert.Equal(t, 2*time.Second, l.ejectionTimeout(2))
+	assert.Equal(t, 4*time.Second, l.ejectionTimeout(3))
+	assert.Equal(t, 5*time.Second, l.ejectionTimeout(4), "capped at MaxEjectTimeout")
+	assert.Equal(t, 5*time.Second, l.ejectionTimeout(100), "no overflow on large counts")
+}
+
+func TestLatencyPoolMedian(t *testing.T) {
+	t.Parallel()
+	l := &LatencyEjectingLoadBalancer{Targets: newEjectTargets(&fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{})}
+	l.once.Do(l.init)
+	l.MinSamples = 1
+	set := func(i int, ms float64, samples uint64) {
+		l.peers[i].samples.Store(samples)
+		if ms > 0 {
+			l.peers[i].ewmaBits.Store(math.Float64bits(ms * float64(time.Millisecond)))
+		}
+	}
+	// 3 eligible (odd) -> middle.
+	set(0, 1, 5)
+	set(1, 2, 5)
+	set(2, 9, 5)
+	set(3, 1, 0) // under-sampled -> excluded
+	set(4, 0, 5) // unseeded -> excluded
+	med, elig := l.poolMedian()
+	assert.Equal(t, 3, elig)
+	assert.InDelta(t, 2*float64(time.Millisecond), med, 1, "odd median = middle value")
+
+	// 4 eligible (even) -> mean of the two middles.
+	set(3, 3, 5)
+	med, elig = l.poolMedian()
+	assert.Equal(t, 4, elig)
+	assert.InDelta(t, 2.5*float64(time.Millisecond), med, 1, "even median = mean of two middles")
+}
+
+func TestLatencyEjectingConcurrent(t *testing.T) {
+	t.Parallel()
+	slow := &fakeUpstream{}
+	slow.delay.Store(int64(latSlow))
+	l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+	hammer(l, 16, 200*time.Millisecond)
+	assert.True(t, latEjected(l, 0), "the slow target ends ejected under concurrency")
+}
+
+func TestLatencyEjectingPickZeroAlloc(t *testing.T) {
+	// not parallel: testing.AllocsPerRun must not run concurrently with other tests
+	l := latTestLB(newEjectTargets(&fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+	l.once.Do(l.init)
+	l.peers[1].ejectedUntil.Store(time.Now().Add(time.Hour).UnixNano()) // partially-ejected pool
+	n := len(l.peers)
+	allocs := testing.AllocsPerRun(200, func() { l.pick(n) })
+	assert.Zero(t, allocs, "pick (incl. the panic-check scan) allocates nothing")
+
+	// poolMedian runs per-record; its stack buffer must keep it zero-alloc for a
+	// small pool (the reason it can run off the send path cheaply).
+	for i := range l.peers {
+		l.peers[i].samples.Store(l.MinSamples)
+		l.peers[i].ewmaBits.Store(math.Float64bits(float64(i+1) * float64(time.Millisecond)))
+	}
+	medAllocs := testing.AllocsPerRun(200, func() { l.poolMedian() })
+	assert.Zero(t, medAllocs, "poolMedian uses a stack buffer for n<=16")
+}


### PR DESCRIPTION
## What

Adds `upstream.LatencyEjectingLoadBalancer` — latency-based outlier ejection, the next backlog item. Error-based ejection (#217) and the circuit breaker (#220) only trip on **errors**; neither catches a **gray failure** — a backend still returning 200s but crept far slower than its peers. This detects it.

**Purely additive**: new type/file; the other balancers are untouched (the only existing-code change is a zero-default `delay` knob on the `fakeUpstream` test helper).

## How it works

Each target keeps a **lock-free time-decayed EWMA of its TTFB** (one `atomic.Uint64` via `math.Float64bits`). A target whose mean exceeds `EjectionFactor` × the **pool median** (plus an additive `MinEjectDelta` and an absolute `MinEjectLatency` floor) is ejected for a backed-off cooldown and passively re-probed, reusing `EjectingLoadBalancer`'s eject mechanics.

Because the test is **relative to the pool median**, it self-tunes — a uniform slowdown raises every target and the median together, so no one is an outlier. **Guard rails** keep it from becoming an outage amplifier:

| rail | prevents |
|---|---|
| `MinSamples` | cold-start / re-probe mis-eject (a first request's TLS handshake) |
| `MinHosts` | a meaningless baseline (you can't name an outlier in a pool of < 3) |
| `MaxEjectionPercent` | progressive pool drain (cap binds at `floor(n·pct/100)`) |
| `PanicThreshold` | pool-wide ejection on a systemic slowdown (route to all instead) |

It **fails open** (a slow-but-up host beats a 503) — the opposite of the circuit breaker. It is **latency-only by design**: a transport error is never timed (a ~0ns connection-refused would make a dead host look fast) and never ejects here, so panic-mode and fail-open only ever route to slow-but-up hosts. An `Upstream` uses one balancer; choose `EjectingLoadBalancer`/circuit breaker instead when hard errors dominate.

```go
lb := upstream.NewLatencyEjectingLoadBalancer([]*upstream.Target{ /* 3+ targets */ })
lb.EjectionFactor = 3 // eject a target 3× slower than the pool median
s.Use(upstream.New(lb))
```

## How it was built

A multi-agent design pass (3 proposals → synthesis → **2 adversarial critiques**). Both critiques returned **fix-then-implement** with serious holes, which drove four corrections folded in here and covered by `-race` tests:

1. **Dropped the spec's folded-in error path** — it made panic mode route traffic to *dead* (error-ejected) hosts (a 3-of-4 connection-refused pool would re-include the dead nodes). Latency-only eliminates that class entirely.
2. **Reseed the EWMA on eject** (`ewmaBits=0, samples=0`) so a recovered host seeds fresh and isn't re-ejected on stale data — the spec's "decays to ~0 over the cooldown" was false (`w=0.125`), so a recovered 20×-slow host would have flapped.
3. **Heal the backoff only under a valid baseline** — a transient pool dropout can't reset the backoff exponent.
4. **Pair `lastNanos` to the committed EWMA** (store only on the winning CAS) — removes a decay-bias-under-contention race.

`/scrutinize` then verified each fix against its triggering scenario on the implemented code (verdict **ship**), and its doc nits are applied. The tests fail if a fix is reverted (e.g. `RecoversAfterCooldownNoImmediateReEject` re-ejects without the reseed; `CapBindsAtFloor` allows 2 without the `(ej+1)` cap).

## Tests

`latencyejecting_test.go` (`-race`, stress-stable ×8): `NoEjectionOnUniformSlowdown` (the headline anti-amplifier), `DetectsAndEjectsTheSlowOne`, `CapBindsAtFloor`, `PanicModeRoutesToAll`, `NoOscillationCascade`, `ColdStartNoEject`, `RecoversAfterCooldownNoImmediateReEject`, `TwoNodePoolNeverLatencyEjects`, `ErrorsAreNotTimedNorLatencyEjected`, `FailOpenAllEjected`, backoff table, an even/odd `poolMedian` unit test, a concurrent hammer, and zero-alloc checks for `pick` and `poolMedian`.

`make` passes — `go vet`, `golangci-lint` **0 issues** (fieldalignment), `go test -race ./...`.

### Documented inherent limitations
Tracks the **mean**, so a tail-only regression (healthy median, fat p99) isn't caught; a **majority-slow** pool isn't detected (the slow hosts become the median — handled by failing open, not per-host ejection); and it assumes targets see **statistically similar traffic** (a target fronting heavier routes can read as a false outlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)