### PR TITLE
test(upstream): de-flake TestLatencyEjectingConcurrent under -race

### DIFF
--- a/pkg/upstream/latencyejecting_test.go
+++ b/pkg/upstream/latencyejecting_test.go
@@ -3,6 +3,7 @@ package upstream
 import (
 	"math"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -249,10 +250,40 @@ func TestLatencyPoolMedian(t *testing.T) {
 func TestLatencyEjectingConcurrent(t *testing.T) {
 	t.Parallel()
 	slow := &fakeUpstream{}
-	slow.delay.Store(int64(latSlow))
+	// A clear outlier (much slower than its peers) so the verdict survives -race
+	// timing noise: under -race the "fast" peers' measured latency rises, lifting the
+	// pool median, so a small gap can leave the slow one under the EjectionFactor bar.
+	slow.delay.Store(int64(30 * time.Millisecond))
 	l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
-	hammer(l, 16, 200*time.Millisecond)
-	assert.True(t, latEjected(l, 0), "the slow target ends ejected under concurrency")
+	l.MinSamples = 10
+	l.EjectTimeout = time.Minute // sticky: once ejected it stays, so the check never races a re-admit
+	l.once.Do(l.init)            // build peers now so the poll goroutine never races lazy init
+
+	// Hammer in the background and poll for ejection (rather than asserting at one
+	// racy instant, where the slow target may be momentarily re-admitted/re-probing).
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				resp, _ := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+				if resp != nil {
+					resp.Body.Close()
+				}
+			}
+		}()
+	}
+	require.Eventually(t, func() bool { return latEjected(l, 0) }, 3*time.Second, 10*time.Millisecond,
+		"the slow target gets ejected under concurrency")
+	close(stop)
+	wg.Wait()
 }
 
 func TestLatencyEjectingPickZeroAlloc(t *testing.T) {


### PR DESCRIPTION
## What

`TestLatencyEjectingConcurrent` (added in #221) flaked on the **#222 merge CI** (`Should be true: the slow target ends ejected under concurrency`). Two root causes under `-race` on a loaded runner:

1. **Inflated median** — race instrumentation + scheduling raise the *fast* peers' measured TTFB, lifting the pool median so a **5ms** outlier can fall under `EjectionFactor × median`.
2. **Re-admit oscillation** — the test used a 30ms `EjectTimeout`, so the slow target's cooldown could expire and it could be re-admitted/re-probing at the exact instant the single `assert.True(latEjected)` fired.

## Fix

- A **clear outlier** (30ms vs ~0 peers) that survives timing noise.
- A **sticky `EjectTimeout`** (1 min) so an ejection isn't raced by a re-admit.
- **`require.Eventually`** polling for the ejection instead of asserting at one racy instant.
- Run `init()` synchronously before launching the background hammer, so the poll goroutine never **data-races** the lazy peer-slice build (caught while hardening this — the `Eventually` condition reads `l.peers` concurrently with first-request lazy init).

Test-only; no production change. Stress-stable **×40 under `-race`**; `make` (vet + golangci-lint 0 issues + `go test -race ./...`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)