### PR TITLE
feat(upstream): add HedgingLoadBalancer (speculative-retry hedging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,26 @@ lb.EjectionFactor = 3 // eject a target 3× slower than the pool median
 s.Use(upstream.New(lb))
 ```
 
+## Hedging (speculative retry)
+
+`upstream.NewHedgingLoadBalancer` wraps any balancer to cut **tail latency**: if an
+idempotent, body-less request hasn't responded within `HedgeDelay`, it sends a
+duplicate to another target (the wrapped balancer self-selects a different one),
+returns whichever response arrives first, and cancels the loser. The race happens
+inside the `RoundTripper`, so the proxy only ever sees the winner.
+
+```go
+h := upstream.NewHedgingLoadBalancer(lb) // lb is any balancer
+h.HedgeDelay = 30 * time.Millisecond     // ~p95; <= 0 disables (zero-cost pass-through)
+s.Use(upstream.New(h))
+```
+
+`MaxHedge` (default 1) caps the fan-out. Non-idempotent requests, and a request
+already inside the retry loop, pass straight through. Because losing legs are
+cancelled with `context.Canceled`, a custom `IsFailure` on the wrapped balancer
+must exclude it (the default does), or hedging would slowly eject the healthy
+backend it raced.
+
 ## Trusted proxies
 
 Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes from a trusted CIDR. Configure trust with `TrustCIDRs(...)` or accept the defaults from `Trusted()` (standard private and loopback ranges). Servers created with `NewFrontend()` start with no trusted proxies by default.

--- a/pkg/upstream/example_test.go
+++ b/pkg/upstream/example_test.go
@@ -132,6 +132,24 @@ func ExampleNewLatencyEjectingLoadBalancer() {
 	s.Use(upstream.New(lb))
 }
 
+// Cut tail latency by hedging: wrap any balancer so a slow idempotent request is
+// duplicated to another target after HedgeDelay, taking the first response. It
+// composes with every balancer (here round-robin). If the wrapped balancer uses a
+// custom IsFailure, exclude context.Canceled so cancelled losing legs don't eject
+// the healthy backend they raced.
+func ExampleNewHedgingLoadBalancer() {
+	tr := &upstream.HTTPTransport{}
+	lb := upstream.NewRoundRobinLoadBalancer([]*upstream.Target{
+		{Host: "10.0.0.1:8080", Transport: tr},
+		{Host: "10.0.0.2:8080", Transport: tr},
+	})
+	h := upstream.NewHedgingLoadBalancer(lb)
+	h.HedgeDelay = 30 * time.Millisecond // ~p95; <= 0 disables
+
+	s := parapet.New()
+	s.Use(upstream.New(h)) // h is the proxy's transport, like any balancer
+}
+
 // Observe each origin round-trip via OnRoundTrip — invoked once per attempt with
 // the resolved target, status, latency, and error. Wire it to metrics or logging
 // (see prom.Upstream); here it just inspects the info.

--- a/pkg/upstream/hedging.go
+++ b/pkg/upstream/hedging.go
@@ -1,0 +1,287 @@
+package upstream
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const defaultMaxHedge = 1
+
+// loserDrainCap bounds how much of a losing response body is discarded before
+// Close, so reaping a large already-headers-received loser cannot tie up a
+// goroutine streaming a body nobody will read. A capped-then-closed HTTP/1 body may
+// forfeit keep-alive reuse for that one conn, which is fine: the losing leg's
+// round-trip has already been context-cancelled.
+const loserDrainCap = 4 << 10 // 4 KiB
+
+// NewHedgingLoadBalancer wraps a load balancer (or any http.RoundTripper that picks
+// a target per call) with speculative-retry hedging to cut tail latency. HedgeDelay
+// is left 0, so the returned wrapper is a zero-cost pass-through until you set it.
+func NewHedgingLoadBalancer(next http.RoundTripper) *HedgingLoadBalancer {
+	return &HedgingLoadBalancer{Next: next, MaxHedge: defaultMaxHedge, HedgeOnError: true}
+}
+
+// HedgingLoadBalancer races an idempotent, body-less request against up to MaxHedge
+// hedges, returns the first response to win, and cancels the losing legs. After
+// HedgeDelay the in-flight request is duplicated via a second call to the wrapped
+// balancer, which self-selects (and advances past) a target, so the hedge naturally
+// lands on a different host. The race happens entirely inside RoundTrip, so the
+// proxy only ever sees the single winner — there is no concurrent write to the
+// client.
+//
+// It is a drop-in http.RoundTripper for upstream.New and composes with every
+// balancer. Only idempotent body-less requests are hedged (GET/HEAD/OPTIONS/TRACE,
+// like the retry path), and a request already inside the proxy's retry loop is not
+// additionally hedged — retries and hedges layer, never multiply. HedgeDelay <= 0
+// disables hedging entirely (no timer, no clone, no goroutine).
+//
+// The wrapped balancer's Next.RoundTrip MUST honor request-context cancellation
+// (every transport in this package does): a hedge cancels the losing legs, so a
+// transport that ignores cancellation would leak a draining goroutine per hedge.
+// For the same reason, if you give the wrapped balancer a custom IsFailure, it MUST
+// exclude context.Canceled (the default does) — otherwise every cancelled losing
+// leg is counted as a failure and slowly ejects/trips the healthy backend it raced.
+//
+// Configuration fields are read once; set them before serving.
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
+type HedgingLoadBalancer struct {
+	once sync.Once
+
+	// Next is the wrapped balancer. Each attempt calls Next.RoundTrip, which picks
+	// and advances past a target, so a hedge lands on a different one.
+	Next http.RoundTripper
+
+	// HedgeDelay is how long to wait for the in-flight request before launching a
+	// hedge. <= 0 disables hedging (pure pass-through to Next.RoundTrip).
+	HedgeDelay time.Duration
+
+	// MaxHedge is the number of extra speculative attempts beyond the original (each
+	// HedgeDelay-spaced). Defaults to 1 (at most one hedge -> 2x fan-out).
+	MaxHedge int
+
+	// HedgeOnError launches the next hedge immediately on a losing transport error
+	// rather than waiting out HedgeDelay. NewHedgingLoadBalancer enables it; a bare
+	// HedgingLoadBalancer{} literal leaves it false (a bool can't be defaulted in init).
+	HedgeOnError bool
+
+	// IsHedgeable decides whether a request may be hedged; nil uses the idempotent
+	// body-less rule (and never hedges a request already being retried).
+	IsHedgeable func(r *http.Request) bool
+
+	// IsWinner decides whether a leg's result wins the race; nil means "a response
+	// with no transport error". Set it to, say, only accept non-5xx.
+	IsWinner func(resp *http.Response, err error) bool
+}
+
+// hedgeResult is one leg's outcome. idx identifies the leg's cancel in the
+// supervisor's slice; host is the target it resolved to.
+type hedgeResult struct {
+	resp *http.Response
+	err  error
+	host string
+	idx  int
+}
+
+func (l *HedgingLoadBalancer) init() {
+	if l.MaxHedge <= 0 {
+		l.MaxHedge = defaultMaxHedge
+	}
+}
+
+func (l *HedgingLoadBalancer) hedgeable(r *http.Request) bool {
+	if l.IsHedgeable != nil {
+		return l.IsHedgeable(r)
+	}
+	if !canRetry(r) {
+		return false
+	}
+	_, retrying := r.Context().Value(retryContextKey{}).(int)
+	return !retrying // a request already inside the retry loop is not re-hedged
+}
+
+func (l *HedgingLoadBalancer) won(resp *http.Response, err error) bool {
+	if l.IsWinner != nil {
+		return l.IsWinner(resp, err)
+	}
+	return err == nil && resp != nil
+}
+
+// RoundTrip races the request against hedges and returns the winner.
+func (l *HedgingLoadBalancer) RoundTrip(r *http.Request) (*http.Response, error) {
+	l.once.Do(l.init)
+
+	// Fast path: hedging off or request not eligible -> one plain call, no
+	// clone/goroutine/timer.
+	if l.HedgeDelay <= 0 || l.MaxHedge <= 0 || !l.hedgeable(r) {
+		return l.Next.RoundTrip(r)
+	}
+
+	maxAttempts := l.MaxHedge + 1
+	results := make(chan hedgeResult, maxAttempts) // buffered: a late loser never blocks on send
+
+	// cancels[i] tears down leg i. Each leg runs on its OWN context (child of the
+	// request) so the winner's body stays alive after the losers are cancelled.
+	// Touched only by this (supervisor) goroutine.
+	cancels := make([]context.CancelFunc, 0, maxAttempts)
+	launch := func() {
+		idx := len(cancels)
+		legCtx, legCancel := context.WithCancel(r.Context())
+		cancels = append(cancels, legCancel)
+		req := r.Clone(legCtx) // deep-copies Header+URL: legs never share a Host or header slice
+		go func() {
+			resp, err := safeRoundTrip(l.Next, req)
+			results <- hedgeResult{resp: resp, err: err, host: req.URL.Host, idx: idx}
+		}()
+	}
+
+	launched := 1
+	launch() // primary, immediately
+	timer := time.NewTimer(l.HedgeDelay)
+	defer timer.Stop()
+
+	var firstErr error
+	received := 0
+
+	for {
+		select {
+		case res := <-results:
+			received++
+			if l.won(res.resp, res.err) {
+				// WINNER. Cancel every OTHER leg (idempotent if already cancelled) but
+				// NOT the winner's — its body context must stay live until the proxy
+				// finishes streaming. Drain the cancelled in-flight losers off-thread.
+				r.URL.Host = res.host // report the real winning target to OnRoundTrip/logger
+				for j := range cancels {
+					if j != res.idx {
+						cancels[j]()
+					}
+				}
+				go reap(results, launched-received)
+				return wrapWinner(res.resp, cancels[res.idx]), nil
+			}
+			// Loser: a transport error, or IsWinner==false.
+			cancels[res.idx]() // release this finished leg's context
+			drainClose(res.resp)
+			if firstErr == nil {
+				firstErr = res.err
+			}
+			if received == maxAttempts {
+				// Every attempt finished without a winner: surface the first error so the
+				// Upstream ErrorHandler maps it (ErrUnavailable->503, else ->502).
+				if firstErr == nil {
+					firstErr = ErrUnavailable
+				}
+				return nil, firstErr
+			}
+			// Fail-fast: an attempt errored and a hedge slot remains -> launch now.
+			if l.HedgeOnError && launched < maxAttempts {
+				stopDrain(timer)
+				launch()
+				launched++
+				if launched < maxAttempts {
+					timer.Reset(l.HedgeDelay)
+				}
+			}
+
+		case <-timer.C:
+			if launched < maxAttempts {
+				launch()
+				launched++
+				if launched < maxAttempts {
+					timer.Reset(l.HedgeDelay) // remaining hedges fire every HedgeDelay
+				}
+			}
+
+		case <-r.Context().Done():
+			// Client disconnected. Tear down every leg and drain their bodies.
+			for j := range cancels {
+				cancels[j]()
+			}
+			go reap(results, launched-received)
+			return nil, r.Context().Err()
+		}
+	}
+}
+
+// wrapWinner hands the proxy the winning response, wrapping its body so Close
+// releases the winning leg's context exactly when the proxy is done streaming
+// (closing the underlying body first, so a stacked leastconn body still does its
+// active-- accounting). It preserves io.ReadWriteCloser so the 101-upgrade
+// type-assert in httputil.ReverseProxy still succeeds.
+func wrapWinner(resp *http.Response, cancel context.CancelFunc) *http.Response {
+	if resp.Body == nil {
+		cancel() // nothing to keep the context alive for
+		return resp
+	}
+	if rwc, ok := resp.Body.(io.ReadWriteCloser); ok {
+		resp.Body = &hedgeRWCBody{ReadWriteCloser: rwc, cancel: cancel}
+	} else {
+		resp.Body = &hedgeBody{ReadCloser: resp.Body, cancel: cancel}
+	}
+	return resp
+}
+
+type hedgeBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *hedgeBody) Close() error {
+	err := b.ReadCloser.Close() // close underlying first (e.g. leastconn active--, conn return)
+	b.cancel()                  // then release the winning leg's context (idempotent)
+	return err
+}
+
+type hedgeRWCBody struct {
+	io.ReadWriteCloser
+	cancel context.CancelFunc
+}
+
+func (b *hedgeRWCBody) Close() error {
+	err := b.ReadWriteCloser.Close()
+	b.cancel()
+	return err
+}
+
+// reap drains and closes the bodies of n still-in-flight legs as they abort, off
+// the request goroutine. Every launched leg sends exactly once (safeRoundTrip
+// guarantees a send even on panic), so the n reads always complete.
+func reap(results <-chan hedgeResult, n int) {
+	for range n {
+		drainClose((<-results).resp)
+	}
+}
+
+func drainClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.CopyN(io.Discard, resp.Body, loserDrainCap) // bounded: don't stream a body nobody reads
+	_ = resp.Body.Close()
+}
+
+// safeRoundTrip publishes a recovered transport panic as an error result so a
+// misbehaving Next (e.g. a nil Transport) cannot wedge a reaper waiting on a leg
+// that never sends. Mirrors the panic-safety discipline in leastconn/circuitbreaker.
+func safeRoundTrip(next http.RoundTripper, r *http.Request) (resp *http.Response, err error) {
+	defer func() {
+		if recover() != nil {
+			resp, err = nil, ErrUnavailable
+		}
+	}()
+	return next.RoundTrip(r)
+}
+
+// stopDrain stops a timer and drains its channel so a later Reset is race-free.
+func stopDrain(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+}

--- a/pkg/upstream/hedging_test.go
+++ b/pkg/upstream/hedging_test.go
@@ -1,0 +1,235 @@
+package upstream
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxFake is a transport whose latency honors request-context cancellation, so a
+// cancelled losing leg aborts (as a real transport does).
+type ctxFake struct {
+	calls  atomic.Int64
+	delay  time.Duration
+	err    error
+	status int
+}
+
+func (t *ctxFake) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.calls.Add(1)
+	if t.err != nil {
+		return nil, t.err
+	}
+	if t.delay > 0 {
+		select {
+		case <-time.After(t.delay):
+		case <-r.Context().Done():
+			return nil, r.Context().Err()
+		}
+	}
+	w := httptest.NewRecorder()
+	if t.status != 0 {
+		w.WriteHeader(t.status)
+	}
+	_, _ = w.Write([]byte("ok"))
+	return w.Result(), nil
+}
+
+func rrLB(trs ...http.RoundTripper) *RoundRobinLoadBalancer {
+	targets := make([]*Target, len(trs))
+	for i, tr := range trs {
+		targets[i] = &Target{Host: "t" + string(rune('0'+i)), Transport: tr}
+	}
+	return NewRoundRobinLoadBalancer(targets)
+}
+
+func TestHedging_DisabledIsPassThrough(t *testing.T) {
+	t.Parallel()
+	f := &ctxFake{delay: 30 * time.Millisecond}
+	h := NewHedgingLoadBalancer(rrLB(f)) // HedgeDelay 0 -> disabled
+	resp, err := h.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.EqualValues(t, 1, f.calls.Load(), "no hedge when HedgeDelay<=0")
+}
+
+func TestHedging_NonHedgeablePassThrough(t *testing.T) {
+	t.Parallel()
+	f := &ctxFake{}
+	h := NewHedgingLoadBalancer(rrLB(f))
+	h.HedgeDelay = 10 * time.Millisecond
+	// POST is not idempotent/body-less -> not hedgeable.
+	resp, err := h.RoundTrip(httptest.NewRequest("POST", "/", strings.NewReader("x")))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.EqualValues(t, 1, f.calls.Load())
+}
+
+func TestHedging_AlreadyRetryingPassThrough(t *testing.T) {
+	t.Parallel()
+	f := &ctxFake{delay: 30 * time.Millisecond}
+	h := NewHedgingLoadBalancer(rrLB(f, &ctxFake{}))
+	h.HedgeDelay = 5 * time.Millisecond
+	r := httptest.NewRequest("GET", "/", nil)
+	r = r.WithContext(context.WithValue(r.Context(), retryContextKey{}, 1)) // inside the retry loop
+	resp, err := h.RoundTrip(r)
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.EqualValues(t, 1, f.calls.Load(), "a retried request is not also hedged")
+}
+
+func TestHedging_HedgeWinsAndCopiesBackHost(t *testing.T) {
+	t.Parallel()
+	slow := &ctxFake{delay: time.Second}
+	fast := &ctxFake{}
+	h := NewHedgingLoadBalancer(rrLB(slow, fast)) // primary -> t0(slow), hedge -> t1(fast)
+	h.HedgeDelay = 15 * time.Millisecond
+
+	r := httptest.NewRequest("GET", "/", nil)
+	resp, err := h.RoundTrip(r)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.EqualValues(t, 1, slow.calls.Load())
+	assert.EqualValues(t, 1, fast.calls.Load())
+	assert.Equal(t, "t1", r.URL.Host, "the winning target's host is copied back for OnRoundTrip/logging")
+}
+
+func TestHedging_PrimaryWinsNoHedge(t *testing.T) {
+	t.Parallel()
+	fast := &ctxFake{}
+	hedge := &ctxFake{}
+	h := NewHedgingLoadBalancer(rrLB(fast, hedge))
+	h.HedgeDelay = 200 * time.Millisecond // primary returns well within this
+	resp, err := h.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.EqualValues(t, 1, fast.calls.Load())
+	assert.EqualValues(t, 0, hedge.calls.Load(), "primary won before HedgeDelay -> no hedge launched")
+}
+
+func TestHedging_FailFastOnError(t *testing.T) {
+	t.Parallel()
+	boom := &ctxFake{err: errors.New("dial fail")} // primary errors immediately
+	fast := &ctxFake{}
+	h := NewHedgingLoadBalancer(rrLB(boom, fast))
+	h.HedgeDelay = 500 * time.Millisecond // long: only fail-fast can make the hedge fire quickly
+	h.HedgeOnError = true
+
+	start := time.Now()
+	resp, err := h.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	elapsed := time.Since(start)
+	require.NoError(t, err, "the hedge wins after the primary errors")
+	resp.Body.Close()
+	assert.Less(t, elapsed, 200*time.Millisecond, "the hedge fired immediately on the error, not after HedgeDelay")
+}
+
+func TestHedging_AllFailReturnsError(t *testing.T) {
+	t.Parallel()
+	h := NewHedgingLoadBalancer(rrLB(&ctxFake{err: errors.New("e0")}, &ctxFake{err: errors.New("e1")}))
+	h.HedgeDelay = 10 * time.Millisecond
+	resp, err := h.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	assert.Nil(t, resp)
+	assert.Error(t, err, "no winner -> surfaces the first error for the ErrorHandler")
+}
+
+// rwcStream is a writable body (io.ReadWriteCloser) for the 101-upgrade path.
+type rwcStream struct{ closed atomic.Bool }
+
+func (s *rwcStream) Read([]byte) (int, error)    { return 0, io.EOF }
+func (s *rwcStream) Write(p []byte) (int, error) { return len(p), nil }
+func (s *rwcStream) Close() error                { s.closed.Store(true); return nil }
+
+func TestHedging_PreservesReadWriteCloserWinner(t *testing.T) {
+	t.Parallel()
+	body := &rwcStream{}
+	upgrade := funcTransport(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusSwitchingProtocols, Body: body, Header: http.Header{}}, nil
+	})
+	slow := &ctxFake{delay: time.Second}
+	h := NewHedgingLoadBalancer(rrLB(slow, upgrade))
+	h.HedgeDelay = 15 * time.Millisecond
+
+	resp, err := h.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err)
+	_, ok := resp.Body.(io.ReadWriteCloser)
+	assert.True(t, ok, "a 101 upgrade winner body must remain an io.ReadWriteCloser")
+	require.NoError(t, resp.Body.Close())
+	assert.True(t, body.closed.Load(), "underlying upgrade body closed")
+}
+
+func TestHedging_Concurrent(t *testing.T) {
+	t.Parallel()
+	slow := &ctxFake{delay: 30 * time.Millisecond}
+	fast := &ctxFake{}
+	h := NewHedgingLoadBalancer(rrLB(slow, fast))
+	h.HedgeDelay = 5 * time.Millisecond
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := h.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			if err == nil && resp != nil {
+				resp.Body.Close()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// THE regression guard for the winner-truncation bug. Recorder-based fakes return a
+// body NOT bound to any request context, so they cannot catch it; this races real
+// servers over a real transport, where the response body's lifetime IS the request
+// context. If the winner's leg were cancelled (the original shared-context design),
+// io.ReadAll would return a truncated body + context.Canceled.
+func TestHedging_StreamingWinnerBodyNotTruncated(t *testing.T) {
+	t.Parallel()
+	const chunks, chunkSize = 40, 1024
+	stream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fl, _ := w.(http.Flusher)
+		w.WriteHeader(http.StatusOK)
+		for range chunks {
+			_, _ = w.Write(bytes.Repeat([]byte("x"), chunkSize))
+			if fl != nil {
+				fl.Flush()
+			}
+			time.Sleep(time.Millisecond) // body keeps streaming after headers arrive
+		}
+	}))
+	defer stream.Close()
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(2 * time.Second): // always loses
+		case <-r.Context().Done():
+		}
+	}))
+	defer slow.Close()
+
+	tr := &HTTPTransport{}
+	// primary -> t0 (slow, loses), hedge -> t1 (streaming, wins).
+	lb := NewRoundRobinLoadBalancer([]*Target{
+		{Host: strings.TrimPrefix(slow.URL, "http://"), Transport: tr},
+		{Host: strings.TrimPrefix(stream.URL, "http://"), Transport: tr},
+	})
+	h := NewHedgingLoadBalancer(lb)
+	h.HedgeDelay = 20 * time.Millisecond
+
+	resp, err := h.RoundTrip(httptest.NewRequest("GET", "http://x/", nil))
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, resp.Body.Close())
+	require.NoError(t, err, "the winner body must read fully — not aborted by cancelling the loser")
+	assert.Equal(t, chunks*chunkSize, len(body), "the entire winner body reaches the caller")
+}


### PR DESCRIPTION
## What

Cuts **tail latency** via request hedging. `HedgingLoadBalancer` wraps any balancer: if an idempotent, body-less request hasn't responded within `HedgeDelay`, it sends a duplicate to another target (the wrapped balancer self-selects a different one), returns whichever response **wins**, and cancels the losing legs. The race happens entirely inside `RoundTrip`, so the proxy only ever receives **one** `*http.Response` — there's no concurrent write to the client `ResponseWriter`, which is the structural reason hedging belongs at the RoundTripper layer.

**Purely additive**: new type/file; the hedger *wraps* `Next`, so no other balancer changes.

```go
h := upstream.NewHedgingLoadBalancer(lb) // lb is any balancer
h.HedgeDelay = 30 * time.Millisecond     // ~p95; <= 0 disables (zero-cost pass-through)
s.Use(upstream.New(h))
```

`MaxHedge` (default 1) caps fan-out; `HedgeOnError` fires the next hedge on a losing error instead of waiting; non-idempotent requests and any request **already inside the retry loop** pass straight through — hedges and retries *layer*, never multiply. `IsHedgeable`/`IsWinner` override the defaults.

## How it was built — and the fatal bug the review caught

A multi-agent design pass produced the spec; its critique returned **fix-then-implement** after finding a **FATAL bug**: the proposed single *shared* context, cancelled on win, **truncates the winner's still-streaming response body** — net/http binds a response body's lifetime to its request context. Folded-in corrections, all `-race`-tested:

1. **Per-leg contexts** — on a winner, every *other* leg is cancelled but **not** the winner's; the winner body is wrapped so `Close()` releases the winning leg's context exactly when the proxy is done. No truncation, no context leak.
2. **Winner-body wrapper** closes the underlying body *before* cancelling (so a stacked leastconn `lcBody` still does its `active--`) and preserves `io.ReadWriteCloser` for the **101 upgrade** path.
3. **Host copy-back** (`r.URL.Host = winner host`) so `OnRoundTrip`/logger report the real winning target, not the unmutated original (composes with #222's host reset).
4. A **deterministic, bounded reaper** drains losing-leg bodies off the request goroutine; `safeRoundTrip` publishes a transport panic as a result so a reaper never wedges; the results channel is buffered so a late loser never blocks.

`/scrutinize` then verified each fix against its triggering scenario on the implemented code (verdict **ship**); its doc nit is applied.

## Tests

`hedging_test.go` (`-race`, stress-stable ×10): disabled/non-hedgeable/already-retrying pass-through; **hedge-wins + host copy-back**; primary-wins-no-hedge; **fail-fast-on-error** (hedge fires in <200ms despite a 500ms delay); all-fail surfaces the error; **101 RWC winner preserved**; a concurrent hammer; and — critically — **`TestHedging_StreamingWinnerBodyNotTruncated`**, which races real `httptest` servers over a real `HTTPTransport` (the only setup where the body is context-bound) and asserts the full winner body reaches the caller. **It fails if the winner leg is cancelled** — recorder-based fakes can't catch the truncation bug, so this is the genuine guard.

## Caveat (documented)

Losing legs are cancelled with `context.Canceled`, so a **custom `IsFailure`** on the wrapped balancer must exclude it (the default does) or hedging would slowly eject the healthy backend it raced; and `Next.RoundTrip` must honor request-context cancellation (every in-tree transport does).

`make` passes — `go vet`, `golangci-lint` **0 issues**, `go test -race ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)