### PR TITLE
feat(upstream): observable circuit-breaker / ejection state (OnStateChange + prom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,11 @@ lb.IsFailure = func(resp *http.Response, err error) bool {
 
 Pair it with `prom.Upstream()` (wired into `Upstream.OnRoundTrip`) to watch
 ejections take effect: traffic shifts off a failing backend in
-`parapet_upstream_requests{host,status}`.
+`parapet_upstream_requests{host,status}`. Wire each reliability balancer's
+`OnStateChange` to `prom.UpstreamState()` to make the state machine itself
+observable — `parapet_upstream_state_transitions_total{host,from,to,reason}`
+(trips, ejections, recoveries, half-open probes) plus a current-state gauge — and
+`prom.Upstream()` also counts fail-fast 503s in `parapet_upstream_fast_rejects_total`.
 
 `upstream.NewCircuitBreakingLoadBalancer` goes a step further: it **fails fast**.
 An open target is rejected *without a round-trip* (so a request never pays the

--- a/pkg/prom/upstream.go
+++ b/pkg/prom/upstream.go
@@ -1,6 +1,7 @@
 package prom
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"sync"
@@ -12,9 +13,10 @@ import (
 
 //nolint:govet
 type upstreamMetrics struct {
-	once     sync.Once
-	requests *prometheus.CounterVec
-	duration *prometheus.HistogramVec
+	once        sync.Once
+	requests    *prometheus.CounterVec
+	duration    *prometheus.HistogramVec
+	fastRejects *prometheus.CounterVec
 }
 
 var _upstream upstreamMetrics
@@ -30,7 +32,11 @@ func (p *upstreamMetrics) init() {
 			Name:      "upstream_request_duration_seconds",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"host"})
-		reg.MustRegister(p.requests, p.duration)
+		p.fastRejects = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "upstream_fast_rejects_total",
+		}, []string{"host"})
+		reg.MustRegister(p.requests, p.duration, p.fastRejects)
 	})
 }
 
@@ -50,6 +56,14 @@ func (p *upstreamMetrics) observe(_ *http.Request, info upstream.RoundTripInfo) 
 	if h, err := p.duration.GetMetricWith(prometheus.Labels{"host": info.Host}); err == nil {
 		h.Observe(info.Duration.Seconds())
 	}
+	// Fast-reject: a reliability balancer shed the request before any round-trip
+	// (Upstream.RoundTrip then leaves host empty). errors.Is so a wrapped
+	// ErrUnavailable still counts.
+	if errors.Is(info.Err, upstream.ErrUnavailable) {
+		if c, err := p.fastRejects.GetMetricWith(prometheus.Labels{"host": info.Host}); err == nil {
+			c.Inc()
+		}
+	}
 }
 
 // Upstream returns an upstream.RoundTripFunc that records per-backend origin
@@ -66,6 +80,10 @@ func (p *upstreamMetrics) observe(_ *http.Request, info upstream.RoundTripInfo) 
 //	     an origin-error rate is sum(status=~"5..") + sum(status="error"))
 //	{namespace}_upstream_request_duration_seconds{host}         histogram of TTFB
 //	    (transport round-trip latency: connect + send + time to response headers)
+//	{namespace}_upstream_fast_rejects_total{host}               counter of requests
+//	    a reliability balancer shed before any round-trip (ErrUnavailable). The host
+//	    is "" for a shed before any pick; pair with prom.UpstreamState for circuit
+//	    and ejection state.
 //
 // It fires once per attempt, so retries are counted individually. The host label is
 // the resolved upstream target (operator-configured, bounded), distinct from the

--- a/pkg/prom/upstream_state.go
+++ b/pkg/prom/upstream_state.go
@@ -1,0 +1,72 @@
+package prom
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+//nolint:govet
+type upstreamStateMetrics struct {
+	once        sync.Once
+	state       *prometheus.GaugeVec
+	transitions *prometheus.CounterVec
+}
+
+var _upstreamState upstreamStateMetrics
+
+func (p *upstreamStateMetrics) init() {
+	p.once.Do(func() {
+		p.state = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Name:      "upstream_breaker_state",
+		}, []string{"host"})
+		p.transitions = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "upstream_state_transitions_total",
+		}, []string{"host", "from", "to", "reason"})
+		reg.MustRegister(p.state, p.transitions)
+	})
+}
+
+func (p *upstreamStateMetrics) observe(c upstream.StateChange) {
+	if g, err := p.state.GetMetricWith(prometheus.Labels{"host": c.Host}); err == nil {
+		g.Set(float64(c.To)) // State's iota IS the gauge value: 0 closed / 1 open / 2 half_open
+	}
+	if ctr, err := p.transitions.GetMetricWith(prometheus.Labels{
+		"host":   c.Host,
+		"from":   c.From.String(),
+		"to":     c.To.String(),
+		"reason": c.Reason.String(),
+	}); err == nil {
+		ctr.Inc()
+	}
+}
+
+// UpstreamState returns an upstream.StateChangeFunc that records per-target
+// circuit-breaker / ejection state on the shared registry, for wiring into a
+// reliability balancer's OnStateChange:
+//
+//	lb := upstream.NewCircuitBreakingLoadBalancer(targets)
+//	lb.OnStateChange = prom.UpstreamState()
+//	s.Use(upstream.New(lb))
+//
+// It registers two metrics (lazily, once per process):
+//
+//	{namespace}_upstream_breaker_state{host}                           gauge: 0 closed, 1 open, 2 half_open
+//	{namespace}_upstream_state_transitions_total{host,from,to,reason}  counter of transitions
+//
+// The transitions counter is the authoritative signal: its increments are exact and
+// order-independent, so alert on it. The gauge is a best-effort convenience — under
+// concurrent transitions on the same host the emit-after-commit ordering can leave
+// it momentarily, or until the next transition, showing a stale value; and for the
+// ejecting balancers it reflects committed eject/recover events, not cooldown-expiry
+// rotation membership (a target whose cooldown expired but has not yet served a
+// successful request reads open). A target that has never transitioned has no gauge
+// sample. The host label is the operator-configured upstream target (bounded).
+func UpstreamState() upstream.StateChangeFunc {
+	_upstreamState.init()
+	return _upstreamState.observe
+}

--- a/pkg/prom/upstream_state_test.go
+++ b/pkg/prom/upstream_state_test.go
@@ -1,0 +1,77 @@
+package prom_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/upstream"
+
+	. "github.com/moonrhythm/parapet/pkg/prom"
+)
+
+func gaugeValue(t *testing.T, name string, want map[string]string) float64 {
+	t.Helper()
+	mfs, err := Registry().Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, p := range m.GetLabel() {
+				got[p.GetName()] = p.GetValue()
+			}
+			if subset(want, got) {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	return -1
+}
+
+func TestUpstreamState(t *testing.T) {
+	observe := UpstreamState()
+	require.NotNil(t, observe)
+
+	const host = "prom-state-test.backend"
+	observe(upstream.StateChange{Host: host, From: upstream.StateClosed, To: upstream.StateOpen, Reason: upstream.ReasonTrip})
+	observe(upstream.StateChange{Host: host, From: upstream.StateOpen, To: upstream.StateHalfOpen, Reason: upstream.ReasonProbe})
+
+	assert.EqualValues(t, 1, counterValue(t, "parapet_upstream_state_transitions_total",
+		map[string]string{"host": host, "from": "closed", "to": "open", "reason": "trip"}))
+	assert.EqualValues(t, 1, counterValue(t, "parapet_upstream_state_transitions_total",
+		map[string]string{"host": host, "from": "open", "to": "half_open", "reason": "probe"}))
+	assert.EqualValues(t, 2, gaugeValue(t, "parapet_upstream_breaker_state", map[string]string{"host": host}),
+		"gauge reflects the last To (half_open == 2)")
+}
+
+func TestUpstreamFastRejects(t *testing.T) {
+	observe := Upstream()
+	const host = "prom-fastreject-test.backend"
+
+	observe(nil, upstream.RoundTripInfo{Host: host, Err: upstream.ErrUnavailable})
+	assert.EqualValues(t, 1, counterValue(t, "parapet_upstream_fast_rejects_total", map[string]string{"host": host}))
+
+	// A normal transport error is not a fast-reject.
+	observe(nil, upstream.RoundTripInfo{Host: host, Err: errors.New("dial fail")})
+	assert.EqualValues(t, 1, counterValue(t, "parapet_upstream_fast_rejects_total", map[string]string{"host": host}),
+		"only ErrUnavailable (shed-before-round-trip) counts")
+}
+
+// Make circuit-breaker / ejection state observable: count transitions and track
+// the current state per backend.
+func ExampleUpstreamState() {
+	lb := upstream.NewCircuitBreakingLoadBalancer([]*upstream.Target{
+		{Host: "10.0.0.1:8080", Transport: &upstream.HTTPTransport{}},
+		{Host: "10.0.0.2:8080", Transport: &upstream.HTTPTransport{}},
+	})
+	lb.OnStateChange = UpstreamState() // prom.UpstreamState()
+
+	u := upstream.New(lb)
+	u.OnRoundTrip = Upstream() // prom.Upstream() — also counts fast-reject 503s
+	_ = u
+}

--- a/pkg/upstream/circuitbreaker.go
+++ b/pkg/upstream/circuitbreaker.go
@@ -123,6 +123,12 @@ type CircuitBreakingLoadBalancer struct {
 	// breaker toward closing rather than being treated as neutral (a wrongly closed
 	// but still-broken target simply re-trips on the next real failure).
 	IsFailure func(resp *http.Response, err error) bool
+
+	// OnStateChange observes per-target circuit state transitions (nil disables);
+	// see prom.UpstreamState. It is fired synchronously from the goroutine that
+	// commits the transition, exactly once per transition, after the new state is
+	// published. The callee owns its own concurrency.
+	OnStateChange StateChangeFunc
 }
 
 // cbState is one target's circuit-breaker state. word is the single source of
@@ -256,7 +262,9 @@ func (l *CircuitBreakingLoadBalancer) admit(b *cbState, now int64) (uint32, cbAd
 			// so winner and losers admit uniformly (no thundering herd, and no
 			// successes/probe pre-claim race).
 			b.halfOpenSince.Store(now)
-			b.word.CompareAndSwap(v, cbPack(gen+1, 0, cbHalfOpen))
+			if b.word.CompareAndSwap(v, cbPack(gen+1, 0, cbHalfOpen)) {
+				l.emit(b, StateOpen, StateHalfOpen, ReasonProbe) // single CAS winner
+			}
 			continue
 
 		default: // cbHalfOpen
@@ -265,7 +273,7 @@ func (l *CircuitBreakingLoadBalancer) admit(b *cbState, now int64) (uint32, cbAd
 				// ProbeTimeout (a hung, never-returning round-trip), re-arming the
 				// cooldown; the stale probe's eventual record is generation-inert.
 				if now-b.halfOpenSince.Load() > int64(l.ProbeTimeout) {
-					l.transition(b, gen, cbHalfOpen, cbOpen)
+					l.transition(b, gen, cbHalfOpen, cbOpen, ReasonExpire)
 					continue
 				}
 				return 0, 0, false // fail fast, skip
@@ -290,9 +298,9 @@ func (l *CircuitBreakingLoadBalancer) record(b *cbState, gen uint32, adm cbAdmis
 	if adm == cbAdmitProbe {
 		switch {
 		case failed:
-			l.transition(b, gen, cbHalfOpen, cbOpen) // re-open; word-CAS reclaims all slots
+			l.transition(b, gen, cbHalfOpen, cbOpen, ReasonReopen) // re-open; word-CAS reclaims all slots
 		case int(b.successes.Add(1)) >= l.SuccessThreshold:
-			l.transition(b, gen, cbHalfOpen, cbClosed) // heal; word-CAS reclaims all slots
+			l.transition(b, gen, cbHalfOpen, cbClosed, ReasonHeal) // heal; word-CAS reclaims all slots
 		default:
 			l.releaseProbe(b, gen) // sub-threshold success: free just this slot
 		}
@@ -306,7 +314,7 @@ func (l *CircuitBreakingLoadBalancer) record(b *cbState, gen uint32, adm cbAdmis
 			// threshold-crossers collapses to exactly one trip per down-window.
 			g, _, state := cbUnpack(b.word.Load())
 			if state == cbClosed {
-				l.transition(b, g, cbClosed, cbOpen)
+				l.transition(b, g, cbClosed, cbOpen, ReasonTrip)
 			}
 		}
 		return
@@ -325,6 +333,25 @@ func (l *CircuitBreakingLoadBalancer) failed(resp *http.Response, err error) boo
 	return err != nil && !errors.Is(err, context.Canceled)
 }
 
+// cbExternal maps the internal packed state to the public State.
+func cbExternal(s uint64) State {
+	switch s {
+	case cbOpen:
+		return StateOpen
+	case cbHalfOpen:
+		return StateHalfOpen
+	default:
+		return StateClosed
+	}
+}
+
+// emit reports a state transition to OnStateChange, if set.
+func (l *CircuitBreakingLoadBalancer) emit(b *cbState, from, to State, reason Reason) {
+	if l.OnStateChange != nil {
+		l.OnStateChange(StateChange{Host: b.target.Host, From: from, To: to, Reason: reason})
+	}
+}
+
 // transition advances a breaker from (gen, from) to (gen+1, next), zeroing the
 // probe count and the satellite counters. It is a no-op if the breaker has already
 // left (gen, from) — so concurrent callers collapse to exactly one transition per
@@ -332,7 +359,7 @@ func (l *CircuitBreakingLoadBalancer) failed(resp *http.Response, err error) boo
 // that observes OPEN is guaranteed (SC atomics) to read the fresh cooldown deadline
 // rather than a stale-expired one; generations is committed only after the CAS wins
 // so a lost race never over-counts the backoff exponent.
-func (l *CircuitBreakingLoadBalancer) transition(b *cbState, gen uint32, from, next uint64) bool {
+func (l *CircuitBreakingLoadBalancer) transition(b *cbState, gen uint32, from, next uint64, reason Reason) bool {
 	var until int64
 	var e int32
 	if next == cbOpen {
@@ -359,6 +386,7 @@ func (l *CircuitBreakingLoadBalancer) transition(b *cbState, gen uint32, from, n
 				b.generations.Store(0)
 				b.openedUntil.Store(0)
 			}
+			l.emit(b, cbExternal(from), cbExternal(next), reason) // one event per generation edge
 			return true
 		}
 		// CAS failed because a sibling changed the probes field at the same

--- a/pkg/upstream/ejecting.go
+++ b/pkg/upstream/ejecting.go
@@ -61,6 +61,14 @@ type EjectingLoadBalancer struct {
 	// nil, any transport error other than a client-canceled request counts.
 	// Set it to also treat responses such as 5xx as failures.
 	IsFailure func(resp *http.Response, err error) bool
+
+	// OnStateChange observes a target being ejected (ReasonEject) or returned to
+	// rotation on a confirmed success (ReasonRecover); nil disables it. It reflects
+	// committed eject/recover events, NOT cooldown-expiry rotation membership: a
+	// target whose cooldown has expired but has not yet served a successful request
+	// still reads StateOpen until that success. Alert on the prom.UpstreamState
+	// transitions counter, which is exact. The callee owns its own concurrency.
+	OnStateChange StateChangeFunc
 }
 
 // ejectTarget holds the passive-health state for a single target.
@@ -135,9 +143,14 @@ func (l *EjectingLoadBalancer) record(t *ejectTarget, resp *http.Response, err e
 	// the common all-healthy path only loads (shared cache lines) and never stores
 	// (which would bounce the line exclusive across cores on every request).
 	if t.fails.Load() != 0 || t.ejections.Load() != 0 || t.ejectedUntil.Load() != 0 {
+		// Swap (not Store) so exactly one of several concurrent successes observes the
+		// non-zero deadline and emits ReasonRecover — the recovery winner.
+		wasEjected := t.ejectedUntil.Swap(0) != 0
 		t.fails.Store(0)
 		t.ejections.Store(0)
-		t.ejectedUntil.Store(0)
+		if wasEjected && l.OnStateChange != nil {
+			l.OnStateChange(StateChange{Host: t.target.Host, From: StateOpen, To: StateClosed, Reason: ReasonRecover})
+		}
 	}
 }
 
@@ -168,6 +181,16 @@ func (l *EjectingLoadBalancer) eject(t *ejectTarget) {
 		until := now.Add(l.ejectionTimeout(e)).UnixNano()
 		if t.ejectedUntil.CompareAndSwap(prev, until) {
 			t.ejections.Store(e)
+			// A re-eject of a target that expired but never recovered (prev != 0) is a
+			// self-loop from open; a fresh eject is from closed. Keeps the metric edges
+			// chained given recover only fires on a confirmed success (see OnStateChange).
+			if l.OnStateChange != nil {
+				from := StateClosed
+				if prev != 0 {
+					from = StateOpen
+				}
+				l.OnStateChange(StateChange{Host: t.target.Host, From: from, To: StateOpen, Reason: ReasonEject})
+			}
 			return
 		}
 		// Lost the CAS to a concurrent ejector; re-read — its value is now in the

--- a/pkg/upstream/latencyejecting.go
+++ b/pkg/upstream/latencyejecting.go
@@ -117,6 +117,12 @@ type LatencyEjectingLoadBalancer struct {
 
 	// MaxEjectTimeout caps the ejection cooldown. Defaults to 5m.
 	MaxEjectTimeout time.Duration
+
+	// OnStateChange observes a target being ejected (ReasonEject) or healed back into
+	// rotation (ReasonRecover); nil disables it. Like EjectingLoadBalancer, it
+	// reflects committed eject/recover events, not cooldown-expiry rotation
+	// membership. See prom.UpstreamState. The callee owns its own concurrency.
+	OnStateChange StateChangeFunc
 }
 
 // latPeer holds one target's latency-ejection state. ewmaBits is the single source
@@ -320,8 +326,12 @@ func (l *LatencyEjectingLoadBalancer) ejectedCount(now int64) (c int) {
 // dropout cannot reset the backoff of a genuinely-slow host.
 func (l *LatencyEjectingLoadBalancer) maybeHeal(p *latPeer) {
 	if p.ejections.Load() != 0 || p.ejectedUntil.Load() != 0 {
+		// Swap so exactly one concurrent healer emits ReasonRecover (the winner).
+		wasEjected := p.ejectedUntil.Swap(0) != 0
 		p.ejections.Store(0)
-		p.ejectedUntil.Store(0)
+		if wasEjected && l.OnStateChange != nil {
+			l.OnStateChange(StateChange{Host: p.target.Host, From: StateOpen, To: StateClosed, Reason: ReasonRecover})
+		}
 	}
 }
 
@@ -344,6 +354,13 @@ func (l *LatencyEjectingLoadBalancer) eject(p *latPeer) {
 			p.ejections.Store(e)
 			p.ewmaBits.Store(0) // re-probe seeds fresh
 			p.samples.Store(0)  // re-probe must re-accumulate MinSamples before re-eligible
+			if l.OnStateChange != nil {
+				from := StateClosed
+				if prev != 0 {
+					from = StateOpen
+				}
+				l.OnStateChange(StateChange{Host: p.target.Host, From: from, To: StateOpen, Reason: ReasonEject})
+			}
 			return
 		}
 	}

--- a/pkg/upstream/observe.go
+++ b/pkg/upstream/observe.go
@@ -29,6 +29,11 @@ type RoundTripInfo struct {
 	// the load balancer had no target, etc. — or nil once a response was received,
 	// regardless of that response's status code.
 	Err error
+
+	// Attempt is the zero-based retry index: 0 on the first try, 1 on the first
+	// retry, and so on (read from the proxy's retry context). Existing observers
+	// simply see a new zero-valued field.
+	Attempt int
 }
 
 // RoundTripFunc observes an upstream round-trip. Assign one to Upstream.OnRoundTrip

--- a/pkg/upstream/observe_test.go
+++ b/pkg/upstream/observe_test.go
@@ -87,3 +87,23 @@ func TestUpstream_OnRoundTrip(t *testing.T) {
 		})
 	})
 }
+
+func TestUpstream_OnRoundTripAttempt(t *testing.T) {
+	t.Parallel()
+	// The retry index increments across attempts: 0 first try, 1 first retry, ...
+	var infos []RoundTripInfo
+	u := Upstream{
+		Transport: &mockTransport{roundTripFunc: func(r *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("dial fail")
+		}},
+		Retries:       2,
+		BackoffFactor: time.Millisecond,
+		OnRoundTrip:   appendInfo(&infos),
+	}
+	u.ServeHandler(nil).ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+
+	require.Len(t, infos, 3, "1 initial + 2 retries")
+	assert.Equal(t, 0, infos[0].Attempt)
+	assert.Equal(t, 1, infos[1].Attempt)
+	assert.Equal(t, 2, infos[2].Attempt)
+}

--- a/pkg/upstream/state.go
+++ b/pkg/upstream/state.go
@@ -1,0 +1,73 @@
+package upstream
+
+// State is a reliability balancer's per-target health state, reported via
+// OnStateChange. The circuit breaker uses all three; EjectingLoadBalancer and
+// LatencyEjectingLoadBalancer use only StateClosed (in rotation) and StateOpen
+// (ejected). The numeric value doubles as the Prometheus gauge value exported by
+// prom.UpstreamState.
+type State uint8
+
+const (
+	StateClosed   State = iota // routing normally / in rotation
+	StateOpen                  // tripped open / ejected — skipped
+	StateHalfOpen              // admitting trial probes (circuit breaker only)
+)
+
+func (s State) String() string {
+	switch s {
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half_open"
+	default:
+		return "closed"
+	}
+}
+
+// Reason names what drove a transition, for metric labelling.
+type Reason uint8
+
+const (
+	ReasonTrip    Reason = iota // closed -> open: failure threshold crossed (circuit breaker)
+	ReasonReopen                // half_open -> open: a probe failed (circuit breaker)
+	ReasonHeal                  // half_open -> closed: success threshold met (circuit breaker)
+	ReasonProbe                 // open -> half_open: cooldown expired, probing (circuit breaker)
+	ReasonExpire                // half_open -> open: a probe overstayed ProbeTimeout (circuit breaker)
+	ReasonEject                 // -> open: an ejecting balancer took a target out of rotation
+	ReasonRecover               // open -> closed: an ejecting balancer returned a target to rotation
+)
+
+func (r Reason) String() string {
+	switch r {
+	case ReasonReopen:
+		return "reopen"
+	case ReasonHeal:
+		return "heal"
+	case ReasonProbe:
+		return "probe"
+	case ReasonExpire:
+		return "expire"
+	case ReasonEject:
+		return "eject"
+	case ReasonRecover:
+		return "recover"
+	default:
+		return "trip"
+	}
+}
+
+// StateChange reports one per-target reliability transition to a StateChangeFunc.
+type StateChange struct {
+	Host   string // resolved upstream target (operator-configured, bounded label)
+	From   State
+	To     State
+	Reason Reason
+}
+
+// StateChangeFunc observes a per-target reliability state transition. Assign one to
+// a reliability balancer's OnStateChange to make ejection / circuit-breaker state
+// observable — see prom.UpstreamState. It is invoked synchronously on the goroutine
+// that commits the transition, exactly once per transition (concurrent threshold
+// crossers collapse to one), after the new state is published. The callee owns its
+// own concurrency. Nil disables it at zero hot-path cost.
+type StateChangeFunc func(StateChange)

--- a/pkg/upstream/state_test.go
+++ b/pkg/upstream/state_test.go
@@ -1,0 +1,185 @@
+package upstream
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "closed", StateClosed.String())
+	assert.Equal(t, "open", StateOpen.String())
+	assert.Equal(t, "half_open", StateHalfOpen.String())
+}
+
+func TestReasonString(t *testing.T) {
+	t.Parallel()
+	for r, s := range map[Reason]string{
+		ReasonTrip:    "trip",
+		ReasonReopen:  "reopen",
+		ReasonHeal:    "heal",
+		ReasonProbe:   "probe",
+		ReasonExpire:  "expire",
+		ReasonEject:   "eject",
+		ReasonRecover: "recover",
+	} {
+		assert.Equal(t, s, r.String())
+	}
+}
+
+// stateRecorder captures StateChange events for assertions.
+type stateRecorder struct {
+	mu      sync.Mutex
+	changes []StateChange
+}
+
+func (r *stateRecorder) fn() StateChangeFunc {
+	return func(c StateChange) {
+		r.mu.Lock()
+		r.changes = append(r.changes, c)
+		r.mu.Unlock()
+	}
+}
+
+func (r *stateRecorder) all() []StateChange {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]StateChange(nil), r.changes...)
+}
+
+func (r *stateRecorder) reasons() []Reason {
+	out := make([]Reason, 0)
+	for _, c := range r.all() {
+		out = append(out, c.Reason)
+	}
+	return out
+}
+
+func (r *stateRecorder) count(reason Reason) (n int) {
+	for _, c := range r.all() {
+		if c.Reason == reason {
+			n++
+		}
+	}
+	return
+}
+
+func TestCircuitBreaker_StateChangeLifecycle(t *testing.T) {
+	t.Parallel()
+	// Strictly serial driving so emit order == commit order (it is NOT guaranteed
+	// under concurrency — see the burst test, which asserts counts only).
+	var rec stateRecorder
+	t0 := &fakeUpstream{}
+	t0.down.Store(true)
+	l := &CircuitBreakingLoadBalancer{
+		Targets: newEjectTargets(t0), FailureThreshold: 3, SuccessThreshold: 2, OpenTimeout: 20 * time.Millisecond,
+		OnStateChange: rec.fn(),
+	}
+	driveLB(l, 3) // closed -> open (trip)
+	t0.down.Store(false)
+	time.Sleep(40 * time.Millisecond) // cooldown expires
+	driveLB(l, 1)                     // open -> half_open (probe), sub-threshold success
+	driveLB(l, 1)                     // half_open -> closed (heal)
+
+	assert.Equal(t, []Reason{ReasonTrip, ReasonProbe, ReasonHeal}, rec.reasons())
+	first := rec.all()[0]
+	assert.Equal(t, StateClosed, first.From)
+	assert.Equal(t, StateOpen, first.To)
+}
+
+func TestCircuitBreaker_StateChangeConcurrentBurstOneTrip(t *testing.T) {
+	t.Parallel()
+	var rec stateRecorder
+	l := &CircuitBreakingLoadBalancer{Targets: newEjectTargets(&fakeUpstream{}), FailureThreshold: 1, OnStateChange: rec.fn()}
+	l.once.Do(l.init)
+	b := &l.breakers[0]
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			l.record(b, 0, cbAdmitClosed, nil, errors.New("down"))
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 1, rec.count(ReasonTrip), "a concurrent failure burst emits exactly one trip")
+}
+
+func TestEjectingLoadBalancer_StateChange(t *testing.T) {
+	t.Parallel()
+	var rec stateRecorder
+	t0 := &fakeUpstream{}
+	t0.down.Store(true)
+	l := &EjectingLoadBalancer{Targets: newEjectTargets(t0), MaxFails: 3, EjectTimeout: 20 * time.Millisecond, OnStateChange: rec.fn()}
+	driveLB(l, 3) // eject
+	require.Equal(t, 1, rec.count(ReasonEject))
+	c0 := rec.all()[0]
+	assert.Equal(t, StateClosed, c0.From)
+	assert.Equal(t, StateOpen, c0.To)
+
+	t0.down.Store(false)
+	time.Sleep(40 * time.Millisecond)
+	driveLB(l, 5) // re-admitted; first success recovers
+	assert.Equal(t, 1, rec.count(ReasonRecover), "a confirmed success emits exactly one recover")
+}
+
+func TestEjectingLoadBalancer_StateChangeConcurrentOneEject(t *testing.T) {
+	t.Parallel()
+	var rec stateRecorder
+	t0 := &fakeUpstream{}
+	t0.down.Store(true)
+	l := &EjectingLoadBalancer{Targets: newEjectTargets(t0), MaxFails: 1, OnStateChange: rec.fn()}
+	l.once.Do(l.init)
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			l.record(l.targets[0], nil, errors.New("down"))
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 1, rec.count(ReasonEject), "a concurrent failure burst emits exactly one eject")
+}
+
+func TestLatencyEjectingLoadBalancer_StateChange(t *testing.T) {
+	t.Parallel()
+	var rec stateRecorder
+	slow := &fakeUpstream{}
+	slow.delay.Store(int64(latSlow))
+	l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+	l.OnStateChange = rec.fn()
+	driveLB(l, 300)
+	assert.GreaterOrEqual(t, rec.count(ReasonEject), 1, "the slow target's ejection emits ReasonEject")
+	for _, c := range rec.all() {
+		if c.Reason == ReasonEject {
+			assert.Equal(t, StateOpen, c.To)
+		}
+	}
+}
+
+func TestEjectingLoadBalancer_StateChangeConcurrentOneRecover(t *testing.T) {
+	t.Parallel()
+	var rec stateRecorder
+	l := &EjectingLoadBalancer{Targets: newEjectTargets(&fakeUpstream{}), MaxFails: 1, OnStateChange: rec.fn()}
+	l.once.Do(l.init)
+	tt := l.targets[0]
+	l.eject(tt) // ejectedUntil future, ejections=1
+	require.Equal(t, 1, rec.count(ReasonEject))
+
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			l.record(tt, nil, nil) // success -> exactly one goroutine wins the Swap and recovers
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 1, rec.count(ReasonRecover), "concurrent successes emit exactly one recover")
+}

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -120,13 +120,19 @@ func (m Upstream) ServeHandler(h http.Handler) http.Handler {
 
 // RoundTrip wraps transport round-trip
 func (m *Upstream) RoundTrip(r *http.Request) (*http.Response, error) {
+	// The transport (load balancer / single-host) sets the resolved target. Clear it
+	// first so a request shed before any pick (a reliability balancer returning
+	// ErrUnavailable) reports an empty host, not a stale target left from a prior
+	// retry attempt — making the fast-reject metric's host label unambiguous.
+	r.URL.Host = ""
 	start := time.Now()
 	resp, err := m.Transport.RoundTrip(r)
 	logger.Set(r.Context(), "upstream", r.URL.Host)
 	if m.OnRoundTrip != nil {
-		// r.URL.Host is the target the load balancer / single-host transport just
-		// resolved; Duration is the time to response headers, before the body streams.
-		info := RoundTripInfo{Host: r.URL.Host, Duration: time.Since(start), Err: err}
+		// r.URL.Host is the target just resolved; Duration is the time to response
+		// headers, before the body streams; Attempt is the retry index (0 first try).
+		attempt, _ := r.Context().Value(retryContextKey{}).(int)
+		info := RoundTripInfo{Host: r.URL.Host, Duration: time.Since(start), Err: err, Attempt: attempt}
 		if resp != nil {
 			info.Status = resp.StatusCode
 		}


### PR DESCRIPTION
## What

Makes the reliability balancers' **state machine** observable. After #216 you could see per-backend request counts/status/TTFB, but **not** circuit state, trips, ejections, recoveries, half-open probes, or fail-fast 503 volume — the balancers shifted and shed traffic silently. This adds a per-target `OnStateChange` hook, the retry attempt index, and a fast-reject counter.

**Additive** (one deliberate, safe behavior tweak — see below): a nil hook is zero hot-path cost; existing callers see only a new zero-valued `RoundTripInfo.Attempt` field.

## How

- **`state.go`** — `State` (closed/open/half_open), `Reason` (trip/reopen/heal/probe/expire/eject/recover), `StateChange{Host,From,To,Reason}`, `StateChangeFunc`.
- **`OnStateChange`** on all **three** reliability balancers (circuit breaker, ejecting, latency-ejecting), fired **exactly once per transition** from the committing goroutine:
  - the breaker emits inside the winning word-CAS in `transition()`/`admit()` — an explicit `reason` param disambiguates `reopen` vs `expire` (both `half_open→open`);
  - the ejecting balancers emit `ReasonEject` inside the `ejectedUntil` CAS winner, and `ReasonRecover` via `ejectedUntil.Swap(0)!=0` so exactly one of several concurrent successes recovers — the all-healthy path stays load-only.
- **`RoundTripInfo.Attempt`** — the retry index (0 = first try), read from the retry context inside the existing `OnRoundTrip` guard.
- **`prom.UpstreamState()`** → `parapet_upstream_breaker_state{host}` gauge + `parapet_upstream_state_transitions_total{host,from,to,reason}` counter. **`prom.Upstream()`** folds in `parapet_upstream_fast_rejects_total{host}` (counts `ErrUnavailable`, shed before any round-trip).

```go
lb.OnStateChange = prom.UpstreamState()
u := upstream.New(lb)
u.OnRoundTrip = prom.Upstream() // also counts fast-reject 503s
```

## Documented limitations (honest, from the design critique)

- The **gauge is best-effort**: emit-after-commit can leave it momentarily stale under concurrent same-host transitions — the **transitions counter is authoritative** (exact, order-independent), so alert on it.
- For the ejecting balancers the gauge reflects **committed eject/recover events, not cooldown-expiry rotation membership** (a cooldown-expired-but-not-yet-succeeded target reads `open`). `eject()` emits `From=open` on a re-eject so the metric edges still chain.

## Behavior note

`Upstream.RoundTrip` now clears `r.URL.Host` before delegating, so a **shed-before-pick reports an empty fast-reject host** instead of a stale target left from a prior retry. Every balancer / single-host transport re-sets the host on a successful pick, so this is **invisible to routing** — deliberate, called out so it isn't mistaken for an accident.

## How it was built

From the multi-agent backlog design pass; its critique returned **fix-then-implement** and drove: the exactly-once recover (`Swap`), the `From=open` re-eject edge, the gauge-is-best-effort docs, the host reset for an unambiguous fast-reject label, and serial-only ordering tests. `/scrutinize` then verified each fix on the implemented code (verdict **ship**), and its one nit — a concurrent-recover test — is added.

## Tests

`state_test.go`: `String` round-trips; a **serial** lifecycle test asserting the ordered `[trip, probe, heal]` reason sequence; and `-race` concurrent-burst tests asserting **exactly one** emit (one trip, one eject, one recover — these fail if the emit moves outside the CAS/Swap winner). `observe_test.go`: `Attempt` increments `[0,1,2]` across retries. `prom`: `UpstreamState` gauge+transitions and `fast_rejects` (only `ErrUnavailable` counts), plus `ExampleUpstreamState`. The existing breaker/ejection `-race` burst and hung-probe tests stay green (the `transition()` signature change is the riskiest; the added emit is the final, nil-cheap line of the committed CAS block).

`make` passes — `go vet`, `golangci-lint` **0 issues**, `go test -race ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)