### PR TITLE
feat(upstream): add ActiveHealthCheck (out-of-band probing) gated into all balancers

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,45 @@ cancelled with `context.Canceled`, a custom `IsFailure` on the wrapped balancer
 must exclude it (the default does), or hedging would slowly eject the healthy
 backend it raced.
 
+## Active health checks
+
+The balancers above are **passive** — they learn a target is unhealthy only from
+real traffic's failures. `upstream.NewActiveHealthCheck` adds **active** probing:
+it wraps any balancer and probes each target out-of-band (one background goroutine
+per target), routing only to those answering. Pass the **same** `[]*Target` to both
+the balancer and the wrapper so their indices line up:
+
+```go
+targets := []*upstream.Target{
+	{Host: "10.0.0.1:8080", Transport: tr},
+	{Host: "10.0.0.2:8080", Transport: tr},
+}
+ahc := upstream.NewActiveHealthCheck(targets, upstream.NewRoundRobinLoadBalancer(targets))
+ahc.Path = "/healthz"
+ahc.Interval = 5 * time.Second
+ahc.UnhealthyThld = 3 // down after 3 consecutive failed probes; HealthyThld re-admits
+s.Use(upstream.New(ahc))
+```
+
+Active and passive **compose**: the health gate only *removes* candidates, and the
+wrapped balancer keeps its own strategy over the survivors — a weighted balancer
+keeps its exact ratio, the circuit breaker still trips, least-conn still balances.
+A target must pass **both** to be picked. When the gate marks **every** target down,
+each balancer falls back to its own all-down policy: round-robin / ejecting /
+latency-ejecting / least-conn route best-effort (so a broken probe path can't 503 a
+whole healthy pool), while the circuit breaker still sheds. (Least-conn still sheds
+on its *capacity* cap — `MaxConcurrent` — independently of health.)
+
+Probing auto-starts on the first request and, when served by a `parapet.Server`,
+stops on graceful shutdown. For a bare `RoundTripper`, or to bound the prober's
+lifetime explicitly, call `ahc.Start(ctx)` before serving and `ahc.Close()` after.
+By default a slot probes through each `Target.Transport` (exercising the real pool);
+set `ProbeTransport` to isolate probe traffic. A held probe is bounded by `Timeout`,
+and targets begin **up** by default (`StartUnhealthy` flips to fail-closed) so a
+misconfigured probe path cannot black-hole a fresh deploy. The probe uses `http`;
+for a target on the dynamic multi-scheme `Transport` set `ahc.Scheme` to `"h2c"` or
+`"unix"` (the dedicated transports force their own scheme and ignore it).
+
 ## Trusted proxies
 
 Parapet only reads `X-Forwarded-*` and `X-Real-IP` when the connection comes from a trusted CIDR. Configure trust with `TrustCIDRs(...)` or accept the defaults from `Trusted()` (standard private and loopback ranges). Servers created with `NewFrontend()` start with no trusted proxies by default.

--- a/pkg/upstream/circuitbreaker.go
+++ b/pkg/upstream/circuitbreaker.go
@@ -85,6 +85,7 @@ type CircuitBreakingLoadBalancer struct {
 	once     sync.Once
 	i        atomic.Uint32 // round-robin cursor
 	breakers []cbState     // per-target FSM, built in init()
+	gate     []atomic.Bool // active-HC gate; nil = all up (installed before serving)
 
 	// Targets is the set of upstreams to balance across.
 	Targets []*Target
@@ -230,12 +231,25 @@ func (l *CircuitBreakingLoadBalancer) pick(n int) (*cbState, uint32, cbAdmission
 	start := l.i.Add(1) - 1
 	now := time.Now().UnixNano()
 	for k := uint32(0); k < uint32(n); k++ {
-		b := &l.breakers[(start+k)%uint32(n)]
+		idx := (start + k) % uint32(n)
+		if !l.up(idx) {
+			continue // active-HC says down: skip without admitting
+		}
+		b := &l.breakers[idx]
 		if gen, adm, ok := l.admit(b, now); ok {
 			return b, gen, adm, true
 		}
 	}
-	return nil, 0, 0, false
+	return nil, 0, 0, false // all open, probe-saturated, or gated down -> shed (503)
+}
+
+// setHealthGate installs the active health-check gate (see ActiveHealthCheck).
+func (l *CircuitBreakingLoadBalancer) setHealthGate(gate []atomic.Bool) { l.gate = gate }
+
+// up reports the active-HC verdict for target index i. A nil gate means "always
+// up", so the hot path is unchanged for callers not using active health checks.
+func (l *CircuitBreakingLoadBalancer) up(i uint32) bool {
+	return l.gate == nil || int(i) >= len(l.gate) || l.gate[i].Load() // out-of-range => up (fail open, no panic)
 }
 
 // admit decides whether the breaker will accept a request now. CLOSED always

--- a/pkg/upstream/ejecting.go
+++ b/pkg/upstream/ejecting.go
@@ -42,6 +42,7 @@ type EjectingLoadBalancer struct {
 	once    sync.Once
 	i       atomic.Uint32
 	targets []*ejectTarget
+	gate    []atomic.Bool // active-HC gate; nil = all up (installed before serving)
 
 	// Targets is the set of upstreams to balance across.
 	Targets []*Target
@@ -116,18 +117,29 @@ func (l *EjectingLoadBalancer) RoundTrip(r *http.Request) (*http.Response, error
 }
 
 // pick selects the next selectable target in round-robin order, skipping
-// ejected ones. If all targets are ejected it falls open to the round-robin
-// pick so traffic is never fully black-holed.
+// ejected ones AND any the active-HC gate marks down. If all targets are
+// out it falls open to the round-robin pick so traffic is never fully
+// black-holed.
 func (l *EjectingLoadBalancer) pick(n int) *ejectTarget {
 	start := l.i.Add(1) - 1
 	now := time.Now().UnixNano()
 	for k := uint32(0); k < uint32(n); k++ {
-		t := l.targets[(start+k)%uint32(n)]
-		if t.ejectedUntil.Load() <= now {
+		idx := (start + k) % uint32(n)
+		t := l.targets[idx]
+		if t.ejectedUntil.Load() <= now && l.up(idx) { // passive AND active
 			return t
 		}
 	}
 	return l.targets[start%uint32(n)]
+}
+
+// setHealthGate installs the active health-check gate (see ActiveHealthCheck).
+func (l *EjectingLoadBalancer) setHealthGate(gate []atomic.Bool) { l.gate = gate }
+
+// up reports the active-HC verdict for target index i. A nil gate means "always
+// up", so the hot path is unchanged for callers not using active health checks.
+func (l *EjectingLoadBalancer) up(i uint32) bool {
+	return l.gate == nil || int(i) >= len(l.gate) || l.gate[i].Load() // out-of-range => up (fail open, no panic)
 }
 
 // record updates a target's health from a round-trip result.

--- a/pkg/upstream/example_test.go
+++ b/pkg/upstream/example_test.go
@@ -156,6 +156,27 @@ func ExampleNewHedgingLoadBalancer() {
 	s.Use(upstream.New(h)) // h is the proxy's transport, like any balancer
 }
 
+// Add ACTIVE health checking: probe each target out-of-band and route only to those
+// answering, on top of any balancer's own (passive) strategy. Pass the SAME []*Target
+// to both the balancer and the wrapper so the health gate's indices line up. Active
+// HC only removes candidates; the balancer keeps its strategy over the survivors and
+// composes with passive ejection. When served by a parapet.Server it stops on
+// graceful shutdown automatically; call Start(ctx)/Close() for explicit control.
+func ExampleNewActiveHealthCheck() {
+	tr := &upstream.HTTPTransport{}
+	targets := []*upstream.Target{
+		{Host: "10.0.0.1:8080", Transport: tr},
+		{Host: "10.0.0.2:8080", Transport: tr},
+	}
+	ahc := upstream.NewActiveHealthCheck(targets, upstream.NewRoundRobinLoadBalancer(targets))
+	ahc.Path = "/healthz"
+	ahc.Interval = 5 * time.Second
+	ahc.UnhealthyThld = 3 // down after 3 consecutive failed probes
+
+	s := parapet.New()
+	s.Use(upstream.New(ahc)) // ahc is the proxy's transport, like any balancer
+}
+
 // Observe each origin round-trip via OnRoundTrip — invoked once per attempt with
 // the resolved target, status, latency, and error. Wire it to metrics or logging
 // (see prom.Upstream); here it just inspects the info.

--- a/pkg/upstream/gate_test.go
+++ b/pkg/upstream/gate_test.go
@@ -1,0 +1,268 @@
+package upstream
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gatedBalancer is every package balancer: an http.RoundTripper that accepts an
+// active-HC gate.
+type gatedBalancer interface {
+	http.RoundTripper
+	setHealthGate(gate []atomic.Bool)
+}
+
+func gateTargets(rec http.RoundTripper, hosts ...string) []*Target {
+	ts := make([]*Target, len(hosts))
+	for i, h := range hosts {
+		ts[i] = &Target{Host: h, Transport: rec}
+	}
+	return ts
+}
+
+// gateBuilders is every gateable balancer paired with its documented all-down
+// policy (sheds 503 vs fails open). Shared by the gate tests so each of the six is
+// exercised by name — must-fix #5: gate ALL balancers, with no silent no-op.
+var gateBuilders = []struct {
+	name         string
+	build        func([]*Target) gatedBalancer
+	shedsAllDown bool
+}{
+	{"RoundRobin", func(ts []*Target) gatedBalancer { return NewRoundRobinLoadBalancer(ts) }, false},
+	{"Weighted", func(ts []*Target) gatedBalancer { return NewWeightedRoundRobinLoadBalancer(ts) }, false},
+	{"Ejecting", func(ts []*Target) gatedBalancer { return NewEjectingLoadBalancer(ts) }, false},
+	{"LatencyEjecting", func(ts []*Target) gatedBalancer { return NewLatencyEjectingLoadBalancer(ts) }, false},
+	{"LeastConn", func(ts []*Target) gatedBalancer { return NewLeastConnLoadBalancer(ts) }, false},
+	{"CircuitBreaking", func(ts []*Target) gatedBalancer { return NewCircuitBreakingLoadBalancer(ts) }, true},
+}
+
+// TestGate_AllDownPolicy locks in each balancer's documented all-down behavior when
+// the gate marks every target down: the fail-open balancers route best-effort, the
+// circuit breaker sheds 503.
+func TestGate_AllDownPolicy(t *testing.T) {
+	t.Parallel()
+	for _, tc := range gateBuilders {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ts := gateTargets(freshBody(), "t0", "t1", "t2")
+			lb := tc.build(ts)
+			gate := make([]atomic.Bool, len(ts)) // all false == every target down
+			lb.setHealthGate(gate)
+
+			resp, err := lb.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			if tc.shedsAllDown {
+				assert.Nil(t, resp)
+				assert.ErrorIs(t, err, ErrUnavailable, "the circuit breaker sheds when all targets are gated down")
+			} else {
+				require.NoError(t, err, "a fail-open balancer routes best-effort when all targets are gated down")
+				require.NotNil(t, resp)
+				resp.Body.Close()
+			}
+		})
+	}
+}
+
+// TestGate_SkipsDownTarget confirms EVERY gateable balancer actually removes a single
+// down target from rotation (the common case), routing its share to the survivors —
+// run per balancer so a regression to a silent gate no-op is caught (must-fix #5).
+func TestGate_SkipsDownTarget(t *testing.T) {
+	t.Parallel()
+	for _, tc := range gateBuilders {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &recordingTransport{}
+			ts := gateTargets(rec, "t0", "t1", "t2")
+			lb := tc.build(ts)
+			gate := make([]atomic.Bool, 3)
+			gate[0].Store(true)
+			gate[2].Store(true) // t1 is down; t0 and t2 up
+
+			lb.setHealthGate(gate)
+			for range 30 {
+				resp, err := lb.RoundTrip(httptest.NewRequest("GET", "/", nil))
+				require.NoError(t, err)
+				resp.Body.Close()
+			}
+			c := rec.counts()
+			assert.Zero(t, c["t1"], "the down target gets no traffic")
+			assert.Equal(t, 30, c["t0"]+c["t2"], "its share routes to the survivors")
+		})
+	}
+}
+
+// TestGate_ConcurrentFlipWhilePicking exercises the shipped interleaving the prober
+// actually produces: one goroutine flips the gate while others drive RoundTrip. It
+// asserts only that picking under a churning gate never panics and a fail-open
+// balancer never spuriously sheds (the real guard is -race cleanliness).
+func TestGate_ConcurrentFlipWhilePicking(t *testing.T) {
+	t.Parallel()
+	for _, tc := range gateBuilders {
+		if tc.shedsAllDown {
+			continue // a breaker legitimately sheds when the flip lands all-down
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := &recordingTransport{}
+			ts := gateTargets(rec, "t0", "t1", "t2")
+			lb := tc.build(ts)
+			gate := make([]atomic.Bool, 3)
+			for i := range gate {
+				gate[i].Store(true)
+			}
+			lb.setHealthGate(gate)
+
+			stop := make(chan struct{})
+			var flipper sync.WaitGroup
+			flipper.Add(1)
+			go func() {
+				defer flipper.Done()
+				for n := 0; ; n++ {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					gate[n%3].Store(n%2 == 0) // never holds all three down for long
+				}
+			}()
+
+			var wg sync.WaitGroup
+			for range 8 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for range 200 {
+						resp, err := lb.RoundTrip(httptest.NewRequest("GET", "/", nil))
+						assert.NoError(t, err, "a fail-open balancer never spuriously sheds under a gate flip")
+						if resp != nil && resp.Body != nil {
+							resp.Body.Close()
+						}
+					}
+				}()
+			}
+			wg.Wait()
+			close(stop)
+			flipper.Wait()
+		})
+	}
+}
+
+// TestLeastConnGate_HealthFailsOpenButCapacitySheds pins the LeastConn split: the
+// health gate never sheds on its own (a fully-dark pool fails open), but the bulkhead
+// cap still sheds once the (fail-open) targets are saturated.
+func TestLeastConnGate_HealthFailsOpenButCapacitySheds(t *testing.T) {
+	t.Parallel()
+	ts := []*Target{
+		{Host: "a", Transport: freshBody(), MaxConcurrent: 1},
+		{Host: "b", Transport: freshBody(), MaxConcurrent: 1},
+	}
+	lb := NewLeastConnLoadBalancer(ts)
+	gate := make([]atomic.Bool, 2) // all down
+	lb.setHealthGate(gate)
+
+	// All gated down but under cap: fail open and route (don't 503 a whole pool on a
+	// possibly-broken probe path). Hold both in-flight to fill their caps.
+	r1, err := lb.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err, "all-down but under cap fails open")
+	r2, err := lb.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err)
+
+	// Now down AND saturated: the bulkhead capacity decision wins -> shed.
+	resp, err := lb.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, ErrUnavailable, "down and at cap -> shed (the bulkhead contract)")
+
+	r1.Body.Close()
+	r2.Body.Close()
+}
+
+// TestWeightedGate_SurvivorRatioExact is the headline regression test for the SWRR
+// gate (must-fix): with a weight-1 peer gated down, the two survivors must keep their
+// exact 3:1 share — the naive "skip but subtract the full total" drifts it (~2.33:1).
+func TestWeightedGate_SurvivorRatioExact(t *testing.T) {
+	t.Parallel()
+	rec := &recordingTransport{}
+	ts := []*Target{
+		{Host: "heavy", Transport: rec, Weight: 3},
+		{Host: "light", Transport: rec, Weight: 1},
+		{Host: "down", Transport: rec, Weight: 1},
+	}
+	lb := NewWeightedRoundRobinLoadBalancer(ts)
+	gate := make([]atomic.Bool, 3)
+	gate[0].Store(true)
+	gate[1].Store(true)
+	// gate[2] (down) stays false
+
+	lb.setHealthGate(gate)
+	const picks = 4000
+	for range picks {
+		resp, err := lb.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+	c := rec.counts()
+	assert.Zero(t, c["down"], "a gated-down peer is never selected")
+	require.Positive(t, c["light"])
+	assert.InDelta(t, 3.0, float64(c["heavy"])/float64(c["light"]), 0.05,
+		"survivors keep their exact weighted ratio (3:1), not a drifted one")
+}
+
+// TestWeightedGate_RecoveryNoStarvation covers the second SWRR must-fix: a peer that
+// recovers after a long down period must NOT win every subsequent pick (its stale
+// currentWeight is reset), and the pool reconverges to a fair share.
+func TestWeightedGate_RecoveryNoStarvation(t *testing.T) {
+	t.Parallel()
+	rec := &recordingTransport{}
+	ts := gateTargets(rec, "a", "b", "c")
+	for i := range ts {
+		ts[i].Weight = 1
+	}
+	lb := NewWeightedRoundRobinLoadBalancer(ts)
+	gate := make([]atomic.Bool, 3)
+	for i := range gate {
+		gate[i].Store(true)
+	}
+	lb.setHealthGate(gate)
+	lb.once.Do(lb.init) // build peers so the direct pick() calls below are valid
+
+	gate[2].Store(false) // c goes down
+	for range 3000 {     // a,b cycle while c's state is frozen
+		lb.pick()
+	}
+	gate[2].Store(true) // c recovers
+
+	first := map[string]int{}
+	for range 30 {
+		first[lb.pick().Host]++
+	}
+	assert.Less(t, first["c"], 30, "a recovered peer does not thunder-reinstate (win every pick)")
+
+	long := map[string]int{}
+	for range 3000 {
+		long[lb.pick().Host]++
+	}
+	assert.InDelta(t, 1000, long["a"], 120, "the pool reconverges to a fair share")
+	assert.InDelta(t, 1000, long["b"], 120)
+	assert.InDelta(t, 1000, long["c"], 120)
+}
+
+// TestGate_NilGateNoOp confirms the zero-cost default: with no gate installed every
+// balancer behaves exactly as before (here, plain round-robin over all targets).
+func TestGate_NilGateNoOp(t *testing.T) {
+	t.Parallel()
+	rec := &recordingTransport{}
+	ts := gateTargets(rec, "t0", "t1", "t2")
+	lb := NewRoundRobinLoadBalancer(ts) // no setHealthGate call: gate stays nil
+	for range 6 {
+		resp, err := lb.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+	assert.Equal(t, []string{"t0", "t1", "t2", "t0", "t1", "t2"}, rec.hits, "nil gate => unchanged round-robin")
+}

--- a/pkg/upstream/healthcheck.go
+++ b/pkg/upstream/healthcheck.go
@@ -1,0 +1,352 @@
+package upstream
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/moonrhythm/parapet"
+)
+
+// Active health-check defaults.
+const (
+	defaultHCProbePath          = "/"
+	defaultHCProbeMethod        = http.MethodGet
+	defaultHCProbeScheme        = "http"
+	defaultHCProbeInterval      = 10 * time.Second
+	defaultHCProbeTimeout       = 5 * time.Second
+	defaultHCHealthyThreshold   = 1 // recover fast: one good probe re-admits
+	defaultHCUnhealthyThreshold = 3 // matches EjectingLoadBalancer's defaultMaxFails
+
+	// probePlaceholderHost is a syntactically valid authority used only to build the
+	// probe request; the real target Host is assigned to req.URL.Host afterwards, so a
+	// unix-socket path Host is never round-tripped through a URL string (which would
+	// percent-encode its slashes and fail to parse).
+	probePlaceholderHost = "healthcheck.invalid"
+	// probeDrainLimit bounds how much of a probe response body is drained before Close
+	// so the keep-alive connection is returned to the pool rather than dropped.
+	probeDrainLimit = 4 << 10 // 4 KiB
+)
+
+// NewActiveHealthCheck wraps a balancer with background health probing. inner MUST
+// be a balancer built over the SAME []*Target (same pointers, same order) as
+// targets, so the health gate's indices line up — pass the identical slice to both,
+// e.g. NewActiveHealthCheck(targets, NewEjectingLoadBalancer(targets)). Every
+// balancer in this package implements the gate, so inner skips probe-down targets
+// inside its OWN pick (preserving its strategy); a custom RoundTripper that does not
+// implement it still gets probed, but probing cannot influence its routing.
+func NewActiveHealthCheck(targets []*Target, inner http.RoundTripper) *ActiveHealthCheck {
+	return &ActiveHealthCheck{Targets: targets, Balancer: inner}
+}
+
+// ActiveHealthCheck adds out-of-band health probing to a wrapped balancer. It is a
+// drop-in http.RoundTripper for upstream.New: it owns one probe goroutine per
+// target, and publishes each target's verdict into a shared []atomic.Bool "gate"
+// that the wrapped balancer consults in its existing pick. Active health only ever
+// REMOVES candidates — it never overrides the balancer's own (passive) verdict, so
+// a target must satisfy BOTH the active gate AND the balancer's strategy to be
+// chosen; the two compose by AND. When the gate marks a target down, the balancer
+// routes around it per its own policy; when EVERY target is gated down the balancer
+// fails open over its own all-down semantics (RoundRobin/Ejecting/LatencyEjecting/
+// LeastConn route best-effort; CircuitBreaking still sheds 503) — active HC never
+// adds an all-down override, so a broken probe path cannot black-hole a whole pool.
+//
+// Lifecycle: probing auto-starts on the first RoundTrip and (when served by a
+// parapet.Server, via ServerContextKey) stops on graceful shutdown, like
+// pkg/healthz. For a bare RoundTripper, or to fully close the shutdown-race window,
+// call Start(ctx) before serving and Close() after. Close() drains every probe
+// goroutine, so none outlives it.
+//
+// Configuration fields are read once, before the first probe; set them before
+// serving.
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
+type ActiveHealthCheck struct {
+	mu        sync.Mutex // guards the (closed, cancel, spawn) lifecycle decision
+	startOnce sync.Once
+	lazyOnce  sync.Once
+	wg        sync.WaitGroup
+	cancel    context.CancelFunc
+	startCtx  context.Context // set by Start before start(); nil => lazy (Background)
+	closed    bool
+	explicit  bool          // Start(ctx) was called -> skip lazy shutdown registration
+	up        []atomic.Bool // index-aligned to Targets; the shared gate
+	probes    []*probeTarget
+
+	// Targets is the set of upstreams to probe; MUST be the same slice the wrapped
+	// Balancer was built over (see NewActiveHealthCheck).
+	Targets []*Target
+
+	// Balancer is the wrapped strategy. It receives the health gate if it implements
+	// the internal gate interface (all package balancers do).
+	Balancer http.RoundTripper
+
+	// Path and Method are the probe request's URL path and HTTP method. Default "/"
+	// and GET.
+	Path   string
+	Method string
+
+	// Scheme is the probe URL scheme. It matters ONLY for targets backed by the
+	// dynamic multi-scheme Transport, which dispatches on it (use "h2c" or "unix" to
+	// match an h2c/unix data path); the dedicated transports (HTTPTransport,
+	// HTTPSTransport, H2CTransport, UnixTransport) force their own scheme and ignore
+	// it. Default "http". A wrong scheme here probes the wrong protocol and can drive
+	// a healthy backend down, so set it (or ProbeTransport) for non-http data paths.
+	Scheme string
+
+	// Interval is the time between probes for a target. Default 10s.
+	Interval time.Duration
+
+	// Timeout bounds a single probe (a per-probe context deadline). Default 5s.
+	Timeout time.Duration
+
+	// HealthyThld is the number of consecutive successful probes that mark a down
+	// target up again. Default 1 (recover fast).
+	HealthyThld int
+
+	// UnhealthyThld is the number of consecutive failed probes that mark an up target
+	// down. Default 3.
+	UnhealthyThld int
+
+	// ProbeTransport overrides the transport used for probes; nil reuses each
+	// Target.Transport (so the probe exercises the real connection pool/TLS). Set it
+	// to isolate probe traffic from the data pool, or for exotic schemes. Note a probe
+	// shares the data transport's per-host connection budget: with a very small
+	// MaxConn (e.g. 1) an in-flight probe can hold the only connection for up to
+	// Timeout, briefly blocking data requests to that origin — set ProbeTransport to
+	// avoid the contention.
+	ProbeTransport http.RoundTripper
+
+	// StartUnhealthy makes targets begin DOWN (fail-closed cold start): only the first
+	// successful probe admits them. Default false — targets begin up, so a
+	// misconfigured probe path cannot black-hole a fresh deploy.
+	StartUnhealthy bool
+
+	// IsHealthy decides whether a probe result is healthy; nil treats a non-error
+	// response with status < 400 as healthy.
+	IsHealthy func(resp *http.Response, err error) bool
+}
+
+// probeTarget holds one target's probe state. up is the only cross-goroutine field
+// (a pointer into the wrapper's gate slice); okRun/failRun are touched solely by
+// that target's own probe goroutine, so they are plain ints (single-writer).
+type probeTarget struct {
+	target  *Target
+	up      *atomic.Bool
+	okRun   int
+	failRun int
+}
+
+// activeHealthGate is implemented by the package balancers so ActiveHealthCheck can
+// install a per-target up/down gate that the balancer's pick then consults. A nil
+// gate (the default) means "all up", so the hot path is unchanged — one extra
+// atomic load per candidate only when a gate is installed.
+type activeHealthGate interface {
+	setHealthGate(gate []atomic.Bool)
+}
+
+func (a *ActiveHealthCheck) init() {
+	if a.Path == "" {
+		a.Path = defaultHCProbePath
+	}
+	if a.Path[0] != '/' {
+		a.Path = "/" + a.Path
+	}
+	if a.Method == "" {
+		a.Method = defaultHCProbeMethod
+	}
+	if a.Scheme == "" {
+		a.Scheme = defaultHCProbeScheme
+	}
+	if a.Interval <= 0 {
+		a.Interval = defaultHCProbeInterval
+	}
+	if a.Timeout <= 0 {
+		a.Timeout = defaultHCProbeTimeout
+	}
+	if a.HealthyThld <= 0 {
+		a.HealthyThld = defaultHCHealthyThreshold
+	}
+	if a.UnhealthyThld <= 0 {
+		a.UnhealthyThld = defaultHCUnhealthyThreshold
+	}
+
+	a.up = make([]atomic.Bool, len(a.Targets))
+	a.probes = make([]*probeTarget, len(a.Targets))
+	for i := range a.Targets {
+		a.up[i].Store(!a.StartUnhealthy) // fail-open by default
+		a.probes[i] = &probeTarget{target: a.Targets[i], up: &a.up[i]}
+	}
+	if g, ok := a.Balancer.(activeHealthGate); ok {
+		g.setHealthGate(a.up) // inner balancer now skips probe-down targets in its pick
+	}
+}
+
+// Start begins probing under ctx (cancel ctx, or call Close, to stop). Use it for a
+// bare RoundTripper or to bound the prober's lifetime explicitly; otherwise the
+// first RoundTrip auto-starts probing. Calling it after Close, or after a lazy
+// start, is a no-op.
+func (a *ActiveHealthCheck) Start(ctx context.Context) {
+	a.mu.Lock()
+	a.explicit = true
+	if a.startCtx == nil {
+		a.startCtx = ctx
+	}
+	a.mu.Unlock()
+	a.start()
+}
+
+// start runs init + spawns the probe goroutines exactly once. The (closed, cancel,
+// spawn) decision is made under mu so a Close racing a first-RoundTrip start can
+// never leak: if Close set closed first, start spawns nothing; if start spawned
+// first, wg.Add happened before Close's wg.Wait and cancel is published, so Close
+// cancels and drains them.
+func (a *ActiveHealthCheck) start() {
+	a.startOnce.Do(func() {
+		a.init()
+
+		a.mu.Lock()
+		if a.closed {
+			// Close ran first: spawn nothing, and force the gate fail-open. init may have
+			// stored an all-DOWN gate (StartUnhealthy) that no prober will ever lift —
+			// for a shedding balancer (CircuitBreaking) that would 503 the pool forever.
+			for i := range a.up {
+				a.up[i].Store(true)
+			}
+			a.mu.Unlock()
+			return
+		}
+		base := a.startCtx
+		if base == nil {
+			base = context.Background()
+		}
+		ctx, cancel := context.WithCancel(base)
+		a.cancel = cancel
+		a.wg.Add(len(a.probes)) // all Add before any possible wg.Wait in Close
+		probes := a.probes
+		a.mu.Unlock()
+
+		for _, pt := range probes {
+			go a.loop(ctx, pt)
+		}
+	})
+}
+
+// Close stops probing and drains every probe goroutine; idempotent. After Close,
+// start is a no-op, so a late first-RoundTrip never resurrects the prober.
+func (a *ActiveHealthCheck) Close() error {
+	a.mu.Lock()
+	a.closed = true
+	if a.cancel != nil {
+		a.cancel()
+	}
+	a.mu.Unlock()
+	a.wg.Wait()
+	return nil
+}
+
+// RoundTrip starts probing (once), wires graceful shutdown on the lazy path, then
+// defers to the wrapped balancer — the gate already filters its pick, so this never
+// reroutes.
+func (a *ActiveHealthCheck) RoundTrip(r *http.Request) (*http.Response, error) {
+	a.lazyOnce.Do(func() {
+		a.mu.Lock()
+		explicit := a.explicit
+		a.mu.Unlock()
+		if explicit {
+			return // caller owns the lifecycle via Start/Close
+		}
+		if srv, ok := r.Context().Value(parapet.ServerContextKey).(*parapet.Server); ok {
+			srv.RegisterOnShutdown(func() { _ = a.Close() }) // same idiom as healthz
+		}
+	})
+	a.start()
+
+	if len(a.Targets) == 0 {
+		return nil, ErrUnavailable
+	}
+	return a.Balancer.RoundTrip(r)
+}
+
+// loop probes one target immediately (fast cold-start convergence) then every
+// Interval, until ctx is cancelled. Sequential, so a slow probe delays the next
+// tick for its own target only and probes never stack.
+func (a *ActiveHealthCheck) loop(ctx context.Context, pt *probeTarget) {
+	defer a.wg.Done()
+	if ctx.Err() != nil {
+		return // Close raced start: never even probe once
+	}
+	a.probe(ctx, pt)
+
+	t := time.NewTicker(a.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			a.probe(ctx, pt)
+		}
+	}
+}
+
+// probe issues one health request to pt's target and feeds the verdict to observe.
+func (a *ActiveHealthCheck) probe(ctx context.Context, pt *probeTarget) {
+	pctx, cancel := context.WithTimeout(ctx, a.Timeout)
+	defer cancel()
+
+	// Build with a placeholder authority, then assign the real Host and scheme directly
+	// (as the balancers do, r.URL.Host = t.Host) so a unix-socket path Host is never
+	// parsed from a URL string, and the dynamic Transport dispatches on the right scheme.
+	req, err := http.NewRequestWithContext(pctx, a.Method, "http://"+probePlaceholderHost+a.Path, http.NoBody)
+	if err != nil {
+		a.observe(pt, false)
+		return
+	}
+	req.URL.Scheme = a.Scheme
+	req.URL.Host = pt.target.Host
+	// Derive the Host header from URL.Host (the target's dial authority), not the
+	// placeholder. Note this differs from the data path (which forwards the client's
+	// Host): a backend that vhost-routes per request may need a custom IsHealthy or a
+	// probe path that does not depend on the Host header.
+	req.Host = ""
+
+	tr := a.ProbeTransport
+	if tr == nil {
+		tr = pt.target.Transport
+	}
+	resp, rerr := tr.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, probeDrainLimit))
+		_ = resp.Body.Close()
+	}
+	a.observe(pt, a.healthy(resp, rerr))
+}
+
+// observe applies one probe verdict to pt's consecutive-run counters and flips the
+// published up bit on a threshold crossing. Runs only on pt's own goroutine.
+func (a *ActiveHealthCheck) observe(pt *probeTarget, ok bool) {
+	if ok {
+		pt.failRun = 0
+		pt.okRun++
+		if pt.okRun >= a.HealthyThld && !pt.up.Load() {
+			pt.up.Store(true)
+		}
+		return
+	}
+	pt.okRun = 0
+	pt.failRun++
+	if pt.failRun >= a.UnhealthyThld && pt.up.Load() {
+		pt.up.Store(false)
+	}
+}
+
+func (a *ActiveHealthCheck) healthy(resp *http.Response, err error) bool {
+	if a.IsHealthy != nil {
+		return a.IsHealthy(resp, err)
+	}
+	return err == nil && resp != nil && resp.StatusCode < 400
+}

--- a/pkg/upstream/healthcheck_test.go
+++ b/pkg/upstream/healthcheck_test.go
@@ -1,0 +1,373 @@
+package upstream
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet"
+)
+
+// healthFake is a transport that distinguishes probe requests (path == healthPath)
+// from data requests (any other path), counting each and returning a configurable
+// probe status. delay lets a probe outlive its context (for the timeout test).
+type healthFake struct {
+	healthPath string
+	status     atomic.Int32 // probe status code; 0 => 200
+	delay      time.Duration
+	probes     atomic.Int64
+	serves     atomic.Int64
+}
+
+func (f *healthFake) RoundTrip(r *http.Request) (*http.Response, error) {
+	if r.URL.Path == f.healthPath {
+		f.probes.Add(1)
+		if f.delay > 0 {
+			select {
+			case <-time.After(f.delay):
+			case <-r.Context().Done():
+				return nil, r.Context().Err() // a timed-out probe behaves like a real one
+			}
+		}
+		code := int(f.status.Load())
+		if code == 0 {
+			code = 200
+		}
+		return hcResp(code), nil
+	}
+	f.serves.Add(1)
+	return hcResp(200), nil
+}
+
+func hcResp(code int) *http.Response {
+	return &http.Response{StatusCode: code, Body: &countingBody{}, Header: http.Header{}}
+}
+
+func TestActiveHealthCheck_MarksDownAfterThreshold(t *testing.T) {
+	t.Parallel()
+	good := &healthFake{healthPath: "/hz"}
+	bad := &healthFake{healthPath: "/hz"}
+	bad.status.Store(500) // probe returns 5xx -> unhealthy
+	targets := []*Target{{Host: "good", Transport: good}, {Host: "bad", Transport: bad}}
+
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Path = "/hz"
+	ahc.Interval = 5 * time.Millisecond
+	ahc.UnhealthyThld = 2
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ahc.Start(ctx)
+	defer ahc.Close()
+
+	require.Eventually(t, func() bool { return !ahc.up[1].Load() }, 2*time.Second, 5*time.Millisecond,
+		"the 5xx target is marked down after the threshold")
+
+	good.serves.Store(0)
+	bad.serves.Store(0)
+	for range 20 {
+		resp, err := ahc.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		require.NoError(t, err)
+		resp.Body.Close()
+	}
+	assert.EqualValues(t, 0, bad.serves.Load(), "no data traffic routes to the down target")
+	assert.EqualValues(t, 20, good.serves.Load(), "all data traffic routes to the healthy target")
+	assert.Positive(t, bad.probes.Load(), "the down target was probed via its own (default) transport")
+}
+
+func TestActiveHealthCheck_RecoversAfterThreshold(t *testing.T) {
+	t.Parallel()
+	backend := &healthFake{healthPath: "/hz"}
+	backend.status.Store(500) // starts unhealthy
+	targets := []*Target{{Host: "good", Transport: &recordingTransport{}}, {Host: "flap", Transport: backend}}
+
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Path = "/hz"
+	ahc.Interval = 5 * time.Millisecond
+	ahc.HealthyThld = 2
+	ahc.UnhealthyThld = 1
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ahc.Start(ctx)
+	defer ahc.Close()
+
+	require.Eventually(t, func() bool { return !ahc.up[1].Load() }, 2*time.Second, 5*time.Millisecond, "starts down")
+	backend.status.Store(200) // recovers
+	require.Eventually(t, func() bool { return ahc.up[1].Load() }, 2*time.Second, 5*time.Millisecond,
+		"after HealthyThld good probes the target is readmitted")
+}
+
+func TestActiveHealthCheck_FlapResetsOppositeCounter(t *testing.T) {
+	t.Parallel()
+	a := &ActiveHealthCheck{HealthyThld: 2, UnhealthyThld: 3}
+	var up atomic.Bool
+	up.Store(true)
+	pt := &probeTarget{up: &up}
+
+	for _, ok := range []bool{true, false, true, false, true, false, true} {
+		a.observe(pt, ok) // strictly alternating: neither run ever reaches its threshold
+	}
+	assert.True(t, up.Load(), "an alternating ok/fail sequence never crosses a threshold")
+
+	a.observe(pt, false)
+	a.observe(pt, false)
+	a.observe(pt, false) // three consecutive failures now
+	assert.False(t, up.Load(), "UnhealthyThld consecutive failures mark it down")
+}
+
+func TestActiveHealthCheck_StartUnhealthyBeginsDown(t *testing.T) {
+	t.Parallel()
+	targets := []*Target{{Host: "t", Transport: freshBody()}}
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.StartUnhealthy = true
+	ahc.init() // build state without spawning probers
+
+	assert.False(t, ahc.up[0].Load(), "fail-closed cold start: a target begins down until a probe admits it")
+}
+
+func TestActiveHealthCheck_ProbeTimeout(t *testing.T) {
+	t.Parallel()
+	slow := &healthFake{healthPath: "/hz", delay: 200 * time.Millisecond} // never answers within Timeout
+	targets := []*Target{{Host: "slow", Transport: slow}}
+
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Path = "/hz"
+	ahc.Interval = 10 * time.Millisecond
+	ahc.Timeout = 20 * time.Millisecond
+	ahc.UnhealthyThld = 1
+	ahc.StartUnhealthy = true // begins down; a timing-out probe must never bring it up
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ahc.Start(ctx)
+	defer ahc.Close()
+
+	require.Eventually(t, func() bool { return slow.probes.Load() > 2 }, 2*time.Second, 10*time.Millisecond,
+		"the loop keeps probing despite timeouts (a slow probe does not wedge or stack)")
+	assert.False(t, ahc.up[0].Load(), "a probe that exceeds Timeout counts as a failure")
+}
+
+func TestActiveHealthCheck_ProbeTransportOverride(t *testing.T) {
+	t.Parallel()
+	data := &healthFake{healthPath: "/hz"}
+	probeTr := &healthFake{healthPath: "/hz"}
+	targets := []*Target{{Host: "t", Transport: data}}
+
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Path = "/hz"
+	ahc.Interval = 5 * time.Millisecond
+	ahc.ProbeTransport = probeTr
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ahc.Start(ctx)
+	defer ahc.Close()
+
+	require.Eventually(t, func() bool { return probeTr.probes.Load() > 2 }, 2*time.Second, 10*time.Millisecond)
+	assert.EqualValues(t, 0, data.probes.Load(), "probes use ProbeTransport, never the data transport, when set")
+}
+
+// UnixSocketHostProbes is the regression guard for the unix-socket probe bug: a Host
+// containing slashes must be assigned to req.URL.Host directly, never round-tripped
+// through a URL string (which would percent-encode the slashes and fail to parse,
+// leaving the target permanently down). If the request never built, probes would
+// stay 0 and the target would never come up.
+func TestActiveHealthCheck_UnixSocketHostProbes(t *testing.T) {
+	t.Parallel()
+	sock := &healthFake{healthPath: "/hz"}
+	targets := []*Target{{Host: "/var/run/app.sock:80", Transport: sock}}
+
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Path = "/hz"
+	ahc.Interval = 5 * time.Millisecond
+	ahc.HealthyThld = 1
+	ahc.StartUnhealthy = true
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ahc.Start(ctx)
+	defer ahc.Close()
+
+	require.Eventually(t, func() bool { return sock.probes.Load() > 0 }, 2*time.Second, 5*time.Millisecond,
+		"the unix-socket-host probe reaches the transport (the request built without a parse failure)")
+	require.Eventually(t, func() bool { return ahc.up[0].Load() }, 2*time.Second, 5*time.Millisecond,
+		"a healthy unix-socket target is admitted, not held permanently down")
+}
+
+func TestActiveHealthCheck_NonGateInnerNoPanic(t *testing.T) {
+	t.Parallel()
+	backend := &healthFake{healthPath: "/hz"}
+	targets := []*Target{{Host: "t", Transport: backend}}
+	// a custom RoundTripper that does NOT implement activeHealthGate
+	custom := funcTransport(func(r *http.Request) (*http.Response, error) {
+		r.URL.Host = targets[0].Host
+		return targets[0].Transport.RoundTrip(r)
+	})
+
+	ahc := NewActiveHealthCheck(targets, custom)
+	ahc.Path = "/hz"
+	ahc.Interval = 5 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.NotPanics(t, func() {
+		ahc.Start(ctx)
+		resp, err := ahc.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		require.NoError(t, err)
+		resp.Body.Close()
+	})
+	defer ahc.Close()
+	require.Eventually(t, func() bool { return backend.probes.Load() > 0 }, 2*time.Second, 5*time.Millisecond,
+		"probing runs even though the inner RoundTripper cannot be gated")
+}
+
+func TestActiveHealthCheck_CloseBeforeStart(t *testing.T) {
+	t.Parallel()
+	targets := []*Target{{Host: "t", Transport: freshBody()}}
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Interval = time.Hour
+
+	require.NoError(t, ahc.Close()) // Close before any Start
+	assert.NotPanics(t, func() {
+		resp, err := ahc.RoundTrip(httptest.NewRequest("GET", "/", nil)) // a late first request
+		require.NoError(t, err)
+		resp.Body.Close()
+	})
+
+	ahc.mu.Lock()
+	spawned := ahc.cancel != nil
+	ahc.mu.Unlock()
+	assert.False(t, spawned, "Close before Start spawns no prober, and a late RoundTrip never resurrects it")
+}
+
+func TestActiveHealthCheck_CloseDrainsNoLeak(t *testing.T) {
+	// not parallel: NumGoroutine is process-global.
+	base := runtime.NumGoroutine()
+	const n = 5
+	targets := make([]*Target, n)
+	for i := range targets {
+		targets[i] = &Target{Host: "t", Transport: freshBody()}
+	}
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Interval = time.Hour // park on the ticker so Close drains promptly
+
+	ahc.Start(context.Background())
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() >= base+n }, 2*time.Second, 10*time.Millisecond,
+		"one probe goroutine per target")
+	require.NoError(t, ahc.Close())
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() <= base+1 }, 2*time.Second, 10*time.Millisecond,
+		"Close drains every probe goroutine back to baseline")
+}
+
+// StartCloseRace is the deterministic leak test for the lifecycle: a Close that
+// races a first-RoundTrip start must never leak a prober. The race detector is BLIND
+// to the leak (the fixed lifecycle is mutex-guarded, not racy), so the guard is a
+// poll-to-baseline goroutine count, which fails on a timeout if any prober escaped.
+func TestActiveHealthCheck_StartCloseRace(t *testing.T) {
+	// not parallel: NumGoroutine is process-global.
+	base := runtime.NumGoroutine()
+	for range 50 {
+		targets := []*Target{
+			{Host: "a", Transport: freshBody()}, {Host: "b", Transport: freshBody()}, {Host: "c", Transport: freshBody()},
+		}
+		ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+		ahc.Interval = time.Hour
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); ahc.Start(context.Background()) }()
+		go func() { defer wg.Done(); _ = ahc.Close() }()
+		wg.Wait()
+		// No post-loop Close() backstop on purpose: it would cancel any prober the
+		// racing Close missed and mask the very leak this test measures — the poll
+		// below must observe the race's OWN cleanup return to baseline.
+	}
+	require.Eventually(t, func() bool { return runtime.NumGoroutine() <= base+2 }, 3*time.Second, 10*time.Millisecond,
+		"no probe goroutine leaked across 50 Start/Close races")
+}
+
+// LazyStartRegistersShutdown covers the lazy path: a first request served under a
+// parapet.Server arms the prober and registers Close on graceful shutdown, so a
+// SIGTERM stops probing without an explicit Close.
+func TestActiveHealthCheck_LazyStartRegistersShutdown(t *testing.T) {
+	// not parallel: drives a server Shutdown.
+	backend := &healthFake{healthPath: "/hz"}
+	targets := []*Target{{Host: "b", Transport: backend}}
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Path = "/hz"
+	ahc.Interval = time.Hour
+
+	srv := &parapet.Server{WaitBeforeShutdown: time.Millisecond}
+	ctx := context.WithValue(context.Background(), parapet.ServerContextKey, srv)
+	resp, err := ahc.RoundTrip(httptest.NewRequest("GET", "/", nil).WithContext(ctx))
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	require.Eventually(t, func() bool {
+		ahc.mu.Lock()
+		defer ahc.mu.Unlock()
+		return ahc.cancel != nil
+	}, time.Second, 5*time.Millisecond, "the first request lazily armed the prober")
+
+	require.NoError(t, srv.Shutdown())
+	require.Eventually(t, func() bool {
+		ahc.mu.Lock()
+		defer ahc.mu.Unlock()
+		return ahc.closed
+	}, 2*time.Second, 10*time.Millisecond, "graceful shutdown closed the prober via the registered hook")
+}
+
+// CloseBeforeStart with StartUnhealthy installs an all-DOWN gate that no prober will
+// ever lift. For a shedding balancer (CircuitBreaking) that would 503 the pool
+// forever, so start() must force the gate fail-open when it observes closed.
+func TestActiveHealthCheck_CloseBeforeStartCircuitBreakerFailsOpen(t *testing.T) {
+	t.Parallel()
+	targets := []*Target{{Host: "t0", Transport: freshBody()}, {Host: "t1", Transport: freshBody()}}
+	ahc := NewActiveHealthCheck(targets, NewCircuitBreakingLoadBalancer(targets))
+	ahc.StartUnhealthy = true
+	ahc.Interval = time.Hour
+
+	require.NoError(t, ahc.Close()) // close before any start
+
+	resp, err := ahc.RoundTrip(httptest.NewRequest("GET", "/", nil)) // a late request
+	require.NoError(t, err, "a closed wrapper must fail the gate open, not dark-pool a shedding balancer")
+	require.NotNil(t, resp)
+	resp.Body.Close()
+}
+
+// schemeRecorder captures the URL scheme each probe request carries.
+type schemeRecorder struct {
+	scheme atomic.Pointer[string]
+	probes atomic.Int64
+}
+
+func (s *schemeRecorder) RoundTrip(r *http.Request) (*http.Response, error) {
+	sc := r.URL.Scheme
+	s.scheme.Store(&sc)
+	s.probes.Add(1)
+	return hcResp(200), nil
+}
+
+// ProbeCarriesScheme guards that the probe carries the configured Scheme (not a
+// hardcoded http), so a target on the dynamic multi-scheme Transport is probed over
+// the protocol its data path uses, not silently mis-routed and driven down.
+func TestActiveHealthCheck_ProbeCarriesScheme(t *testing.T) {
+	t.Parallel()
+	rec := &schemeRecorder{}
+	targets := []*Target{{Host: "/var/run/app.sock:80", Transport: rec}}
+	ahc := NewActiveHealthCheck(targets, NewRoundRobinLoadBalancer(targets))
+	ahc.Scheme = "unix"
+	ahc.Interval = 5 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ahc.Start(ctx)
+	defer ahc.Close()
+
+	require.Eventually(t, func() bool { return rec.probes.Load() > 0 }, 2*time.Second, 5*time.Millisecond)
+	if p := rec.scheme.Load(); assert.NotNil(t, p) {
+		assert.Equal(t, "unix", *p, "the probe uses the configured Scheme for the dynamic Transport's dispatch")
+	}
+}

--- a/pkg/upstream/latencyejecting.go
+++ b/pkg/upstream/latencyejecting.go
@@ -63,6 +63,7 @@ type LatencyEjectingLoadBalancer struct {
 	i     atomic.Uint32 // round-robin cursor
 	tau   float64       // HalfLife / ln2, precomputed in init
 	peers []latPeer     // per-target state, built in init
+	gate  []atomic.Bool // active-HC gate; nil = all up (installed before serving)
 
 	// Targets is the set of upstreams to balance across.
 	Targets []*Target
@@ -209,12 +210,22 @@ func (l *LatencyEjectingLoadBalancer) pick(n int) *latPeer {
 		return &l.peers[start%uint32(n)] // panic: distrust the signal, spread to all
 	}
 	for k := uint32(0); k < uint32(n); k++ {
-		p := &l.peers[(start+k)%uint32(n)]
-		if p.ejectedUntil.Load() <= now {
+		idx := (start + k) % uint32(n)
+		p := &l.peers[idx]
+		if p.ejectedUntil.Load() <= now && l.up(idx) { // not latency-ejected AND active-HC up
 			return p
 		}
 	}
-	return &l.peers[start%uint32(n)] // all ejected -> fail open
+	return &l.peers[start%uint32(n)] // all ejected/down -> fail open (slow beats 503)
+}
+
+// setHealthGate installs the active health-check gate (see ActiveHealthCheck).
+func (l *LatencyEjectingLoadBalancer) setHealthGate(gate []atomic.Bool) { l.gate = gate }
+
+// up reports the active-HC verdict for target index i. A nil gate means "always
+// up", so the hot path is unchanged for callers not using active health checks.
+func (l *LatencyEjectingLoadBalancer) up(i uint32) bool {
+	return l.gate == nil || int(i) >= len(l.gate) || l.gate[i].Load() // out-of-range => up (fail open, no panic)
 }
 
 // record feeds a completed round-trip's latency into the target's EWMA and runs the

--- a/pkg/upstream/leastconn.go
+++ b/pkg/upstream/leastconn.go
@@ -33,6 +33,7 @@ type LeastConnLoadBalancer struct {
 	once  sync.Once
 	i     atomic.Uint32 // rotation cursor for breaking equal-load ties
 	peers []lcPeer
+	gate  []atomic.Bool // active-HC gate; nil = all up (installed before serving)
 
 	// Targets is the set of upstreams to balance across.
 	Targets []*Target
@@ -129,14 +130,28 @@ func (l *LeastConnLoadBalancer) RoundTrip(r *http.Request) (*http.Response, erro
 // the system is livelock-free.
 func (l *LeastConnLoadBalancer) pick(n int) (*lcPeer, bool) {
 	start := l.i.Add(1) - 1
+	// failOpen ignores the active-HC gate for this pick. It engages only when the
+	// gate has marked EVERY target down: a saturated-but-healthy pool sheds (the
+	// bulkhead contract), but a fully probe-dark pool routes best-effort rather than
+	// 503ing on a possibly-broken probe path. Nil gate => never engages, zero cost.
+	failOpen := false
 	for {
 		var best *lcPeer
 		var bestA int64
+		sawUp := false // any gate-up peer seen THIS scan (whether or not under cap)
 		for k := uint32(0); k < uint32(n); k++ {
 			// uint64 so start+k can't wrap mid-scan when the cursor is near
 			// MaxUint32: a uint32 add there would alias an index and skip a real
 			// peer, false-shedding (503) if the skipped peer was the lone under-cap one.
-			c := &l.peers[(uint64(start)+uint64(k))%uint64(n)]
+			idx := uint32((uint64(start) + uint64(k)) % uint64(n))
+			c := &l.peers[idx]
+			if !failOpen {
+				if l.up(idx) {
+					sawUp = true
+				} else {
+					continue // active-HC down: skip (unless the whole pool is dark)
+				}
+			}
 			a := c.active.Load()
 			if c.cap != 0 && a >= c.cap {
 				continue // at/over the bulkhead cap: skip, try the next target
@@ -146,13 +161,33 @@ func (l *LeastConnLoadBalancer) pick(n int) (*lcPeer, bool) {
 			}
 		}
 		if best == nil {
-			return nil, false // every target saturated -> shed
+			// Nothing selectable in THIS snapshot. sawUp distinguishes the two reasons
+			// from the SAME scan (no second scan to race a concurrent gate flip): if no
+			// peer was even up, the pool is dark -> fail open and re-scan ignoring the
+			// gate; if some peer WAS up (just saturated), that's the bulkhead capacity
+			// shed. A nil gate makes sawUp always true, so it sheds exactly as before.
+			if !failOpen && !sawUp {
+				failOpen = true
+				continue
+			}
+			return nil, false // saturated, or down-and-saturated -> shed
 		}
 		if l.claim(best, bestA) {
 			return best, true
 		}
 		// best filled between the read and the CAS; re-scan (it will now be skipped).
 	}
+}
+
+// setHealthGate installs the active health-check gate (see ActiveHealthCheck).
+func (l *LeastConnLoadBalancer) setHealthGate(gate []atomic.Bool) { l.gate = gate }
+
+// up reports the active-HC verdict for target index i. A nil gate means "always
+// up", so the hot path is unchanged for callers not using active health checks. An
+// out-of-range i (a gate sized to fewer targets than the balancer) is also treated
+// as up, so a mis-wire fails open rather than panicking on the hot path.
+func (l *LeastConnLoadBalancer) up(i uint32) bool {
+	return l.gate == nil || int(i) >= len(l.gate) || l.gate[i].Load()
 }
 
 // claim atomically takes a slot on p if it is still under its cap, given the load

--- a/pkg/upstream/loadbalancer.go
+++ b/pkg/upstream/loadbalancer.go
@@ -61,21 +61,46 @@ func NewRoundRobinLoadBalancer(targets []*Target) *RoundRobinLoadBalancer {
 }
 
 // RoundRobinLoadBalancer strategy
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
 type RoundRobinLoadBalancer struct {
+	i    uint32
+	gate []atomic.Bool // active-HC gate; nil = all up (installed before serving)
+
 	Targets []*Target
-	i       uint32
 }
 
-// RoundTrip sends a request to upstream server
+// RoundTrip sends a request to the next upstream server in round-robin order,
+// skipping any the active-HC gate marks down; if every target is down it falls open
+// to the next slot so traffic is never fully black-holed.
 func (l *RoundRobinLoadBalancer) RoundTrip(r *http.Request) (*http.Response, error) {
-	if len(l.Targets) == 0 {
+	n := len(l.Targets)
+	if n == 0 {
 		return nil, ErrUnavailable
 	}
 
-	i := atomic.AddUint32(&l.i, 1) - 1
-	i %= uint32(len(l.Targets))
-	t := l.Targets[i]
+	start := atomic.AddUint32(&l.i, 1) - 1
+	t := l.Targets[start%uint32(n)] // fail-open default if every target is gated down
+	for k := uint32(0); k < uint32(n); k++ {
+		idx := (start + k) % uint32(n)
+		if l.up(idx) {
+			t = l.Targets[idx]
+			break
+		}
+	}
 
 	r.URL.Host = t.Host
 	return t.Transport.RoundTrip(r)
+}
+
+// setHealthGate installs the active health-check gate (see ActiveHealthCheck).
+func (l *RoundRobinLoadBalancer) setHealthGate(gate []atomic.Bool) { l.gate = gate }
+
+// up reports the active-HC verdict for target index i. A nil gate means "always
+// up", so the hot path is unchanged for callers not using active health checks. An
+// out-of-range i — a gate sized to fewer targets than the balancer, i.e. a violated
+// co-construction contract — is also treated as up, so a mis-wire fails open rather
+// than panicking on the hot path.
+func (l *RoundRobinLoadBalancer) up(i uint32) bool {
+	return l.gate == nil || int(i) >= len(l.gate) || l.gate[i].Load()
 }

--- a/pkg/upstream/weighted.go
+++ b/pkg/upstream/weighted.go
@@ -3,6 +3,7 @@ package upstream
 import (
 	"net/http"
 	"sync"
+	"sync/atomic"
 )
 
 // NewWeightedRoundRobinLoadBalancer creates a weighted round-robin load balancer
@@ -29,6 +30,7 @@ type WeightedRoundRobinLoadBalancer struct {
 	mu    sync.Mutex
 	total int64
 	peers []swrrPeer
+	gate  []atomic.Bool // active-HC gate; nil = all up (installed before serving)
 
 	// Targets is the set of upstreams to balance across.
 	Targets []*Target
@@ -39,6 +41,7 @@ type swrrPeer struct {
 	target  *Target
 	weight  int64 // effective weight, >= 1; immutable after init
 	current int64 // running currentWeight, guarded by the balancer's mu
+	wasUp   bool  // active-HC verdict at the last pick, to detect a down->up recovery
 }
 
 func (l *WeightedRoundRobinLoadBalancer) init() {
@@ -67,8 +70,47 @@ func (l *WeightedRoundRobinLoadBalancer) RoundTrip(r *http.Request) (*http.Respo
 // total; the sum of all currentWeights is invariantly zero across a pick, so the
 // ratios never drift. The lock covers only the integer loop — the network
 // round-trip happens after it is released.
+//
+// With an active-HC gate, SWRR runs over the SURVIVORS only: gated-down peers are
+// neither bumped nor selected, and the winner gives back the LIVE total (the sum of
+// up peers' weights, not l.total) so the survivors' ratio stays exact — subtracting
+// the full total here would drift it. A peer recovering (down->up) has its current
+// reset to 0 so it cannot thunder-reinstate on its stale accumulator. If every peer
+// is gated down it fails open to plain SWRR over all peers (a broken probe path
+// must not black-hole a healthy pool).
 func (l *WeightedRoundRobinLoadBalancer) pick() *Target {
 	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var liveTotal int64
+	best := -1
+	for i := range l.peers {
+		p := &l.peers[i]
+		isUp := l.up(uint32(i))
+		if isUp && !p.wasUp {
+			p.current = 0 // just recovered: drop the stale accumulator
+		}
+		p.wasUp = isUp
+		if !isUp {
+			continue // gated down: do not bump or select; current frozen
+		}
+		p.current += p.weight
+		liveTotal += p.weight
+		if best < 0 || p.current > l.peers[best].current {
+			best = i
+		}
+	}
+	if best < 0 {
+		return l.pickAllOpen() // every target down -> fail open over the whole pool
+	}
+	l.peers[best].current -= liveTotal // give back the LIVE total to preserve the ratio
+	return l.peers[best].target
+}
+
+// pickAllOpen runs one plain SWRR step over every peer, ignoring the gate. Used
+// only when the gate marked all targets down. The caller holds l.mu and has not
+// bumped any peer this step (every peer was skipped), so this is a clean SWRR step.
+func (l *WeightedRoundRobinLoadBalancer) pickAllOpen() *Target {
 	best := -1
 	for i := range l.peers {
 		p := &l.peers[i]
@@ -78,7 +120,14 @@ func (l *WeightedRoundRobinLoadBalancer) pick() *Target {
 		}
 	}
 	l.peers[best].current -= l.total
-	t := l.peers[best].target
-	l.mu.Unlock()
-	return t
+	return l.peers[best].target
+}
+
+// setHealthGate installs the active health-check gate (see ActiveHealthCheck).
+func (l *WeightedRoundRobinLoadBalancer) setHealthGate(gate []atomic.Bool) { l.gate = gate }
+
+// up reports the active-HC verdict for target index i. A nil gate means "always
+// up", so the hot path is unchanged for callers not using active health checks.
+func (l *WeightedRoundRobinLoadBalancer) up(i uint32) bool {
+	return l.gate == nil || int(i) >= len(l.gate) || l.gate[i].Load() // out-of-range => up (fail open, no panic)
 }


### PR DESCRIPTION
## What

`upstream.NewActiveHealthCheck` adds **active** health checking on top of the (passive) balancers: it wraps any balancer and probes each target out-of-band (one goroutine per target), routing only to targets that answer. Pass the **same** `[]*Target` to both:

```go
targets := []*upstream.Target{ {Host: "10.0.0.1:8080", Transport: tr}, {Host: "10.0.0.2:8080", Transport: tr} }
ahc := upstream.NewActiveHealthCheck(targets, upstream.NewRoundRobinLoadBalancer(targets))
ahc.Path = "/healthz"; ahc.UnhealthyThld = 3
s.Use(upstream.New(ahc))
```

## How

- A shared per-target `[]atomic.Bool` **gate**, published by the wrapper and consulted in each balancer's existing `pick`. The gate only *removes* candidates; the balancer keeps its own strategy over the survivors. They compose by **AND**. A nil gate is the unchanged hot path (one short-circuiting nil check).
- **All six** balancers honor it (RoundRobin, Weighted, Ejecting, LatencyEjecting, CircuitBreaking, LeastConn).
- **All-down policy** is each balancer's own: RR/Weighted/Ejecting/LatencyEjecting/LeastConn fail open (a broken probe path can't 503 a healthy pool); CircuitBreaking still sheds. LeastConn keeps its bulkhead capacity shed (`MaxConcurrent`) independent of health.
- **Lifecycle is leak-free**: the `(closed, cancel, spawn)` decision is mutex-guarded, so a `Close` racing a first-`RoundTrip` start can never leak a prober; `wg.Add` always precedes any `wg.Wait`. Auto-stops on `parapet.Server` graceful shutdown; `Start(ctx)`/`Close()` is the explicit path.

## Multi-agent adversarial review

The design returned **fix-then-implement** with 6 must-fixes, all folded in: lifecycle leak (mutex, not the broken atomic.Pointer design), **Weighted SWRR-over-survivors** (subtract the *live* total to keep the exact ratio + reset `current` on recovery), unix-socket probe (no stringify/reparse), deterministic leak test, gate **all six** balancers, LeastConn-vs-Weighted split.

A second scrutiny pass on the implementation (5 dimensions → adversarial verifiers) **confirmed the SWRR correctness** (5 refutations: exact ratio, clean fail-open, correct recovery reset, lock not held across the round-trip) and surfaced findings now fixed:
- **major** — probe hardcoded `http://`, mis-probing the dynamic multi-scheme `Transport` (h2c/unix) → added a `Scheme` field (default `http`); guarded by `ProbeCarriesScheme`.
- **major** — no single-down-skip test for Ejecting/LatencyEjecting (gate could silently regress) → `TestGate_SkipsDownTarget` now runs over **all six** balancers.
- gate sized smaller than the balancer panicked on the hot path → `up()` degrades to fail-open.
- `Close`-before-`Start` + `StartUnhealthy` + CircuitBreaking dark-pooled forever → `start()` forces the gate fail-open when closed; guarded by a new test.
- a concurrent gate flip could spuriously shed in LeastConn → fail-open decided from a single scan snapshot (`sawUp`), not a second scan; guarded by `TestGate_ConcurrentFlipWhilePicking`.
- `StartCloseRace` backstop `Close()` masked the leak it measures → removed.

Each new guard verified load-bearing (fails on the reverted fix).

## Tests

`make` green: `go vet` + `golangci-lint` (0 issues) + `go test -race ./...` (+ 4× full-package stress clean). New `healthcheck_test.go` (lifecycle/probing/leak) and `gate_test.go` (per-balancer gate semantics, weighted survivor-ratio + recovery, concurrent flip). Purely additive — a target with no wrapper is byte-identical (nil gate); other balancers ignore the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)