### PR TITLE
feat(upstream): add Target.MaxConcurrent bulkhead cap on LeastConn

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,14 @@ different axis:
   **concurrency** rather than count — which adapts to slow backends and
   long-lived requests a count-based balancer misses. A request stays counted
   until its response body is closed, which parapet's reverse proxy always does.
+  Set `Target.MaxConcurrent` to cap a target's in-flight requests (the
+  **bulkhead** pattern): the cap is hard and never exceeded, surplus requests
+  route to an under-cap target, and when every target is full the balancer sheds
+  with `503` rather than overloading a saturated origin. A slot is freed only when
+  the response body is closed, so bound **total** request time (a request-context
+  deadline the transport honors) to keep a backend that stalls mid-body from
+  latching the cap — a response-header or idle timeout alone does not cover a
+  mid-body stall.
 
 ```go
 s.Use(upstream.New(upstream.NewWeightedRoundRobinLoadBalancer([]*upstream.Target{

--- a/pkg/upstream/bulkhead_test.go
+++ b/pkg/upstream/bulkhead_test.go
@@ -1,0 +1,281 @@
+package upstream
+
+import (
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// freshBody is a transport that returns a 200 with a NEW closable body per call,
+// so each in-flight request owns its own slot release.
+func freshBody() funcTransport {
+	return func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: &countingBody{}, Header: http.Header{}}, nil
+	}
+}
+
+// blockingTransport holds every request inside RoundTrip until release is closed,
+// so the test can pin a known number of slots as in-flight and observe the peak
+// concurrency the transport ever saw (maxSeen) — the witness for the hard cap.
+type blockingTransport struct {
+	release  chan struct{}
+	inflight atomic.Int64
+	maxSeen  atomic.Int64
+}
+
+func (t *blockingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	cur := t.inflight.Add(1)
+	for { // record the running max without losing a concurrent bump
+		m := t.maxSeen.Load()
+		if cur <= m || t.maxSeen.CompareAndSwap(m, cur) {
+			break
+		}
+	}
+	<-t.release // hold the slot until the test lets go
+	t.inflight.Add(-1)
+	return &http.Response{StatusCode: 200, Body: &countingBody{}, Header: http.Header{}}, nil
+}
+
+func TestLeastConnBulkhead(t *testing.T) {
+	t.Parallel()
+
+	// The core invariant: under a concurrent burst far exceeding the cap, the
+	// transport never sees more than MaxConcurrent in-flight at once, and the
+	// surplus is shed (ErrUnavailable) rather than queued or over-admitted.
+	t.Run("HardCapNeverExceeded", func(t *testing.T) {
+		t.Parallel()
+		const N, K = 24, 3
+		tr := &blockingTransport{release: make(chan struct{})}
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: tr, MaxConcurrent: K}})
+
+		var shed atomic.Int64
+		var wg sync.WaitGroup
+		for range N {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+				if err == ErrUnavailable {
+					shed.Add(1)
+					return
+				}
+				assert.NoError(t, err)
+				if resp != nil && resp.Body != nil {
+					resp.Body.Close()
+				}
+			}()
+		}
+
+		// K winners block inside the transport; the surplus is shed. Wait for both
+		// to settle, then check the witness — never poll a snapshot mid-flight.
+		require.Eventually(t, func() bool { return tr.inflight.Load() == int64(K) },
+			2*time.Second, 5*time.Millisecond, "exactly K requests reach the (blocking) target")
+		require.Eventually(t, func() bool { return shed.Load() == int64(N-K) },
+			2*time.Second, 5*time.Millisecond, "the surplus N-K is shed, not queued")
+
+		assert.LessOrEqual(t, tr.maxSeen.Load(), int64(K),
+			"the transport NEVER saw more than the cap in-flight")
+		assert.LessOrEqual(t, l.peers[0].active.Load(), int64(K), "active is bounded by the cap")
+
+		close(tr.release) // let the K winners finish and release their slots
+		wg.Wait()
+		assert.EqualValues(t, 0, l.peers[0].active.Load(), "every slot released after bodies closed")
+	})
+
+	// A target at its cap is skipped: traffic routes to an under-cap sibling instead
+	// of overloading the saturated one.
+	t.Run("RoutesAroundCappedTarget", func(t *testing.T) {
+		t.Parallel()
+		capped := &recordingTransport{}
+		free := &recordingTransport{}
+		l := NewLeastConnLoadBalancer([]*Target{
+			{Host: "capped", Transport: capped, MaxConcurrent: 1},
+			{Host: "free", Transport: free},
+		})
+
+		// First request lands on the capped target (rotation starts at index 0) and is
+		// held in-flight, filling its single slot.
+		held, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		require.NoError(t, err)
+		require.Equal(t, map[string]int{"capped": 1}, capped.counts())
+
+		// Every subsequent request must route around the full target to "free".
+		for range 5 {
+			resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			require.NoError(t, err)
+			resp.Body.Close()
+		}
+		assert.Equal(t, map[string]int{"capped": 1}, capped.counts(), "no new traffic to the full target")
+		assert.Equal(t, map[string]int{"free": 5}, free.counts(), "surplus routed to the under-cap target")
+
+		held.Body.Close() // release the slot
+		assert.EqualValues(t, 0, l.peers[0].active.Load())
+	})
+
+	// When EVERY target is at its cap, the balancer sheds rather than overloading a
+	// saturated origin — and a freed slot immediately re-admits.
+	t.Run("AllAtCapShedThenReadmit", func(t *testing.T) {
+		t.Parallel()
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: freshBody(), MaxConcurrent: 2}})
+
+		r1, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil)) // active 1
+		require.NoError(t, err)
+		r2, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil)) // active 2 == cap
+		require.NoError(t, err)
+		require.EqualValues(t, 2, l.peers[0].active.Load())
+
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil)) // at cap -> shed
+		assert.Nil(t, resp)
+		assert.Equal(t, ErrUnavailable, err, "a fully-capped balancer sheds with ErrUnavailable")
+
+		r1.Body.Close() // free one slot
+		assert.EqualValues(t, 1, l.peers[0].active.Load(), "body close releases the slot")
+
+		resp, err = l.RoundTrip(httptest.NewRequest("GET", "/", nil)) // slot available again
+		require.NoError(t, err, "a freed slot re-admits")
+		resp.Body.Close()
+		r2.Body.Close()
+		assert.EqualValues(t, 0, l.peers[0].active.Load())
+	})
+
+	// A non-positive MaxConcurrent is the unbounded default: the uncapped fast path,
+	// behaviorally identical to a target with no cap set.
+	t.Run("ZeroMaxConcurrentIsUnbounded", func(t *testing.T) {
+		t.Parallel()
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: freshBody(), MaxConcurrent: 0}})
+		var held []*http.Response
+		for range 8 {
+			resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			require.NoError(t, err)
+			held = append(held, resp) // do not close: pile them all in-flight
+		}
+		assert.EqualValues(t, 8, l.peers[0].active.Load(), "cap 0 imposes no limit")
+		for _, resp := range held {
+			resp.Body.Close()
+		}
+		assert.EqualValues(t, 0, l.peers[0].active.Load())
+	})
+
+	// The cap must be HARD even on the error path: a transport error releases the
+	// slot inline (no body to own), so a stream of failures never latches the cap.
+	t.Run("ErrorPathReleasesSlot", func(t *testing.T) {
+		t.Parallel()
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: errTransport{}, MaxConcurrent: 1}})
+		for range 5 {
+			resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			assert.Nil(t, resp)
+			assert.Error(t, err)
+		}
+		assert.EqualValues(t, 0, l.peers[0].active.Load(), "each error released its slot; the cap never latched")
+	})
+
+	// Two targets with DIFFERENT caps are each bounded independently: under a burst
+	// far exceeding total capacity, neither transport ever sees more than ITS OWN
+	// cap, total admitted == sum(caps), and only the surplus is shed. This is the
+	// per-target isolation the bulkhead promises, and (unlike the serial
+	// route-around test) it drives the concurrent skip/re-scan path with two capped
+	// peers competing.
+	t.Run("IndependentPerTargetCaps", func(t *testing.T) {
+		t.Parallel()
+		const N, K0, K1 = 30, 3, 5
+		t0 := &blockingTransport{release: make(chan struct{})}
+		t1 := &blockingTransport{release: make(chan struct{})}
+		l := NewLeastConnLoadBalancer([]*Target{
+			{Host: "t0", Transport: t0, MaxConcurrent: K0},
+			{Host: "t1", Transport: t1, MaxConcurrent: K1},
+		})
+
+		var shed atomic.Int64
+		var wg sync.WaitGroup
+		for range N {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+				if err == ErrUnavailable {
+					shed.Add(1)
+					return
+				}
+				assert.NoError(t, err)
+				if resp != nil && resp.Body != nil {
+					resp.Body.Close()
+				}
+			}()
+		}
+
+		// Both targets fill to exactly their own cap (no slot can shed while one is
+		// free), and the surplus N-(K0+K1) is shed.
+		require.Eventually(t, func() bool {
+			return t0.inflight.Load() == int64(K0) && t1.inflight.Load() == int64(K1)
+		}, 2*time.Second, 5*time.Millisecond, "each target fills to its own cap")
+		require.Eventually(t, func() bool { return shed.Load() == int64(N-K0-K1) },
+			2*time.Second, 5*time.Millisecond, "only the surplus beyond sum(caps) is shed")
+
+		assert.LessOrEqual(t, t0.maxSeen.Load(), int64(K0), "t0 never exceeded its own cap")
+		assert.LessOrEqual(t, t1.maxSeen.Load(), int64(K1), "t1 never exceeded its own cap")
+
+		close(t0.release)
+		close(t1.release)
+		wg.Wait()
+		assert.EqualValues(t, 0, l.peers[0].active.Load())
+		assert.EqualValues(t, 0, l.peers[1].active.Load())
+	})
+
+	// Weight and cap coexist: the cap clips a heavy target's weighted share. A
+	// Weight-2 target would otherwise carry 2x the concurrency, but its cap of 2
+	// bounds it, so the surplus the weight would have pulled lands on the lighter
+	// (higher-cap) target instead.
+	t.Run("WeightClippedByCap", func(t *testing.T) {
+		t.Parallel()
+		l := NewLeastConnLoadBalancer([]*Target{
+			{Host: "heavy", Transport: freshBody(), Weight: 2, MaxConcurrent: 2},
+			{Host: "light", Transport: freshBody(), Weight: 1, MaxConcurrent: 4},
+		})
+		var held []*http.Response
+		for range 6 { // exactly sum(caps): every request is admitted, filling both
+			resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			require.NoError(t, err)
+			held = append(held, resp) // hold in-flight
+		}
+		assert.EqualValues(t, 2, l.peers[0].active.Load(), "heavy clipped at its cap despite weight 2")
+		assert.EqualValues(t, 4, l.peers[1].active.Load(), "surplus the weight would pull lands on light")
+
+		resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Nil(t, resp)
+		assert.Equal(t, ErrUnavailable, err, "both at cap -> shed")
+
+		for _, resp := range held {
+			resp.Body.Close()
+		}
+		assert.EqualValues(t, 0, l.peers[0].active.Load())
+		assert.EqualValues(t, 0, l.peers[1].active.Load())
+	})
+
+	// Regression for the rotation-cursor overflow: when the tie-break cursor wraps
+	// near MaxUint32, the index scan must still visit EVERY peer. With 3 peers (not
+	// a power of two) and two at their cap, the lone under-cap peer must still be
+	// picked — a uint32 mid-scan wrap would alias an index, skip it, and false-shed.
+	t.Run("RotationCursorWrapNoFalseShed", func(t *testing.T) {
+		t.Parallel()
+		l := NewLeastConnLoadBalancer([]*Target{
+			{Host: "t0", Transport: freshBody(), MaxConcurrent: 5},
+			{Host: "t1", Transport: freshBody(), MaxConcurrent: 5},
+			{Host: "t2", Transport: freshBody(), MaxConcurrent: 5},
+		})
+		l.once.Do(l.init)          // build peers before poking state directly
+		l.peers[0].active.Store(5) // at cap
+		l.peers[1].active.Store(5) // at cap
+		l.i.Store(math.MaxUint32)  // next pick computes start = Add(1)-1 = MaxUint32
+
+		p, ok := l.pick(3)
+		require.True(t, ok, "the lone under-cap peer must be found despite the cursor wrap")
+		assert.Same(t, &l.peers[2], p, "t2 (the only under-cap peer) is selected, not a false shed")
+	})
+}

--- a/pkg/upstream/example_test.go
+++ b/pkg/upstream/example_test.go
@@ -65,10 +65,16 @@ func ExampleNewWeightedRoundRobinLoadBalancer() {
 // in-flight requests (scaled by Weight), which adapts to slow backends better
 // than counting requests.
 func ExampleNewLeastConnLoadBalancer() {
-	tr := &upstream.HTTPTransport{}
+	// MaxConcurrent caps each target's in-flight requests (the bulkhead pattern):
+	// the cap is hard, surplus routes to an under-cap target, and once every target
+	// is full the balancer sheds with 503. A held slot is freed only when the body
+	// is closed, so bound TOTAL request time (a request-context deadline the
+	// transport honors) to keep a stalled backend from latching the cap — a
+	// response-header timeout alone does not (see the Target.MaxConcurrent docs).
+	tr := &upstream.HTTPTransport{ResponseHeaderTimeout: 5 * time.Second}
 	lb := upstream.NewLeastConnLoadBalancer([]*upstream.Target{
-		{Host: "10.0.0.1:8080", Transport: tr},
-		{Host: "10.0.0.2:8080", Transport: tr},
+		{Host: "10.0.0.1:8080", Transport: tr, MaxConcurrent: 100},
+		{Host: "10.0.0.2:8080", Transport: tr, MaxConcurrent: 100},
 	})
 
 	s := parapet.New()

--- a/pkg/upstream/leastconn.go
+++ b/pkg/upstream/leastconn.go
@@ -23,7 +23,10 @@ func NewLeastConnLoadBalancer(targets []*Target) *LeastConnLoadBalancer {
 // A request stays counted as in-flight until its response body is closed, so it
 // must be driven by something that closes the body — parapet's reverse proxy does.
 // Used as a bare http.RoundTripper, the caller must close every response Body (the
-// standard RoundTripper contract) or the target's active count leaks.
+// standard RoundTripper contract) or the target's active count leaks. With a
+// Target.MaxConcurrent cap set, a leaked body is worse than skewed routing: it
+// permanently burns a hard slot, so after MaxConcurrent leaks the target sheds all
+// traffic (see the timeout warning on Target.MaxConcurrent).
 //
 //nolint:govet // fields grouped by role (state, then config) for readability
 type LeastConnLoadBalancer struct {
@@ -39,6 +42,7 @@ type LeastConnLoadBalancer struct {
 type lcPeer struct {
 	target *Target
 	weight int64        // effective weight, >= 1
+	cap    int64        // Target.MaxConcurrent; 0 == unbounded (the bulkhead cap)
 	active atomic.Int64 // in-flight requests
 }
 
@@ -47,6 +51,9 @@ func (l *LeastConnLoadBalancer) init() {
 	for i, t := range l.Targets {
 		l.peers[i].target = t
 		l.peers[i].weight = effectiveWeight(t)
+		if t.MaxConcurrent > 0 { // <= 0 stays 0 (unbounded); read once, never on the hot path
+			l.peers[i].cap = int64(t.MaxConcurrent)
+		}
 	}
 }
 
@@ -59,8 +66,12 @@ func (l *LeastConnLoadBalancer) RoundTrip(r *http.Request) (*http.Response, erro
 		return nil, ErrUnavailable
 	}
 
-	p := l.pick(n)
-	p.active.Add(1)
+	p, ok := l.pick(n)
+	if !ok {
+		return nil, ErrUnavailable // every target at its MaxConcurrent cap -> shed (503)
+	}
+	// pick already claimed the slot (active +1) atomically, so the cap is never
+	// exceeded; the matching decrement is the dec below (panic-safe + at body close).
 
 	var once sync.Once
 	dec := func() { once.Do(func() { p.active.Add(-1) }) }
@@ -102,24 +113,69 @@ func (l *LeastConnLoadBalancer) RoundTrip(r *http.Request) (*http.Response, erro
 	return resp, nil
 }
 
-// pick scans for the target with the lowest active/weight, starting from a
-// rotating cursor so equal-load targets are served round-robin. The comparison
-// cross-multiplies (a/c.weight < bestA/best.weight  <=>  a*best.weight <
-// bestA*c.weight) to stay integer-only; with realistic weights and concurrency the
-// int64 products have ample headroom. It does atomic loads only — a momentary
-// near-tie that misroutes self-corrects on the next pick.
-func (l *LeastConnLoadBalancer) pick(n int) *lcPeer {
+// pick selects the least-loaded target that is UNDER its bulkhead cap and
+// atomically claims a slot on it (active +1), so the slot is already held on
+// return. It scans from a rotating cursor so equal-load targets are served
+// round-robin, comparing active/weight via cross-multiplication (a/c.weight <
+// bestA/best.weight  <=>  a*best.weight < bestA*c.weight) to stay integer-only.
+// Targets at/over their cap are skipped; if every target is at its cap it returns
+// ok=false and RoundTrip sheds (ErrUnavailable). The selection scan is read-only
+// (atomic loads); only the claim mutates.
+//
+// pick is lock-free, not bounded by n scans: a re-scan happens only after a claim
+// CAS observed the chosen peer already at cap, and concurrent releases make the
+// candidate set non-monotonic. But total in-flight is bounded by sum(cap) and every
+// losing CAS corresponds to a sibling that made progress (a claim or release), so
+// the system is livelock-free.
+func (l *LeastConnLoadBalancer) pick(n int) (*lcPeer, bool) {
 	start := l.i.Add(1) - 1
-	best := &l.peers[start%uint32(n)]
-	bestA := best.active.Load()
-	for k := uint32(1); k < uint32(n); k++ {
-		c := &l.peers[(start+k)%uint32(n)]
-		a := c.active.Load()
-		if a*best.weight < bestA*c.weight {
-			best, bestA = c, a
+	for {
+		var best *lcPeer
+		var bestA int64
+		for k := uint32(0); k < uint32(n); k++ {
+			// uint64 so start+k can't wrap mid-scan when the cursor is near
+			// MaxUint32: a uint32 add there would alias an index and skip a real
+			// peer, false-shedding (503) if the skipped peer was the lone under-cap one.
+			c := &l.peers[(uint64(start)+uint64(k))%uint64(n)]
+			a := c.active.Load()
+			if c.cap != 0 && a >= c.cap {
+				continue // at/over the bulkhead cap: skip, try the next target
+			}
+			if best == nil || a*best.weight < bestA*c.weight {
+				best, bestA = c, a
+			}
 		}
+		if best == nil {
+			return nil, false // every target saturated -> shed
+		}
+		if l.claim(best, bestA) {
+			return best, true
+		}
+		// best filled between the read and the CAS; re-scan (it will now be skipped).
 	}
-	return best
+}
+
+// claim atomically takes a slot on p if it is still under its cap, given the load
+// pick already observed in expected. cap == 0 is unbounded (a plain increment, the
+// uncapped fast path — behaviorally identical to today's leastconn). Otherwise the
+// CAS commits only against the exact value observed, so the cap is HARD: under a
+// burst active can never exceed cap. A CAS lost to a sibling release retries on the
+// same peer (still the best choice); a peer that has since filled returns false so
+// pick re-scans for another under-cap target.
+func (l *LeastConnLoadBalancer) claim(p *lcPeer, expected int64) bool {
+	if p.cap == 0 {
+		p.active.Add(1)
+		return true
+	}
+	for {
+		if expected >= p.cap {
+			return false // filled; caller re-scans
+		}
+		if p.active.CompareAndSwap(expected, expected+1) {
+			return true
+		}
+		expected = p.active.Load() // lost the CAS to a sibling; re-read this peer
+	}
 }
 
 // lcBody decrements the target's active count when the response body is closed.

--- a/pkg/upstream/loadbalancer.go
+++ b/pkg/upstream/loadbalancer.go
@@ -17,6 +17,30 @@ type Target struct {
 	// RoundRobinLoadBalancer, EjectingLoadBalancer, and CircuitBreakingLoadBalancer
 	// ignore this field and weight every target equally.
 	Weight int
+
+	// MaxConcurrent caps the in-flight requests LeastConnLoadBalancer routes to this
+	// target (the bulkhead pattern), isolating blast radius: a slow backend can hold
+	// at most this many in-flight requests and cannot drain the pool. A request
+	// counts as in-flight until its response body is closed (not at the headers), so
+	// the cap bounds true end-to-end concurrency including slow body streams. Beyond
+	// the cap, requests route to another under-cap target; when EVERY target is at
+	// its cap the balancer sheds (ErrUnavailable -> 503) rather than overloading a
+	// saturated origin. The cap is hard — never exceeded, even under a concurrent
+	// burst. Values <= 0 mean unbounded (the default). Only LeastConnLoadBalancer
+	// honors it; the other balancers ignore it.
+	//
+	// WARNING: a slot is held until the response body is closed; nothing else
+	// reclaims it. A backend that sends headers then stalls mid-body keeps its slot
+	// until the request's context is cancelled (which closes the body). No
+	// http.Transport timeout covers that stall: ResponseHeaderTimeout bounds only
+	// time-to-headers, and IdleConnTimeout reaps only idle pooled connections, never
+	// an in-flight stalled one. To bound a held slot you must cap TOTAL request time
+	// so the context is cancelled mid-body — a request-scoped context deadline the
+	// transport honors (note pkg/timeout disarms once upstream headers are written,
+	// so it does NOT cover a mid-body stall). Without such a total-time bound, after
+	// MaxConcurrent stalled requests the target sheds all traffic permanently — the
+	// cap becomes a latch, not a limiter.
+	MaxConcurrent int
 }
 
 // effectiveWeight normalizes a target's weight for the weighted balancers: a


### PR DESCRIPTION
## What

Add `Target.MaxConcurrent` — a per-target in-flight cap (the **bulkhead** pattern) honored by `LeastConnLoadBalancer`. A slow backend can hold at most `MaxConcurrent` requests and cannot drain the pool; surplus requests route to an under-cap target, and when every target is full the balancer sheds with `ErrUnavailable` (→ 503) instead of overloading a saturated origin.

## How

- `lcPeer` gains a `cap` field, read once in `init()` from `Target.MaxConcurrent` (`<= 0` → unbounded).
- `pick()` now skips at-cap targets and **atomically claims** the chosen slot before returning (`pick(n) (*lcPeer, bool)`); the old unconditional `active.Add(1)` in `RoundTrip` is gone, so there is no double-increment.
- `claim(p, expected)` does a CAS that commits **only** against the load `pick` observed, so the cap is **hard** — `active` can never exceed `cap` even under a concurrent burst. `cap == 0` takes a plain-increment fast path, behaviorally identical to today's LeastConn.
- A slot is released exactly where it always was: the `lcBody`/`lcRWCBody` `Close()` (panic-safe + body-close), reusing the existing accounting.

## Also fixes a latent bug

`pick()`'s index `(start+k) % uint32(n)` was computed in `uint32`, so when the tie-break cursor wrapped near `MaxUint32` and `n` isn't a power of two, the scan could alias an index and **skip a real peer**. Benign before (a momentary misroute), but the cap turns it into a false **503** when the skipped peer is the lone under-cap one. Index math is now `uint64`. Guarded by `RotationCursorWrapNoFalseShed` (verified to fail on the old code).

## Operational caveat (documented)

A held slot is reclaimed **only on body close**, never on a transport timeout. The docs now direct operators to bound **total** request time via a request-context deadline — `ResponseHeaderTimeout` (time-to-headers only), `IdleConnTimeout` (idle pooled conns only), and the header-only `pkg/timeout` do **not** cover a mid-body stall. Without a total-time bound the cap becomes a latch, not a limiter.

## Tests

`bulkhead_test.go` (all `-race`):
- `HardCapNeverExceeded` — 24-way burst, blocking transport witnesses `maxSeen <= K`, surplus shed.
- `IndependentPerTargetCaps` — two different caps each bounded independently; drives the concurrent skip/re-scan path.
- `RoutesAroundCappedTarget`, `AllAtCapShedThenReadmit`, `ZeroMaxConcurrentIsUnbounded`, `ErrorPathReleasesSlot`, `WeightClippedByCap`, `RotationCursorWrapNoFalseShed`.

`make` green: `go vet` + `golangci-lint` (0 issues) + `go test -race ./...`.

Purely additive — no behavior change for targets without a cap, and the other balancers ignore the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)