### PR TITLE
feat(mirror): add traffic-shadowing middleware (request mirroring)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Each subdirectory under `pkg/` is a self-contained middleware or feature:
 | `host` | Virtual-host routing — matches `Host` header with optional wildcard prefixes. |
 | `location` | Path routing — exact, prefix, and regex matchers. |
 | `block` | Conditional middleware container: match a request, then apply its own inner chain. |
+| `mirror` | Traffic shadowing: tee a copy of matched/sampled requests to a canary chain, fire-and-forget, on a fixed worker pool. Never affects the primary. |
 | `ratelimit` | Fixed-window (per-second/minute/hour), concurrent, and leaky-bucket limiters. |
 | `compress` | Content-negotiated compression: Gzip, Brotli, Deflate. |
 | `headers` | Request/response header manipulation (set, delete, copy). |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Each subdirectory under `pkg/` is a self-contained middleware:
 | [`location`](pkg/location) | Path routing — exact, prefix, and regexp matchers |
 | [`router`](pkg/router) | Simple URL router |
 | [`block`](pkg/block) | Conditional middleware container — match a request, then apply an inner chain |
+| [`mirror`](pkg/mirror) | Traffic shadowing — tee a copy of matched/sampled requests to a canary, fire-and-forget |
 | [`ratelimit`](pkg/ratelimit) | Fixed-window, sliding-window, concurrent, and leaky-bucket limiters |
 | [`compress`](pkg/compress) | Content-negotiated compression (Gzip, Brotli, Deflate) |
 | [`cache`](pkg/cache) | HTTP response cache — honor-origin policy, in-memory or disk backend, single-flight fills, `X-Cache` tag |
@@ -529,6 +530,34 @@ and targets begin **up** by default (`StartUnhealthy` flips to fail-closed) so a
 misconfigured probe path cannot black-hole a fresh deploy. The probe uses `http`;
 for a target on the dynamic multi-scheme `Transport` set `ahc.Scheme` to `"h2c"` or
 `"unix"` (the dedicated transports force their own scheme and ignore it).
+
+## Traffic mirroring (shadowing)
+
+`mirror.New` tees a copy of matched/sampled **requests** to a separate destination
+(a "canary") so you can exercise a new build with real production traffic. It is
+**fire-and-forget**: the primary request and its response are never affected — a
+mirror that is slow, queue-full, or panicking is dropped or recovered, never
+propagated. The canary's response is discarded.
+
+```go
+mr := mirror.New()
+mr.Match = func(r *http.Request) bool { return r.Method == http.MethodGet }
+mr.SampleRate = 0.1                  // shadow 10% of matched requests
+mr.Observe = prom.Mirror()           // optional outcome/latency metrics
+mr.Use(upstream.SingleHost("canary:8080", &upstream.HTTPTransport{}))
+
+s.Use(mr)                            // tees, then falls through to the real chain
+s.Use(upstream.SingleHost("prod:8080", &upstream.HTTPTransport{}))
+```
+
+A fixed worker pool (`Workers`, default 8) bounds mirror concurrency; a full
+`QueueSize` queue drops rather than blocking. The request body is buffered up front
+(bounded by `MaxBodyBytes`) so the primary and the mirror read byte-identical bytes;
+an over-cap body skips the mirror. Each mirror runs on a detached
+`context.Background()` deadline (`Timeout`), so a client disconnect never cancels it.
+The mirrored request is marked (`X-Mirror: 1` by default; `DisableMark` to go fully
+transparent) so the canary can no-op side effects. End-to-end credentials are
+replayed by design — use `Match` to exclude sensitive routes.
 
 ## Trusted proxies
 

--- a/pkg/mirror/example_test.go
+++ b/pkg/mirror/example_test.go
@@ -1,0 +1,26 @@
+package mirror_test
+
+import (
+	"net/http"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/mirror"
+	"github.com/moonrhythm/parapet/pkg/prom"
+	"github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+// Shadow a sample of production GET traffic to a canary backend, fire-and-forget: the
+// mirror never affects the primary request or its response. Mark and sample so the
+// canary can detect (and no-op side effects of) shadow traffic and so only a fraction
+// is teed; Observe wires outcome/latency metrics.
+func ExampleNew() {
+	mr := mirror.New()
+	mr.Match = func(r *http.Request) bool { return r.Method == http.MethodGet }
+	mr.SampleRate = 0.1        // shadow 10% of matched requests
+	mr.Observe = prom.Mirror() // optional outcome/latency metrics
+	mr.Use(upstream.SingleHost("canary:8080", &upstream.HTTPTransport{}))
+
+	s := parapet.NewFrontend()
+	s.Use(mr)                                                          // tees, then falls through to the real chain
+	s.Use(upstream.SingleHost("prod:8080", &upstream.HTTPTransport{})) // the production backend
+}

--- a/pkg/mirror/info.go
+++ b/pkg/mirror/info.go
@@ -1,0 +1,44 @@
+package mirror
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Outcome classifies one mirror decision/result, reported via Observe.
+type Outcome uint8
+
+const (
+	// OutcomeDispatched: the mirror request was enqueued for a worker.
+	OutcomeDispatched Outcome = iota
+	// OutcomeCompleted: a worker finished the round-trip (Status and Duration set).
+	OutcomeCompleted
+	// OutcomeDroppedFull: the queue was full; the mirror was dropped.
+	OutcomeDroppedFull
+	// OutcomeDroppedOversize: the body exceeded MaxBodyBytes; the mirror was skipped.
+	OutcomeDroppedOversize
+	// OutcomePanicked: the mirror chain panicked (recovered; the proxy is unaffected).
+	OutcomePanicked
+)
+
+// MirrorInfo reports one mirror decision/result to Observe.
+//
+//nolint:govet // fields ordered for readability
+type MirrorInfo struct {
+	Outcome  Outcome
+	Status   int           // set on OutcomeCompleted
+	Duration time.Duration // set on OutcomeCompleted
+}
+
+// MirrorFunc is the observation-hook shape (mirrors upstream.RoundTripFunc), returned
+// by prom.Mirror for wiring into Mirror.Observe.
+type MirrorFunc func(info MirrorInfo)
+
+// mirrorJob is one detached mirror request carried through the worker queue. cancel
+// releases the request's detached context (and its timer) when the worker finishes or
+// the job is dropped.
+type mirrorJob struct {
+	req    *http.Request
+	cancel context.CancelFunc
+}

--- a/pkg/mirror/mirror.go
+++ b/pkg/mirror/mirror.go
@@ -1,0 +1,371 @@
+// Package mirror provides a request-shadowing (traffic-mirroring) middleware: it
+// tees a copy of matched/sampled REQUESTS to a separate destination chain (a
+// "canary"), fire-and-forget, without ever affecting the primary request or its
+// response. Use it to exercise a new build with real production traffic.
+package mirror
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"math/rand/v2"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/moonrhythm/parapet"
+)
+
+// hopByHop headers are connection-specific and must not be forwarded to the mirror
+// (the same set as cache/tee.go).
+var hopByHop = map[string]struct{}{
+	"Connection":          {},
+	"Proxy-Connection":    {},
+	"Keep-Alive":          {},
+	"Te":                  {},
+	"Trailer":             {},
+	"Transfer-Encoding":   {},
+	"Upgrade":             {},
+	"Proxy-Authenticate":  {},
+	"Proxy-Authorization": {},
+}
+
+// New creates a request-mirroring middleware. Configure the mirror destination with
+// Use (typically upstream.SingleHost, or a balancer wrapped by upstream.New) and any
+// config fields, then install it ahead of the real chain.
+func New() *Mirror { return &Mirror{} }
+
+// Mirror is a traffic-shadowing Middleware. It tees the REQUEST (not the response) of
+// matched/sampled requests to its destination chain on a fixed worker pool,
+// fire-and-forget, and never affects the primary request. The primary always runs
+// unmodified; a mirror that is slow, full, or panicking is dropped or recovered, not
+// propagated.
+//
+// Config fields and the destination chain (Use) are read once on the first
+// ServeHandler and then FROZEN — set them before serving; a later Use is silently
+// ignored (unlike block.Block, which rebuilds per request). Effective mirror
+// concurrency is Workers, not Workers+QueueSize: the queue only absorbs bursts that
+// drain at worker speed, so under a slow-but-responsive canary the pool caps at
+// Workers and the surplus is dropped (DroppedFull) — size Workers for the canary's
+// latency, and wire Observe to watch the drop counters.
+//
+// The worker pool is started on first use and lives for the PROCESS LIFETIME (no
+// Close): construct one Mirror per destination and reuse it. On graceful shutdown
+// in-flight/queued mirrors are abandoned (each bounded only by Timeout), which is
+// acceptable for fire-and-forget shadow traffic. End-to-end credentials
+// (Authorization, Cookie) are replayed to the canary by design (replay fidelity);
+// use Match to exclude sensitive routes from shadowing.
+//
+//nolint:govet // fields grouped by role (state, then config) for readability
+type Mirror struct {
+	once    sync.Once
+	jobs    chan *mirrorJob
+	handler http.Handler        // built from ms in init()
+	ms      parapet.Middlewares // the mirror destination chain
+
+	dispatched   atomic.Uint64
+	dropFull     atomic.Uint64
+	dropOversize atomic.Uint64
+	completed    atomic.Uint64
+	panicked     atomic.Uint64
+
+	// Match selects which requests are eligible to mirror; nil matches all.
+	Match func(r *http.Request) bool
+
+	// Observe receives one MirrorInfo per decision/result; nil disables it. It is
+	// called SYNCHRONOUSLY and concurrently — on the request goroutine for the
+	// dispatch/drop outcomes (so it must be fast and non-blocking, or it stalls the
+	// primary) and on worker goroutines for completed/panicked — so it must be safe
+	// for concurrent use. See prom.Mirror for a ready, concurrency-safe hook.
+	Observe func(info MirrorInfo)
+
+	// ErrorLog logs a recovered mirror panic; nil uses the standard logger.
+	ErrorLog *log.Logger
+
+	// MarkHeader/MarkValue stamp the mirrored request so the canary can detect it and
+	// no-op side effects. Default "X-Mirror"/"1". Set DisableMark to turn marking off.
+	MarkHeader string
+	MarkValue  string
+
+	// SampleRate is the fraction in [0,1] of MATCHED requests to mirror. The zero
+	// value means 1.0 (mirror all matched) — disable mirroring by NOT installing the
+	// middleware, not by SampleRate=0. Values > 1 clamp to 1; negative clamps to 1.
+	SampleRate float64
+
+	// Timeout bounds a mirror's total in-system lifetime — queue wait plus the
+	// round-trip — as one deadline set at dispatch. It is cooperative: the destination
+	// chain must honor the request context (upstream/httputil do). Default 10s.
+	Timeout time.Duration
+
+	// MaxBodyBytes caps the request body buffered per mirror; a larger body skips the
+	// mirror (the primary is unaffected). Default 1<<20.
+	MaxBodyBytes int64
+
+	// Workers is the fixed number of dispatch goroutines (the real concurrency cap).
+	// Default 8.
+	Workers int
+
+	// QueueSize is the buffered job-queue depth; a full queue drops (never blocks the
+	// primary). Default 256.
+	QueueSize int
+
+	// DisableBody, when true, always mirrors with no body (http.NoBody) — the
+	// zero-buffer mode for large-payload services. The zero value mirrors bodies.
+	DisableBody bool
+
+	// DisableMark, when true, omits the MarkHeader stamp. The zero value marks (so a
+	// canary can detect shadow traffic by default); set it for a fully transparent
+	// mirror.
+	DisableMark bool
+}
+
+// Use appends a middleware to the mirror destination chain. SETUP ONLY: it must be
+// called before the first request; the chain is frozen on first ServeHandler and a
+// later Use is silently ignored.
+func (m *Mirror) Use(x parapet.Middleware) { m.ms.Use(x) }
+
+// UseFunc appends a middleware func to the mirror destination chain. SETUP ONLY (see
+// Use).
+func (m *Mirror) UseFunc(x parapet.MiddlewareFunc) { m.ms.UseFunc(x) }
+
+func (m *Mirror) init() {
+	if m.SampleRate <= 0 {
+		m.SampleRate = 1 // zero/unset/negative => mirror all matched; disable by not installing
+	}
+	if m.SampleRate > 1 {
+		m.SampleRate = 1
+	}
+	if m.MaxBodyBytes <= 0 {
+		m.MaxBodyBytes = 1 << 20
+	}
+	if m.Timeout <= 0 {
+		m.Timeout = 10 * time.Second
+	}
+	if m.Workers <= 0 {
+		m.Workers = 8
+	}
+	if m.QueueSize <= 0 {
+		m.QueueSize = 256
+	}
+	if m.MarkHeader == "" {
+		m.MarkHeader = "X-Mirror"
+	}
+	if m.MarkValue == "" {
+		m.MarkValue = "1"
+	}
+	// Materialize the destination chain once. NotFoundHandler is the terminal, so a
+	// chain with no upstream just 404s into the discard writer (harmless).
+	m.handler = m.ms.ServeHandler(http.NotFoundHandler())
+	m.jobs = make(chan *mirrorJob, m.QueueSize)
+	for range m.Workers {
+		go m.worker()
+	}
+}
+
+func (m *Mirror) logf(format string, v ...any) {
+	if m.ErrorLog == nil {
+		log.Printf(format, v...)
+		return
+	}
+	m.ErrorLog.Printf(format, v...)
+}
+
+func (m *Mirror) emit(info MirrorInfo) {
+	if m.Observe != nil {
+		m.Observe(info)
+	}
+}
+
+// ServeHandler implements parapet.Middleware.
+func (m *Mirror) ServeHandler(next http.Handler) http.Handler {
+	m.once.Do(m.init)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Gate cheapest first; each short-circuits to next with no clone/buffer/goroutine.
+		if m.Match != nil && !m.Match(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if m.SampleRate < 1 && rand.Float64() >= m.SampleRate {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Capture the body ONCE up front, bounded. captureBody rewires r.Body so the
+		// PRIMARY reads identical bytes, and returns the bytes for the mirror (or
+		// declines). It MUST run before r is read elsewhere.
+		body, ok := m.captureBody(r)
+		if !ok {
+			// Body over cap (or unreadable): primary already restored; skip the mirror.
+			m.dropOversize.Add(1)
+			m.emit(MirrorInfo{Outcome: OutcomeDroppedOversize})
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Enqueue the detached mirror BEFORE serving the primary: the body and overflow
+		// decision are already final, the enqueue is a non-blocking send, and starting
+		// the mirror alongside the primary gives the canary realistic timing.
+		m.dispatch(r, body)
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// captureBody reads the body up to MaxBodyBytes, leaving the PRIMARY able to read the
+// identical bytes. It returns:
+//
+//	(nil,  true)  — bodiless request (or DisableBody): the mirror gets NoBody.
+//	(buf,  true)  — body fit the cap: primary rewired to a fresh reader over buf.
+//	(nil,  false) — body exceeds the cap or a read error: primary restored, mirror declined.
+func (m *Mirror) captureBody(r *http.Request) ([]byte, bool) {
+	if m.DisableBody || r.Body == nil || r.Body == http.NoBody {
+		return nil, true
+	}
+	// GetBody (a stdlib-replayable body) lets us read the mirror's copy WITHOUT
+	// disturbing the primary's reader — the primary keeps r.Body untouched. It still
+	// buffers the mirror copy (MaxBodyBytes+1) on the request goroutine.
+	if r.GetBody != nil {
+		if rc, err := r.GetBody(); err == nil {
+			b, err := io.ReadAll(io.LimitReader(rc, m.MaxBodyBytes+1))
+			_ = rc.Close()
+			if err == nil && int64(len(b)) <= m.MaxBodyBytes {
+				return b, true // primary body untouched; mirror replays b
+			}
+		}
+		return nil, false // oversize or replay failed: decline, primary untouched
+	}
+
+	limit := m.MaxBodyBytes
+	var br bytes.Buffer
+	n, err := io.CopyN(&br, r.Body, limit+1)
+	read := br.Bytes()
+	if err != nil && err != io.EOF {
+		// Read error: restore consumed bytes + remainder so the primary is whole; decline.
+		r.Body = restoreBody(read, r.Body)
+		return nil, false
+	}
+	if n > limit {
+		// Over the cap: primary streams normally from read-bytes + untouched remainder.
+		r.Body = restoreBody(read, r.Body)
+		return nil, false
+	}
+	_ = r.Body.Close()
+	// Primary now reads the buffered copy; identical bytes, Content-Length preserved.
+	// Copy out of the buffer so the mirror's view cannot be aliased by buffer reuse.
+	out := append([]byte(nil), read...)
+	r.Body = io.NopCloser(bytes.NewReader(out))
+	return out, true
+}
+
+// restoreBody splices already-read bytes ahead of the untouched remainder, preserving
+// Close on the original body. Used when we decline to mirror but must leave the
+// primary able to read the whole body.
+func restoreBody(read []byte, rest io.ReadCloser) io.ReadCloser {
+	return struct {
+		io.Reader
+		io.Closer
+	}{io.MultiReader(bytes.NewReader(read), rest), rest}
+}
+
+// dispatch builds a detached, header-sanitized, marked mirror request and enqueues it
+// without ever blocking the primary.
+func (m *Mirror) dispatch(r *http.Request, body []byte) {
+	// FRESH root context, NOT WithoutCancel(r.Context()): the mirror outlives the
+	// client request and runs concurrently with its teardown, so it must not share
+	// request-scoped mutable state (logger record, trace span) nor be cancelled when
+	// the client response completes — exactly as pkg/cache/stale.go argues.
+	ctx, cancel := context.WithTimeout(context.Background(), m.Timeout)
+
+	c := r.Clone(ctx) // deep-copies Header/URL/Trailer/Form; mirror mutations are isolated
+	c.RequestURI = "" // must be empty on a client request (else RoundTrip panics)
+	c.RemoteAddr = "" // don't forward, like upstream.go's r.RemoteAddr = ""
+	c.Close = false
+	c.TransferEncoding = nil // else inbound chunked framing overrides our fixed Content-Length
+	for k := range c.Header {
+		if _, hop := hopByHop[http.CanonicalHeaderKey(k)]; hop {
+			delete(c.Header, k)
+		}
+	}
+	c.Header.Del("Expect") // don't negotiate 100-continue with the canary
+	if !m.DisableMark {
+		c.Header.Set(m.MarkHeader, m.MarkValue) // canary can detect and no-op side effects
+	}
+	if body != nil {
+		c.Body = io.NopCloser(bytes.NewReader(body)) // own reader over shared immutable bytes
+		c.ContentLength = int64(len(body))
+		c.GetBody = func() (io.ReadCloser, error) { // lets the proxy retry an idempotent mirror
+			return io.NopCloser(bytes.NewReader(body)), nil
+		}
+	} else {
+		c.Body = http.NoBody
+		c.ContentLength = 0
+		c.GetBody = func() (io.ReadCloser, error) { return http.NoBody, nil }
+	}
+
+	job := &mirrorJob{req: c, cancel: cancel}
+	select {
+	case m.jobs <- job:
+		m.dispatched.Add(1)
+		m.emit(MirrorInfo{Outcome: OutcomeDispatched})
+	default:
+		// Queue full: DROP, never block the primary. Release the context immediately so
+		// its timer does not leak.
+		cancel()
+		m.dropFull.Add(1)
+		m.emit(MirrorInfo{Outcome: OutcomeDroppedFull})
+	}
+}
+
+func (m *Mirror) worker() {
+	for job := range m.jobs {
+		m.serveOne(job)
+	}
+}
+
+// serveOne drives one mirror request and discards its response. recover() is
+// MANDATORY: this goroutine runs outside the http.Server's per-request recover, so a
+// mirror panic would otherwise crash the whole proxy.
+func (m *Mirror) serveOne(job *mirrorJob) {
+	defer job.cancel() // release the detached context (frees the timer) on completion
+	start := time.Now()
+	dw := &discardResponseWriter{}
+	defer func() {
+		if rec := recover(); rec != nil {
+			m.panicked.Add(1)
+			m.logf("mirror: recovered panic: %v", rec)
+			m.emit(MirrorInfo{Outcome: OutcomePanicked})
+		}
+	}()
+	m.handler.ServeHTTP(dw, job.req)
+	m.completed.Add(1)
+	m.emit(MirrorInfo{Outcome: OutcomeCompleted, Status: dw.status, Duration: time.Since(start)})
+}
+
+// Stats returns the lock-free dispatch counters for tests/introspection.
+func (m *Mirror) Stats() (dispatched, dropFull, dropOversize, completed, panicked uint64) {
+	return m.dispatched.Load(), m.dropFull.Load(), m.dropOversize.Load(),
+		m.completed.Load(), m.panicked.Load()
+}
+
+// discardResponseWriter swallows the mirror's response (status/headers/body), like
+// cache/stale.go's discardResponseWriter on a background revalidation. Header() is
+// lazily stable so the proxy can set headers safely; Write drops the body; a no-op
+// Flush satisfies httputil.ReverseProxy's http.Flusher type-assert on streaming
+// responses.
+type discardResponseWriter struct {
+	h      http.Header
+	status int
+}
+
+func (d *discardResponseWriter) Header() http.Header {
+	if d.h == nil {
+		d.h = http.Header{}
+	}
+	return d.h
+}
+
+func (d *discardResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (d *discardResponseWriter) WriteHeader(code int)        { d.status = code }
+func (d *discardResponseWriter) Flush()                      {}

--- a/pkg/mirror/mirror_bench_test.go
+++ b/pkg/mirror/mirror_bench_test.go
@@ -1,0 +1,52 @@
+package mirror_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moonrhythm/parapet/pkg/mirror"
+)
+
+// BenchmarkServeHandlerNoMiss measures the gate-only hot path: a non-matching request
+// short-circuits to next with no clone/buffer/goroutine. This is what every request
+// pays when it is not selected for mirroring.
+func BenchmarkServeHandlerNoMiss(b *testing.B) {
+	m := mirror.New()
+	m.Match = func(*http.Request) bool { return false } // never mirror
+	h := m.ServeHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		h.ServeHTTP(w, r)
+	}
+}
+
+// BenchmarkServeHandlerUnderCapBody measures the capture+dispatch cost of a small
+// mirrored body. A generous queue and a discard destination keep workers from
+// becoming the bottleneck so the bench reflects the request-goroutine cost.
+func BenchmarkServeHandlerUnderCapBody(b *testing.B) {
+	m := mirror.New()
+	m.QueueSize = 1 << 16
+	m.Use(parapetNoopMiddleware{})
+	h := m.ServeHandler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		_, _ = r.Body.Read(make([]byte, 0))
+	}))
+	body := bytes.Repeat([]byte("x"), 256)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		r := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+		h.ServeHTTP(httptest.NewRecorder(), r)
+	}
+}
+
+// parapetNoopMiddleware is a discard mirror destination for benchmarks.
+type parapetNoopMiddleware struct{}
+
+func (parapetNoopMiddleware) ServeHandler(http.Handler) http.Handler {
+	return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+}

--- a/pkg/mirror/mirror_test.go
+++ b/pkg/mirror/mirror_test.go
@@ -1,0 +1,515 @@
+package mirror_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/mirror"
+)
+
+func httputilReverseProxyTo(target string) http.Handler {
+	u, _ := url.Parse(target)
+	return httputil.NewSingleHostReverseProxy(u)
+}
+
+// recorder is a mirror-destination middleware that captures the request it receives
+// and signals done. Behaviors: doPanic panics; gate (if set) blocks the handler until
+// released OR the request context is cancelled (honoring the detached deadline).
+type recorder struct {
+	mu               sync.Mutex
+	method           string
+	host             string
+	header           http.Header
+	body             []byte
+	contentLength    int64
+	transferEncoding []string
+
+	done        chan struct{}
+	doPanic     bool
+	gate        chan struct{}
+	ctxCanceled atomic.Bool
+	ctxHadValue atomic.Bool // did the mirror request inherit a client context value?
+	seen        atomic.Int64
+}
+
+type testCtxKey struct{}
+
+func newRecorder() *recorder { return &recorder{done: make(chan struct{}, 64)} }
+
+func (rc *recorder) ServeHandler(http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if rc.doPanic {
+			panic("mirror boom")
+		}
+		if rc.gate != nil {
+			select {
+			case <-rc.gate:
+			case <-r.Context().Done():
+				rc.ctxCanceled.Store(true)
+				return // context cancelled/timed out: free the worker
+			}
+		}
+		rc.ctxHadValue.Store(r.Context().Value(testCtxKey{}) != nil)
+		b, _ := io.ReadAll(r.Body)
+		rc.mu.Lock()
+		rc.method = r.Method
+		rc.host = r.Host
+		rc.header = r.Header.Clone()
+		rc.body = b
+		rc.contentLength = r.ContentLength
+		rc.transferEncoding = r.TransferEncoding
+		rc.mu.Unlock()
+		rc.seen.Add(1)
+		rc.done <- struct{}{}
+	})
+}
+
+func (rc *recorder) waitDone(t *testing.T) {
+	t.Helper()
+	select {
+	case <-rc.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("mirror did not complete in time")
+	}
+}
+
+func (rc *recorder) gotBody() []byte {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	return rc.body
+}
+
+// newMirror builds a Mirror with the recorder as its destination and small,
+// deterministic pool sizes. Marking is disabled unless a test re-enables it.
+func newMirror(rc *recorder) *mirror.Mirror {
+	m := mirror.New()
+	m.Use(rc)
+	m.Workers = 4
+	m.QueueSize = 16
+	return m
+}
+
+func serve(m *mirror.Mirror, primary http.HandlerFunc, r *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	m.ServeHandler(primary).ServeHTTP(w, r)
+	return w
+}
+
+func TestPrimaryUnaffectedNoBody(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+
+	var primarySaw string
+	w := serve(m, func(w http.ResponseWriter, r *http.Request) {
+		primarySaw = r.Method + " " + r.URL.Path
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = w.Write([]byte("primary"))
+	}, httptest.NewRequest("GET", "/path", nil))
+
+	assert.Equal(t, "GET /path", primarySaw)
+	assert.Equal(t, http.StatusTeapot, w.Code, "the primary response is untouched")
+	assert.Equal(t, "primary", w.Body.String())
+	rc.waitDone(t)
+	assert.Equal(t, "GET", rc.method, "the mirror saw the request too")
+}
+
+// TestPrimaryBodyIdenticalUnderCap is the load-bearing test: independent readers, no
+// shared cursor — both the primary and the mirror see the exact client bytes.
+func TestPrimaryBodyIdenticalUnderCap(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+	want := bytes.Repeat([]byte("abcd"), 1024) // 4 KiB
+
+	var primaryBody []byte
+	serve(m, func(_ http.ResponseWriter, r *http.Request) {
+		primaryBody, _ = io.ReadAll(r.Body)
+	}, httptest.NewRequest("POST", "/", bytes.NewReader(want)))
+
+	assert.Equal(t, want, primaryBody, "the primary reads the whole original body")
+	rc.waitDone(t)
+	assert.Equal(t, want, rc.gotBody(), "the mirror reads byte-identical bytes")
+}
+
+func TestOverCapSkipsMirrorPrimaryWhole(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+	m.MaxBodyBytes = 1024
+	want := bytes.Repeat([]byte("x"), 1025) // cap+1
+
+	var primaryBody []byte
+	serve(m, func(_ http.ResponseWriter, r *http.Request) {
+		primaryBody, _ = io.ReadAll(r.Body)
+	}, httptest.NewRequest("POST", "/", bytes.NewReader(want)))
+
+	assert.Equal(t, want, primaryBody, "primary still reads the COMPLETE oversize body")
+	_, _, dropOversize, _, _ := m.Stats()
+	assert.EqualValues(t, 1, dropOversize, "over-cap is skipped, not mirrored")
+	assert.EqualValues(t, 0, rc.seen.Load())
+}
+
+func TestBodyExactlyAtCapMirrored(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+	m.MaxBodyBytes = 1024
+	want := bytes.Repeat([]byte("y"), 1024) // exactly cap
+
+	serve(m, func(_ http.ResponseWriter, r *http.Request) { _, _ = io.ReadAll(r.Body) },
+		httptest.NewRequest("POST", "/", bytes.NewReader(want)))
+
+	rc.waitDone(t)
+	assert.Equal(t, want, rc.gotBody(), "a body exactly at the cap is mirrored in full")
+}
+
+func TestReadErrorDeclines(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+
+	boom := io.ErrUnexpectedEOF
+	prefix := []byte("partial-bytes-consumed-during-capture")
+	r := httptest.NewRequest("POST", "/", &partialErrReader{data: prefix, err: boom})
+	var primaryBytes []byte
+	var primaryErr error
+	serve(m, func(_ http.ResponseWriter, r *http.Request) {
+		primaryBytes, primaryErr = io.ReadAll(r.Body)
+	}, r)
+
+	// restoreBody must splice the bytes capture consumed ahead of the remainder so the
+	// primary sees the exact same prefix-then-error it would without the middleware.
+	assert.Equal(t, prefix, primaryBytes, "the primary reads the spliced-back consumed bytes")
+	assert.ErrorIs(t, primaryErr, boom, "then observes the same read error, unswallowed")
+	_, _, dropOversize, _, _ := m.Stats()
+	assert.EqualValues(t, 1, dropOversize, "a read error declines the mirror")
+}
+
+func TestMirrorPanicIsolated(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	rc.doPanic = true
+	m := newMirror(rc)
+
+	const n = 5
+	for range n {
+		w := serve(m, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+			httptest.NewRequest("GET", "/", nil))
+		assert.Equal(t, http.StatusOK, w.Code, "the primary is unaffected by a mirror panic")
+	}
+
+	require.Eventually(t, func() bool {
+		_, _, _, _, panicked := m.Stats()
+		return panicked == n
+	}, 2*time.Second, 10*time.Millisecond, "every mirror panic is recovered, workers survive")
+}
+
+func TestSlowMirrorNeverBlocksPrimary(t *testing.T) {
+	// not parallel: NumGoroutine is process-global. The fixed worker pool means the
+	// goroutine count is bounded by Workers regardless of request count.
+	baseGoroutines := runtime.NumGoroutine()
+	rc := newRecorder()
+	rc.gate = make(chan struct{}) // workers block until released at the end
+	defer close(rc.gate)
+	m := newMirror(rc) // Workers=4, QueueSize=16
+
+	const n = 200
+	for range n {
+		start := time.Now()
+		serve(m, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+			httptest.NewRequest("GET", "/", nil))
+		assert.Less(t, time.Since(start), 200*time.Millisecond, "the primary never waits on the mirror")
+	}
+
+	// Most are dropped (queue full); the pool never grows unbounded (Workers, not n).
+	_, dropFull, _, _, _ := m.Stats()
+	assert.Positive(t, dropFull, "surplus mirrors are dropped, not queued forever")
+	assert.LessOrEqual(t, runtime.NumGoroutine(), baseGoroutines+m.Workers+8,
+		"no goroutine-per-request leak (fixed worker pool)")
+}
+
+func TestDetachedContextNotCancelledByClient(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	rc.gate = make(chan struct{})
+	m := newMirror(rc)
+
+	ctx := context.WithValue(context.Background(), testCtxKey{}, "client-value")
+	ctx, cancel := context.WithCancel(ctx)
+	r := httptest.NewRequest("GET", "/", nil).WithContext(ctx)
+	serve(m, func(http.ResponseWriter, *http.Request) {}, r)
+
+	cancel() // tear down the client request AFTER dispatch
+	time.Sleep(20 * time.Millisecond)
+	close(rc.gate) // let the mirror proceed
+	rc.waitDone(t)
+	assert.False(t, rc.ctxCanceled.Load(), "the mirror is NOT cancelled by the client (rooted at Background)")
+	assert.False(t, rc.ctxHadValue.Load(),
+		"the mirror does NOT inherit client ctx VALUES — proving Background(), which WithoutCancel would not")
+}
+
+func TestHungMirrorRespectsTimeout(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	rc.gate = make(chan struct{}) // never released: only the timeout frees the worker
+	m := newMirror(rc)
+	m.Timeout = 50 * time.Millisecond
+
+	start := time.Now()
+	serve(m, func(http.ResponseWriter, *http.Request) {}, httptest.NewRequest("GET", "/", nil))
+
+	require.Eventually(t, func() bool { return rc.ctxCanceled.Load() }, 2*time.Second, 5*time.Millisecond,
+		"the detached Timeout fires and frees the worker")
+	assert.Less(t, time.Since(start), time.Second, "no permanent worker pin")
+}
+
+func TestHopByHopStrippedMarkedAndReframed(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+	m.MarkHeader = "X-Mirror"
+	m.MarkValue = "1"
+
+	body := []byte("hello-canary")
+	r := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+	r.Host = "app.example.com"
+	r.Header.Set("Connection", "keep-alive")
+	r.Header.Set("Keep-Alive", "timeout=5")
+	r.Header.Set("Proxy-Authorization", "secret")
+	r.Header.Set("Upgrade", "websocket")
+	r.Header.Set("Expect", "100-continue")
+	r.Header.Set("X-App", "keep-me")
+	r.TransferEncoding = []string{"chunked"} // inbound chunked framing
+	r.ContentLength = -1
+
+	serve(m, func(_ http.ResponseWriter, r *http.Request) { _, _ = io.ReadAll(r.Body) }, r)
+	rc.waitDone(t)
+
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	for _, h := range []string{"Connection", "Keep-Alive", "Proxy-Authorization", "Upgrade", "Expect"} {
+		assert.Empty(t, rc.header.Get(h), "%s must be stripped from the mirror", h)
+	}
+	assert.Equal(t, "keep-me", rc.header.Get("X-App"), "ordinary headers are preserved")
+	assert.Equal(t, "1", rc.header.Get("X-Mirror"), "the mirror is marked")
+	assert.Equal(t, "app.example.com", rc.host, "Host (not hop-by-hop) reaches the canary")
+	// The must-fix: chunked inbound framing must NOT override the fixed Content-Length.
+	assert.Empty(t, rc.transferEncoding, "TransferEncoding cleared so it does not re-frame as chunked")
+	assert.EqualValues(t, len(body), rc.contentLength, "the mirror carries the fixed Content-Length we set")
+	assert.Equal(t, body, rc.body)
+}
+
+func TestDisableBody(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+	m.DisableBody = true
+	want := []byte("payload")
+
+	var primaryBody []byte
+	serve(m, func(_ http.ResponseWriter, r *http.Request) { primaryBody, _ = io.ReadAll(r.Body) },
+		httptest.NewRequest("POST", "/", bytes.NewReader(want)))
+
+	assert.Equal(t, want, primaryBody, "the primary body is intact")
+	rc.waitDone(t)
+	assert.Empty(t, rc.gotBody(), "the mirror gets no body when DisableBody")
+}
+
+func TestRequestURIClearedAndIntegration(t *testing.T) {
+	t.Parallel()
+	// Point the mirror at a real httptest server through a real reverse proxy so the
+	// RequestURI-must-be-empty contract AND the chunked->Content-Length must-fix are
+	// exercised end to end against a real transport (not just the clone).
+	want := bytes.Repeat([]byte("z"), 3000)
+	var (
+		gotMirror  atomic.Bool
+		gotBody    atomic.Bool
+		gotLen     atomic.Int64
+		gotChunked atomic.Bool
+	)
+	canary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Mirror") == "1" {
+			gotMirror.Store(true)
+		}
+		gotLen.Store(r.ContentLength)
+		gotChunked.Store(len(r.TransferEncoding) > 0)
+		b, _ := io.ReadAll(r.Body)
+		gotBody.Store(bytes.Equal(b, want))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer canary.Close()
+
+	m := mirror.New()
+	m.Workers = 2
+	m.UseFunc(func(http.Handler) http.Handler {
+		return httputilReverseProxyTo(canary.URL)
+	})
+
+	r := httptest.NewRequest("POST", "/x", bytes.NewReader(want))
+	r.TransferEncoding = []string{"chunked"} // inbound chunked framing
+	r.ContentLength = -1
+	serve(m, func(w http.ResponseWriter, r *http.Request) { _, _ = io.ReadAll(r.Body); w.WriteHeader(http.StatusOK) }, r)
+
+	require.Eventually(t, gotMirror.Load, 2*time.Second, 10*time.Millisecond,
+		"the mirrored request reached a real reverse-proxy destination (RequestURI cleared, no panic)")
+	assert.True(t, gotBody.Load(), "the canary received the byte-identical body")
+	assert.EqualValues(t, len(want), gotLen.Load(), "fixed Content-Length, not chunked-reframed")
+	assert.False(t, gotChunked.Load(), "TransferEncoding=nil prevented chunked re-framing")
+}
+
+func TestSamplingDistribution(t *testing.T) {
+	t.Parallel()
+	t.Run("rate 0.25 within tolerance", func(t *testing.T) {
+		rc := newRecorder()
+		m := newMirror(rc)
+		m.QueueSize = 1 << 16
+		m.SampleRate = 0.25
+		const n = 40000
+		for range n {
+			serve(m, func(http.ResponseWriter, *http.Request) {}, httptest.NewRequest("GET", "/", nil))
+		}
+		dispatched, _, _, _, _ := m.Stats()
+		assert.InEpsilon(t, 0.25*n, float64(dispatched), 0.1, "≈25%% mirrored")
+	})
+
+	t.Run("Match gate excludes with zero dispatch", func(t *testing.T) {
+		rc := newRecorder()
+		m := newMirror(rc)
+		m.Match = func(r *http.Request) bool { return r.Method == http.MethodPost }
+		for range 20 {
+			serve(m, func(http.ResponseWriter, *http.Request) {}, httptest.NewRequest("GET", "/", nil))
+		}
+		dispatched, _, _, _, _ := m.Stats()
+		assert.Zero(t, dispatched, "non-matching requests are never mirrored")
+	})
+}
+
+// TestObserveOutcomes drains to quiescence (every submitted request reached a
+// terminal outcome) before asserting Stats agrees with the observed event counts.
+func TestObserveOutcomes(t *testing.T) {
+	t.Parallel()
+	var byOutcome [5]atomic.Int64
+	rc := newRecorder()
+	m := newMirror(rc)
+	m.Observe = func(info mirror.MirrorInfo) { byOutcome[info.Outcome].Add(1) }
+
+	const n = 10
+	for range n {
+		serve(m, func(http.ResponseWriter, *http.Request) {}, httptest.NewRequest("GET", "/", nil))
+	}
+
+	// Quiescence barrier on the EMITTED-event side we assert against (not the separate
+	// completed counter, which is incremented just before its emit — waiting on it
+	// would race the OutcomeCompleted emit).
+	require.Eventually(t, func() bool {
+		return byOutcome[mirror.OutcomeDispatched].Load() == n && byOutcome[mirror.OutcomeCompleted].Load() == n
+	}, 2*time.Second, 10*time.Millisecond)
+
+	dispatched, dropFull, dropOversize, completed, panicked := m.Stats()
+	assert.EqualValues(t, dispatched, byOutcome[mirror.OutcomeDispatched].Load())
+	assert.EqualValues(t, completed, byOutcome[mirror.OutcomeCompleted].Load())
+	assert.EqualValues(t, dropFull, byOutcome[mirror.OutcomeDroppedFull].Load())
+	assert.EqualValues(t, dropOversize, byOutcome[mirror.OutcomeDroppedOversize].Load())
+	assert.EqualValues(t, panicked, byOutcome[mirror.OutcomePanicked].Load())
+	assert.EqualValues(t, n, completed, "all dispatched mirrors completed")
+}
+
+func TestComposeUnderBlock(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+	// Mirror only requests whose path starts with /api (the kind of gating block does).
+	m.Match = func(r *http.Request) bool { return strings.HasPrefix(r.URL.Path, "/api") }
+
+	serve(m, func(http.ResponseWriter, *http.Request) {}, httptest.NewRequest("GET", "/web", nil))
+	serve(m, func(http.ResponseWriter, *http.Request) {}, httptest.NewRequest("GET", "/api/x", nil))
+
+	rc.waitDone(t)
+	dispatched, _, _, _, _ := m.Stats()
+	assert.EqualValues(t, 1, dispatched, "only the matching request is teed")
+}
+
+// partialErrReader yields data, then fails with err — exercising the restore splice.
+type partialErrReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (e *partialErrReader) Read(p []byte) (int, error) {
+	if e.off < len(e.data) {
+		n := copy(p, e.data[e.off:])
+		e.off += n
+		return n, nil
+	}
+	return 0, e.err
+}
+
+// TestGetBodyFastPath exercises the captureBody GetBody branch (httptest.NewRequest
+// does not set GetBody, so the rest of the suite only hits the io.CopyN path).
+// http.NewRequest with a *bytes.Reader sets GetBody.
+func TestGetBodyFastPath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("under cap: primary untouched, mirror replays", func(t *testing.T) {
+		rc := newRecorder()
+		m := newMirror(rc)
+		want := bytes.Repeat([]byte("g"), 2048)
+		r, err := http.NewRequest("POST", "/", bytes.NewReader(want))
+		require.NoError(t, err)
+		require.NotNil(t, r.GetBody, "http.NewRequest sets GetBody for a bytes.Reader")
+
+		var primaryBody []byte
+		serve(m, func(_ http.ResponseWriter, r *http.Request) { primaryBody, _ = io.ReadAll(r.Body) }, r)
+		assert.Equal(t, want, primaryBody, "the primary reads its untouched body")
+		rc.waitDone(t)
+		assert.Equal(t, want, rc.gotBody(), "the mirror replays the identical bytes via GetBody")
+	})
+
+	t.Run("over cap declines, primary whole", func(t *testing.T) {
+		rc := newRecorder()
+		m := newMirror(rc)
+		m.MaxBodyBytes = 1024
+		want := bytes.Repeat([]byte("h"), 2048) // > cap
+		r, err := http.NewRequest("POST", "/", bytes.NewReader(want))
+		require.NoError(t, err)
+
+		var primaryBody []byte
+		serve(m, func(_ http.ResponseWriter, r *http.Request) { primaryBody, _ = io.ReadAll(r.Body) }, r)
+		assert.Equal(t, want, primaryBody, "the primary still reads the whole oversize body")
+		_, _, dropOversize, _, _ := m.Stats()
+		assert.EqualValues(t, 1, dropOversize, "the GetBody path declines over-cap too")
+	})
+}
+
+func TestDisableMark(t *testing.T) {
+	t.Parallel()
+	rc := newRecorder()
+	m := newMirror(rc)
+	m.DisableMark = true // a fully transparent mirror
+
+	serve(m, func(http.ResponseWriter, *http.Request) {}, httptest.NewRequest("GET", "/", nil))
+	rc.waitDone(t)
+
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	assert.Empty(t, rc.header.Get("X-Mirror"), "DisableMark omits the mark header")
+}
+
+var _ parapet.Middleware = (*recorder)(nil)

--- a/pkg/prom/mirror.go
+++ b/pkg/prom/mirror.go
@@ -1,0 +1,68 @@
+package prom
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/moonrhythm/parapet/pkg/mirror"
+)
+
+//nolint:govet
+type mirrorMetrics struct {
+	once     sync.Once
+	outcomes *prometheus.CounterVec
+	duration prometheus.Histogram
+}
+
+var _mirror mirrorMetrics
+
+func (p *mirrorMetrics) init() {
+	p.once.Do(func() {
+		p.outcomes = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "mirror_total",
+		}, []string{"outcome"})
+		p.duration = prometheus.NewHistogram(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "mirror_request_duration_seconds",
+			Buckets:   prometheus.DefBuckets,
+		})
+		reg.MustRegister(p.outcomes, p.duration)
+	})
+}
+
+func outcomeLabel(o mirror.Outcome) string {
+	switch o {
+	case mirror.OutcomeDispatched:
+		return "dispatched"
+	case mirror.OutcomeCompleted:
+		return "completed"
+	case mirror.OutcomeDroppedFull:
+		return "dropped_full"
+	case mirror.OutcomeDroppedOversize:
+		return "dropped_oversize"
+	case mirror.OutcomePanicked:
+		return "panicked"
+	default:
+		return "unknown"
+	}
+}
+
+func (p *mirrorMetrics) observe(info mirror.MirrorInfo) {
+	if c, err := p.outcomes.GetMetricWith(prometheus.Labels{"outcome": outcomeLabel(info.Outcome)}); err == nil {
+		c.Inc()
+	}
+	if info.Outcome == mirror.OutcomeCompleted {
+		p.duration.Observe(info.Duration.Seconds())
+	}
+}
+
+// Mirror returns a mirror.MirrorFunc that records shadow-traffic metrics on the
+// shared registry, for wiring into Mirror.Observe — keeping pkg/mirror
+// Prometheus-free (the prom.Upstream convention). mirror_total{outcome} counts each
+// decision/result; mirror_request_duration_seconds observes completed round-trips.
+func Mirror() mirror.MirrorFunc {
+	_mirror.init()
+	return _mirror.observe
+}

--- a/pkg/prom/mirror_test.go
+++ b/pkg/prom/mirror_test.go
@@ -1,0 +1,50 @@
+package prom_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/mirror"
+
+	. "github.com/moonrhythm/parapet/pkg/prom"
+)
+
+func TestMirror(t *testing.T) {
+	observe := Mirror()
+	require.NotNil(t, observe)
+
+	// Baselines so the test is order- and -count-independent against the shared
+	// process-global registry (the counters persist across tests/runs).
+	outcomes := []string{"dispatched", "completed", "dropped_full", "dropped_oversize", "panicked"}
+	base := map[string]float64{}
+	for _, o := range outcomes {
+		v := counterValue(t, "parapet_mirror_total", map[string]string{"outcome": o})
+		if v < 0 {
+			v = 0 // series not created yet (counterValue returns -1 for absent)
+		}
+		base[o] = v
+	}
+	baseDuration := histogramCount(t, "parapet_mirror_request_duration_seconds", nil)
+
+	observe(mirror.MirrorInfo{Outcome: mirror.OutcomeDispatched})
+	observe(mirror.MirrorInfo{Outcome: mirror.OutcomeCompleted, Status: 200, Duration: 5 * time.Millisecond})
+	observe(mirror.MirrorInfo{Outcome: mirror.OutcomeDroppedFull})
+	observe(mirror.MirrorInfo{Outcome: mirror.OutcomeDroppedOversize})
+	observe(mirror.MirrorInfo{Outcome: mirror.OutcomePanicked})
+
+	for _, o := range outcomes {
+		assert.EqualValues(t, base[o]+1, counterValue(t, "parapet_mirror_total", map[string]string{"outcome": o}),
+			"outcome %q counted once", o)
+	}
+	assert.EqualValues(t, baseDuration+1, histogramCount(t, "parapet_mirror_request_duration_seconds", nil),
+		"only a completed round-trip contributes a duration sample")
+}
+
+func ExampleMirror() {
+	mr := mirror.New()
+	mr.Observe = Mirror() // prom.Mirror(): count by outcome, observe completed-round-trip latency
+	_ = mr                // mr.Use(canary); s.Use(mr)
+}


### PR DESCRIPTION
## What

`pkg/mirror` — a request-tee middleware that shadows a copy of matched/sampled **requests** to a separate destination (a "canary"), **fire-and-forget**. The primary request and its response are never affected; the canary's response is discarded.

```go
mr := mirror.New()
mr.Match = func(r *http.Request) bool { return r.Method == http.MethodGet }
mr.SampleRate = 0.1                  // shadow 10% of matched requests
mr.Observe = prom.Mirror()           // optional outcome/latency metrics
mr.Use(upstream.SingleHost("canary:8080", &upstream.HTTPTransport{}))
s.Use(mr)                            // tees, then falls through to the real chain
s.Use(upstream.SingleHost("prod:8080", &upstream.HTTPTransport{}))
```

## How

- **Destination** is a `parapet.Middlewares` chain via `Use`/`UseFunc` (the `block.Block` idiom), materialized once on first `ServeHandler`.
- **Body fidelity** — buffered up front, bounded by `MaxBodyBytes`, so the primary and the mirror read **byte-identical** bytes (no shared cursor). An over-cap or read-erroring body declines the mirror and the primary is restored whole (`io.MultiReader` splice).
- **Isolation** — a fixed worker pool (`Workers`) is the real concurrency cap; a full `QueueSize` queue **drops** rather than blocking the primary. Each mirror runs on a **detached `context.Background()`** deadline (`Timeout`) — like `cache/stale.go` — so a client disconnect never cancels it, and `cancel` is released on every path (no timer leak). A panicking mirror is **recovered in the worker** (outside the server's per-request recover), so it can't crash the proxy.
- **Observability** — typed `Outcome` + `Observe` hook (the `upstream.RoundTripFunc` shape) with lock-free `Stats`; `prom.Mirror()` wires `mirror_total{outcome}` + a duration histogram, keeping `pkg/mirror` Prometheus-free.

## Reviewed (two passes)

The **design** pass (`fix-then-implement`) resolved the proposals (buffer-up-front body fidelity; detached `Background()` not `WithoutCancel`; per-job `cancel` lifecycle) and supplied the must-fixes I folded in: `c.TransferEncoding=nil` (inbound chunked framing was overriding the fixed `Content-Length`), strip `Expect` (100-continue), `Use()`-is-setup-only + worker-back-pressure docs, observe-test quiescence barrier.

The **implementation** scrutiny pass (4 dimensions → adversarial verifiers, focused on body-tee/context/panic/lifecycle) came back **no blockers** — those core guarantees verified sound. Applied the 3 majors: `DisableMark` to honor the marking opt-out (the prior "empty MarkHeader disables" path was dead code — `init` always defaulted it); fixed the `TestObserveOutcomes` barrier to wait on the emitted-event side (not the counter, incremented just before its emit); and full **GetBody fast-path** test coverage (the branch `httptest.NewRequest` never exercises). Plus the nits: strengthened the detached-context test to prove `Background()` (a client ctx **value** is not inherited — which `WithoutCancel` would keep), the read-error test to exercise the splice-back, and the integration test to validate the chunked→`Content-Length` must-fix through a **real** reverse proxy; documented Observe concurrency/non-blocking, process-lifetime workers, and credential replay.

## Tests

`mirror_test.go` covers primary-unaffected, byte-identical body, over-cap-skip, exactly-at-cap, read-error-splice, panic-isolation (workers survive), slow-mirror-never-blocks (+ bounded goroutines), detached-context, hung-timeout, hop-by-hop/Expect strip + chunked reframe + mark, GetBody fast-path, DisableBody/DisableMark, RequestURI-cleared real-proxy integration, sampling distribution, observe quiescence, compose-under-match; plus benches and `prom/mirror_test.go`. Each must-fix guard verified load-bearing. `make` green (vet, lint 0 issues, `-race`, + stress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)