### PR TITLE
feat(ratelimit): add Redis-backed fixed-window limiter (no Redis client dep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Each subdirectory under `pkg/` is a self-contained middleware:
 | [`location`](pkg/location) | Path routing — exact, prefix, and regexp matchers |
 | [`router`](pkg/router) | Simple URL router |
 | [`block`](pkg/block) | Conditional middleware container — match a request, then apply an inner chain |
-| [`ratelimit`](pkg/ratelimit) | Fixed-window, sliding-window, concurrent, and leaky-bucket limiters |
+| [`ratelimit`](pkg/ratelimit) | Fixed-window (in-memory or Redis-backed for a global limit), sliding-window, concurrent, and leaky-bucket limiters |
 | [`compress`](pkg/compress) | Content-negotiated compression (Gzip, Brotli, Deflate) |
 | [`cache`](pkg/cache) | HTTP response cache — honor-origin policy, in-memory or disk backend, single-flight fills, `X-Cache` tag |
 | [`cache/purge`](pkg/cache/purge) | Cache invalidation — purge by host, URL, path prefix, or surrogate tag, plus a reaper |

--- a/pkg/ratelimit/example_test.go
+++ b/pkg/ratelimit/example_test.go
@@ -32,6 +32,22 @@ func ExampleSlidingWindowPerSecond() {
 	s.Use(ratelimit.SlidingWindowPerSecond(10)) // ~10 req/s per client IP, no boundary doubling
 }
 
+// RedisFixedWindow enforces ONE global limit across a fleet of proxy instances by
+// keeping the counter in Redis. Inject your client via a tiny RedisRunnerFunc
+// adapter so pkg/ratelimit depends on no Redis library; it fails open on a Redis
+// error. Here every instance shares a 1000 req/min budget per client IP.
+func ExampleRedisFixedWindowPerMinute() {
+	// rdb is your *redis.Client (go-redis); the adapter is the only client-specific code.
+	// runner := ratelimit.RedisRunnerFunc(
+	// 	func(ctx context.Context, script string, keys []string, args ...any) (int64, error) {
+	// 		return rdb.Eval(ctx, script, keys, args...).Int64()
+	// 	})
+	var runner ratelimit.RedisRunner // = runner above
+
+	s := parapet.New()
+	s.Use(ratelimit.RedisFixedWindowPerMinute(runner, 1000))
+}
+
 // Concurrent caps the number of in-flight requests per key rather than the
 // arrival rate; once a request finishes, its slot is freed. Excess requests are
 // rejected immediately. Useful for protecting an expensive endpoint from pile-up.

--- a/pkg/ratelimit/redis.go
+++ b/pkg/ratelimit/redis.go
@@ -1,0 +1,171 @@
+package ratelimit
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// fixedWindowScript is one atomic Redis step: INCR the window counter and, only on
+// its birth (n == 1), arm a one-shot TTL. The window epoch is already folded into
+// KEYS[1] client-side, so a new window is simply a new key starting at 0 — LIMITING
+// is always correct regardless of the TTL. PEXPIRE is only best-effort eviction of
+// the dead epoch key; if it ever fails to take (e.g. a server crash mid-script) the
+// stale key merely wastes memory until Redis maxmemory eviction, never mis-limits.
+const fixedWindowScript = `local n = redis.call('INCR', KEYS[1])
+if n == 1 then redis.call('PEXPIRE', KEYS[1], ARGV[1]) end
+return n`
+
+const defaultRedisPrefix = "parapet:rl:"
+
+// RedisRunner is the minimal Redis surface the distributed limiter needs: run a Lua
+// script and return its integer reply. Inject an adapter over your client (go-redis,
+// rueidis, redigo, …) so pkg/ratelimit hard-depends on no Redis client. keys/args
+// map to the script's KEYS/ARGV. Implementations MUST be safe for concurrent use and
+// MUST return either the script's integer reply or a non-nil error (a broken adapter
+// that returns (0, nil) would be read as "1 request seen" and admit).
+type RedisRunner interface {
+	Eval(ctx context.Context, script string, keys []string, args ...any) (int64, error)
+}
+
+// RedisRunnerFunc adapts a plain func to RedisRunner.
+type RedisRunnerFunc func(ctx context.Context, script string, keys []string, args ...any) (int64, error)
+
+// Eval implements RedisRunner.
+func (f RedisRunnerFunc) Eval(ctx context.Context, script string, keys []string, args ...any) (int64, error) {
+	return f(ctx, script, keys, args...)
+}
+
+// RedisFixedWindow creates a Redis-backed fixed-window rate limiter, so N proxy
+// instances enforce one GLOBAL limit. runner is your injected Redis client adapter.
+// It fails OPEN on a Redis error (availability over strict limiting); build the
+// strategy directly to change that.
+func RedisFixedWindow(runner RedisRunner, rate int, unit time.Duration) *RateLimiter {
+	return New(&RedisFixedWindowStrategy{Runner: runner, Max: rate, Size: unit, FailOpen: true})
+}
+
+// RedisFixedWindowPerSecond creates a Redis-backed fixed-window limiter per second.
+func RedisFixedWindowPerSecond(runner RedisRunner, rate int) *RateLimiter {
+	return RedisFixedWindow(runner, rate, time.Second)
+}
+
+// RedisFixedWindowPerMinute creates a Redis-backed fixed-window limiter per minute.
+func RedisFixedWindowPerMinute(runner RedisRunner, rate int) *RateLimiter {
+	return RedisFixedWindow(runner, rate, time.Minute)
+}
+
+// RedisFixedWindowPerHour creates a Redis-backed fixed-window limiter per hour.
+func RedisFixedWindowPerHour(runner RedisRunner, rate int) *RateLimiter {
+	return RedisFixedWindow(runner, rate, time.Hour)
+}
+
+// RedisFixedWindowStrategy implements Strategy with a Redis-backed fixed window, so a
+// fleet of proxy instances shares one global counter per key. The hot path is one
+// atomic Lua round-trip; all mutable state lives in Redis (no local map, no mutex).
+//
+// Config is read once on first use; set fields before serving. The zero value fails
+// CLOSED on a Redis error (deny); the constructors set FailOpen = true (fail open for
+// availability). Like the in-memory FixedWindowStrategy it admits up to 2*Max across
+// a window boundary, ignores Weight, and has no background goroutine.
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
+type RedisFixedWindowStrategy struct {
+	once    sync.Once
+	size    time.Duration // resolved Size
+	prefix  string        // resolved Prefix
+	timeout time.Duration // resolved Timeout
+
+	// Runner is the REQUIRED injected Redis client adapter. A nil Runner makes every
+	// Take fail per FailOpen (no panic on the hot path).
+	Runner RedisRunner
+
+	// Max is the global tokens per window. Max <= 0 admits nothing.
+	Max int
+
+	// Size is the window size; <= 0 resolves to time.Second. Windows that do not
+	// divide an hour are fine here (After is epoch-anchored, see below).
+	Size time.Duration
+
+	// Prefix namespaces the Redis keys; "" resolves to "parapet:rl:".
+	Prefix string
+
+	// Timeout bounds each Take's Redis round-trip (a per-call context deadline); <= 0
+	// resolves to 100ms. It bounds a SLOW (not just failed) Redis off the hot path.
+	Timeout time.Duration
+
+	// FailOpen decides a Redis error: true admits (the constructors' default), false
+	// denies (the zero value). Fail open trades strict limiting for availability.
+	FailOpen bool
+
+	// OnError observes a Redis error (timeout, dial, script error); nil ignores it.
+	OnError func(error)
+}
+
+func (b *RedisFixedWindowStrategy) init() {
+	b.size = b.Size
+	if b.size <= 0 {
+		b.size = time.Second
+	}
+	b.timeout = b.Timeout
+	if b.timeout <= 0 {
+		b.timeout = 100 * time.Millisecond
+	}
+	b.prefix = b.Prefix
+	if b.prefix == "" {
+		b.prefix = defaultRedisPrefix
+	}
+}
+
+// Take atomically increments the current window's Redis counter and reports whether
+// the caller is within Max. Exactly one round-trip; the over-Max request is still
+// counted (the safe direction — never over-admits). On any Redis error (including a
+// Timeout) it fails open or closed per FailOpen.
+func (b *RedisFixedWindowStrategy) Take(key string) bool {
+	b.once.Do(b.init)
+	if b.Runner == nil {
+		return b.FailOpen
+	}
+
+	// Client-side epoch -> the same wall-clock window as the in-memory FixedWindow and
+	// as After below. A distinct epoch is a distinct key, so window rollover is
+	// lock-free (a fresh key starts at 0).
+	epoch := time.Now().UnixNano() / int64(b.size)
+	rkey := b.prefix + key + ":" + strconv.FormatInt(epoch, 10)
+	// Window + 1s slack so a clock-skewed reader of the SAME epoch still finds the
+	// key before it self-evicts; PEXPIRE is just a janitor. The slack also floors the
+	// TTL at >= 1s, so a sub-second Size never yields a non-positive PEXPIRE.
+	ttlMs := b.size.Milliseconds() + 1000
+
+	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	defer cancel()
+
+	n, err := b.Runner.Eval(ctx, fixedWindowScript, []string{rkey}, ttlMs)
+	if err != nil {
+		if b.OnError != nil {
+			b.OnError(err)
+		}
+		return b.FailOpen
+	}
+	return n <= int64(b.Max)
+}
+
+// Put is a no-op: a fixed window does not return tokens (matches FixedWindow).
+func (b *RedisFixedWindowStrategy) Put(string) {}
+
+// After returns the time until the current window rolls over, with NO round-trip. It
+// is anchored to the SAME integer epoch (now/Size) folded into the Redis key, so the
+// returned duration is exactly the time to the end of the current window's key.
+//
+// This intentionally DIVERGES from FixedWindowStrategy.After, which uses
+// time.Truncate (anchored to time.Time's year-1 zero) and is therefore only correct
+// for windows that divide an hour; epoch anchoring is correct for ANY Size. The
+// middleware only calls After after a rejecting Take, so it always reflects a window
+// the key is currently in.
+func (b *RedisFixedWindowStrategy) After(string) time.Duration {
+	b.once.Do(b.init) // resolve b.size even if After races ahead of the first Take
+	now := time.Now()
+	epoch := now.UnixNano() / int64(b.size)
+	next := time.Unix(0, (epoch+1)*int64(b.size))
+	return next.Sub(now)
+}

--- a/pkg/ratelimit/redis_test.go
+++ b/pkg/ratelimit/redis_test.go
@@ -1,0 +1,283 @@
+package ratelimit_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/moonrhythm/parapet/pkg/ratelimit"
+)
+
+// fakeRedis simulates a single-threaded Redis INCR+PEXPIRE over an in-process map,
+// capturing the last call so tests can assert the key/args the strategy builds.
+type fakeRedis struct {
+	mu       sync.Mutex
+	data     map[string]int64
+	lastKeys []string
+	lastArgs []any
+	err      error         // if set, Eval returns it
+	block    chan struct{} // if set, Eval blocks until ctx is done (slow-Redis sim)
+	calls    atomic.Int64
+}
+
+func (f *fakeRedis) Eval(ctx context.Context, _ string, keys []string, args ...any) (int64, error) {
+	f.calls.Add(1)
+	f.mu.Lock()
+	f.lastKeys, f.lastArgs = keys, args
+	f.mu.Unlock()
+
+	if f.block != nil {
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-f.block:
+		}
+	}
+	if f.err != nil {
+		return 0, f.err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.data == nil {
+		f.data = map[string]int64{}
+	}
+	f.data[keys[0]]++
+	return f.data[keys[0]], nil
+}
+
+func newFakeRedis() *fakeRedis { return &fakeRedis{data: map[string]int64{}} }
+
+func TestRedisFixedWindowConstructors(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis()
+
+	cases := []struct {
+		name string
+		m    *RateLimiter
+		size time.Duration
+	}{
+		{"RedisFixedWindow", RedisFixedWindow(f, 5, 2*time.Second), 2 * time.Second},
+		{"PerSecond", RedisFixedWindowPerSecond(f, 5), time.Second},
+		{"PerMinute", RedisFixedWindowPerMinute(f, 5), time.Minute},
+		{"PerHour", RedisFixedWindowPerHour(f, 5), time.Hour},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, ok := tc.m.Strategy.(*RedisFixedWindowStrategy)
+			require.True(t, ok)
+			assert.True(t, s.FailOpen, "constructors fail open")
+			assert.Equal(t, 5, s.Max)
+			assert.Equal(t, tc.size, s.Size)
+		})
+	}
+}
+
+func TestRedisFixedWindowAdmitsThenDenies(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis()
+	b := &RedisFixedWindowStrategy{Runner: f, Max: 2, Size: time.Hour}
+
+	assert.True(t, b.Take("a"))
+	assert.True(t, b.Take("a"))
+	assert.False(t, b.Take("a"), "3rd over Max=2 denied")
+	assert.True(t, b.Take("b"), "a different key is independent")
+
+	// The key is namespaced and epoch-suffixed.
+	epoch := time.Now().UnixNano() / int64(time.Hour)
+	require.Len(t, f.lastKeys, 1)
+	assert.True(t, strings.HasPrefix(f.lastKeys[0], "parapet:rl:"), "default prefix")
+	assert.True(t, strings.HasSuffix(f.lastKeys[0], ":"+strconv.FormatInt(epoch, 10)), "epoch suffix")
+	assert.Contains(t, f.lastKeys[0], "b")
+}
+
+// TestRedisFixedWindowExactlyMaxUnderRace is THE cross-instance no-double-grant
+// property, simulated: many goroutines hammer one key against a single-threaded
+// (mutex-serialized) counter; exactly Max must be admitted.
+func TestRedisFixedWindowExactlyMaxUnderRace(t *testing.T) {
+	t.Parallel()
+	const g, r, max = 16, 50, 100
+	f := newFakeRedis()
+	b := &RedisFixedWindowStrategy{Runner: f, Max: max, Size: time.Hour, FailOpen: true}
+
+	var admitted atomic.Int64
+	var wg sync.WaitGroup
+	for range g {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range r {
+				if b.Take("k") {
+					admitted.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	assert.EqualValues(t, max, admitted.Load(), "exactly Max admitted across all goroutines")
+}
+
+func TestRedisFixedWindowRollsToFreshWindow(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis()
+	const size = 50 * time.Millisecond
+	b := &RedisFixedWindowStrategy{Runner: f, Max: 1, Size: size}
+
+	// Align to just after a window boundary so the two same-window Takes below cannot
+	// straddle one (epochs are absolute now/Size, not relative to the first call).
+	now := time.Now().UnixNano()
+	time.Sleep(time.Duration((now/int64(size)+1)*int64(size) - now))
+
+	require.True(t, b.Take("k"))
+	require.False(t, b.Take("k"), "window exhausted")
+	time.Sleep(size) // cross into the next epoch
+	assert.True(t, b.Take("k"), "a fresh epoch key starts at 0")
+}
+
+// TestRedisFixedWindowMaxZeroAdmitsNothing pins the Max<=0 branch (where n<=Max goes
+// negative), matching the in-memory FixedWindow's admit-nothing reading.
+func TestRedisFixedWindowMaxZeroAdmitsNothing(t *testing.T) {
+	t.Parallel()
+	b := &RedisFixedWindowStrategy{Runner: newFakeRedis(), Max: 0, Size: time.Hour}
+	assert.False(t, b.Take("k"))
+	assert.False(t, b.Take("k"))
+}
+
+// TestRedisFixedWindowAfterEpochAnchored: After must equal the time to the end of the
+// integer-epoch window for ANY Size — including windows that do NOT divide an hour,
+// where the in-memory FixedWindow's time.Truncate answer would be wrong.
+func TestRedisFixedWindowAfterEpochAnchored(t *testing.T) {
+	t.Parallel()
+	for _, size := range []time.Duration{time.Second, 7 * time.Second, 13 * time.Minute, time.Hour} {
+		b := &RedisFixedWindowStrategy{Runner: newFakeRedis(), Max: 1, Size: size}
+		now := time.Now()
+		got := b.After("k")
+		// After reads the clock again internally; if that read crossed an epoch
+		// boundary (astronomically rare), `want` and `got` reference different windows.
+		// Skip that vanishing case rather than flake.
+		if now.UnixNano()/int64(size) != time.Now().UnixNano()/int64(size) {
+			continue
+		}
+		epoch := now.UnixNano() / int64(size)
+		want := time.Unix(0, (epoch+1)*int64(size)).Sub(now)
+		assert.InDelta(t, float64(want), float64(got), float64(5*time.Millisecond),
+			"After is anchored to the integer epoch boundary for Size=%s", size)
+		assert.Positive(t, got)
+		assert.LessOrEqual(t, got, size)
+	}
+}
+
+func TestRedisFixedWindowFailOpenClosed(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("redis down")
+
+	t.Run("fail open admits and reports", func(t *testing.T) {
+		var gotErr error
+		var n atomic.Int64
+		f := &fakeRedis{err: boom}
+		b := &RedisFixedWindowStrategy{Runner: f, Max: 1, Size: time.Second, FailOpen: true,
+			OnError: func(err error) { gotErr = err; n.Add(1) }}
+		assert.True(t, b.Take("k"))
+		assert.Equal(t, boom, gotErr)
+		assert.EqualValues(t, 1, n.Load(), "OnError fired exactly once")
+	})
+
+	t.Run("fail closed denies", func(t *testing.T) {
+		b := &RedisFixedWindowStrategy{Runner: &fakeRedis{err: boom}, Max: 1, Size: time.Second}
+		assert.False(t, b.Take("k"), "zero value fails closed")
+	})
+}
+
+// TestRedisFixedWindowTimeoutBounded: a slow Redis must be bounded by Timeout off the
+// hot path (the failure mode an adapter-side timeout cannot guarantee).
+func TestRedisFixedWindowTimeoutBounded(t *testing.T) {
+	t.Parallel()
+	f := &fakeRedis{block: make(chan struct{})} // never unblocks: only ctx cancels it
+	b := &RedisFixedWindowStrategy{Runner: f, Max: 1, Size: time.Second, Timeout: 20 * time.Millisecond, FailOpen: true}
+
+	start := time.Now()
+	got := b.Take("k")
+	elapsed := time.Since(start)
+	assert.True(t, got, "fails open after the deadline")
+	assert.Less(t, elapsed, 500*time.Millisecond, "the per-Take Timeout bounds the stall")
+	assert.GreaterOrEqual(t, elapsed, 15*time.Millisecond, "it actually waited out the deadline")
+}
+
+func TestRedisFixedWindowNilRunner(t *testing.T) {
+	t.Parallel()
+	assert.NotPanics(t, func() {
+		assert.False(t, (&RedisFixedWindowStrategy{Max: 1, Size: time.Second}).Take("k"), "nil runner fails closed by default")
+		assert.True(t, (&RedisFixedWindowStrategy{Max: 1, Size: time.Second, FailOpen: true}).Take("k"))
+	})
+}
+
+// TestRedisFixedWindowTTLFloor: the +1s slack keeps PEXPIRE >= 1s even for a
+// sub-millisecond Size (a raw ms TTL would be 0/negative).
+func TestRedisFixedWindowTTLFloor(t *testing.T) {
+	t.Parallel()
+	f := newFakeRedis()
+	b := &RedisFixedWindowStrategy{Runner: f, Max: 1, Size: 500 * time.Microsecond}
+	b.Take("k")
+	require.Len(t, f.lastArgs, 1)
+	assert.GreaterOrEqual(t, f.lastArgs[0].(int64), int64(1000), "TTL floored at >= 1000ms")
+}
+
+func TestRedisFixedWindowRunnerFuncForwards(t *testing.T) {
+	t.Parallel()
+	var gotKeys []string
+	var gotArgs []any
+	fn := RedisRunnerFunc(func(_ context.Context, _ string, keys []string, args ...any) (int64, error) {
+		gotKeys, gotArgs = keys, args
+		return 1, nil
+	})
+	b := &RedisFixedWindowStrategy{Runner: fn, Max: 1, Size: time.Hour}
+	assert.True(t, b.Take("k"))
+	require.Len(t, gotKeys, 1)
+	assert.True(t, strings.HasPrefix(gotKeys[0], "parapet:rl:"))
+	require.Len(t, gotArgs, 1)
+	assert.EqualValues(t, int64(time.Hour.Milliseconds()+1000), gotArgs[0])
+}
+
+// TestRedisFixedWindowServeHandler wires the strategy through the middleware: the
+// second request from one client gets a 429 with Retry-After, and Put is never used.
+func TestRedisFixedWindowServeHandler(t *testing.T) {
+	t.Parallel()
+	m := RedisFixedWindowPerMinute(newFakeRedis(), 1)
+	m.Key = func(*http.Request) string { return "client" }
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	w1 := httptest.NewRecorder()
+	h.ServeHTTP(w1, httptest.NewRequest("GET", "/", nil))
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, httptest.NewRequest("GET", "/", nil))
+	assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+	assert.NotEmpty(t, w2.Header().Get("Retry-After"), "a denied request carries Retry-After")
+}
+
+// TestRedisFixedWindowAfterRacesTake: After must resolve config via once.Do even when
+// it races the first Take (no data race on b.size).
+func TestRedisFixedWindowAfterRacesTake(t *testing.T) {
+	t.Parallel()
+	b := &RedisFixedWindowStrategy{Runner: newFakeRedis(), Max: 1, Size: time.Second}
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(2)
+		go func() { defer wg.Done(); b.Take("k") }()
+		go func() { defer wg.Done(); _ = b.After("k") }()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## What

A distributed fixed-window rate limiter, so a fleet of proxy instances enforces **one global limit** per key. Crucially, it adds **zero new `go.mod` dependency**: the package owns the atomic Lua script and depends only on a tiny injected `RedisRunner` interface (one `Eval` method). Callers adapt their client in ~3 lines:

```go
runner := ratelimit.RedisRunnerFunc(func(ctx context.Context, s string, keys []string, args ...any) (int64, error) {
    return rdb.Eval(ctx, s, keys, args...).Int64() // rdb is your *redis.Client
})
s.Use(ratelimit.RedisFixedWindowPerMinute(runner, 1000))
```

This follows the in-repo `cache.Storage` pattern ("smallest interface the package needs") — unlike a single-provider integration, the Redis client ecosystem is fragmented, so an interface beats pinning one client + version on every parapet user.

## How

- One atomic `INCR` + birth-only `PEXPIRE`. The window epoch (`now/Size`) is folded into the key **client-side**, so a new window is a fresh key at 0 (lock-free rollover) and `PEXPIRE` is best-effort eviction — **limiting is correct regardless of the TTL**.
- A per-`Take` context `Timeout` (default 100ms) bounds a **slow** Redis off the hot path (the failure an adapter-side timeout can't guarantee); `FailOpen` (constructors default true) decides a Redis error; a nil runner fails per `FailOpen` without a panic.
- Mirrors the `FixedWindow` family one-for-one (`RedisFixedWindow{,PerSecond,PerMinute,PerHour}`), the unchanged `Strategy` interface and middleware, no background goroutine.
- `After()` is anchored to the **same integer epoch** the key uses — not `time.Truncate` (year-1-anchored), which diverges from the Unix-epoch key boundary for windows that don't divide an hour. So `Retry-After` is exact for any `Size`.

## Reviewed

Design pass (`fix-then-implement`) → applied the epoch-anchored `After` (the one must-fix). Implementation scrutiny pass came back **all-nit, no blockers**: the `After` math was verified correct over 200k sampled instants per size, and the regression test confirmed load-bearing (it fails on the old `time.Truncate` for `Size=7s`/`13m`). Folded in the nits: hardened two timing-sensitive tests against a rare epoch straddle, pinned the `Max<=0` admit-nothing branch, and clarified the `PEXPIRE` best-effort-eviction comment.

## Tests

A faithful single-threaded `fakeRedis` (INCR+PEXPIRE) drives: cross-instance exactly-`Max` under `-race`, admit/deny + epoch-suffixed key, fail-open vs fail-closed (+ `OnError`), the `Timeout` bound, nil runner, the TTL floor, `RedisRunnerFunc` forwarding, epoch-anchored `After` across non-hour-divisor sizes, a `ServeHandler` 429 integration, and an `After`-races-`Take` `once.Do` race. `make` green (vet, lint 0 issues, `-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)