### PR TITLE
test: de-flake timing-sensitive -race tests (concurrentqueue + latency-ejection)

### DIFF
--- a/pkg/ratelimit/concurrentqueue_test.go
+++ b/pkg/ratelimit/concurrentqueue_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/moonrhythm/parapet/pkg/ratelimit"
 )
@@ -16,6 +17,31 @@ func TestConcurrentQueue(t *testing.T) {
 	assert.IsType(t, &ConcurrentQueueStrategy{}, m.Strategy)
 }
 
+// recvBool waits for a queued Take to return, failing on timeout. Synchronizing on
+// the goroutine's actual return (rather than a fixed sleep) is what keeps the
+// QueueCount bookkeeping race-free: by the time the value arrives, Take has fully
+// returned and decremented QueueCount, so the next Take cannot observe a stale count.
+func recvBool(t *testing.T, ch <-chan bool) bool {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the queued Take to return")
+		return false
+	}
+}
+
+// stillBlocked asserts a queued Take has not returned yet.
+func stillBlocked(t *testing.T, ch <-chan bool) {
+	t.Helper()
+	select {
+	case <-ch:
+		t.Fatal("the queued Take returned before a slot was freed")
+	default:
+	}
+}
+
 func TestConcurrentQueueStrategy(t *testing.T) {
 	t.Parallel()
 
@@ -25,33 +51,37 @@ func TestConcurrentQueueStrategy(t *testing.T) {
 	})
 
 	t.Run("Take then Put", func(t *testing.T) {
-		s := ConcurrentQueueStrategy{
-			Capacity: 2,
-			Size:     1,
-		}
+		// Capacity 2 (in-process), queue Size 1: a 3rd concurrent Take queues; a 4th
+		// drops; a Put frees a slot and the queued Take acquires it.
+		s := ConcurrentQueueStrategy{Capacity: 2, Size: 1}
 
-		assert.True(t, s.Take("")) // capacity = 1, size = 0
-		assert.True(t, s.Take("")) // capacity = 2, size = 0
-		go func() {
-			assert.True(t, s.Take("")) // capacity = 2, size = 1
-		}()
-		time.Sleep(5 * time.Millisecond)
-		assert.False(t, s.Take("")) // capacity = 2, size = 1, drop
-		assert.False(t, s.Take("")) // capacity = 2, size = 1, drop
-		assert.True(t, s.Take("1"))
-		s.Put("") // capacity = 2, size = 0
-		time.Sleep(5 * time.Millisecond)
-		go func() {
-			assert.True(t, s.Take("")) // capacity = 2, size = 1
-		}()
-		time.Sleep(5 * time.Millisecond)
-		assert.True(t, s.Take("1"))
-		s.Put("") // capacity = 2, size = 0
-		time.Sleep(5 * time.Millisecond)
-		s.Put("") // capacity = 1, size = 0
-		time.Sleep(5 * time.Millisecond)
-		assert.True(t, s.Take("")) // capacity = 2, size = 0
-		time.Sleep(5 * time.Millisecond)
+		require.True(t, s.Take("")) // 1/2 in process
+		require.True(t, s.Take("")) // 2/2 in process (capacity full)
+
+		// A 3rd Take queues and blocks until a slot frees.
+		q := make(chan bool, 1)
+		go func() { q <- s.Take("") }()
+		// Let the queued goroutine reach the block (increment QueueCount to 1). There
+		// is no external signal for "now blocked"; a generous wait covers CI load.
+		time.Sleep(100 * time.Millisecond)
+
+		require.False(t, s.Take(""), "queue full (Size=1) -> drop")
+		require.False(t, s.Take(""), "still dropping")
+		stillBlocked(t, q)
+		require.True(t, s.Take("other"), "a different key is independent")
+
+		s.Put("") // free a slot -> unblock the queued Take
+		require.True(t, recvBool(t, q), "the queued Take acquired the freed slot")
+
+		// Repeat: another queued Take, again released by a Put.
+		go func() { q <- s.Take("") }()
+		time.Sleep(100 * time.Millisecond)
+		require.True(t, s.Take("other"), "a different key is still independent")
+		s.Put("")
+		require.True(t, recvBool(t, q), "the second queued Take acquired its slot")
+
+		s.Put("") // drain back to one in process
+		require.True(t, s.Take(""), "a free slot admits immediately")
 	})
 
 	t.Run("Put before take", func(t *testing.T) {

--- a/pkg/upstream/latencyejecting_test.go
+++ b/pkg/upstream/latencyejecting_test.go
@@ -79,6 +79,10 @@ func TestLatencyEjectingLoadBalancer(t *testing.T) {
 		slow.delay.Store(int64(latSlow))
 		fast := []*fakeUpstream{slow, {}, {}, {}, {}}
 		l := latTestLB(newEjectTargets(fast...))
+		// Sticky cooldown: the slow target need only cross the ejection bar ONCE during
+		// the drive and then stays ejected, so the assert cannot race a re-admission /
+		// re-probe (which resets samples) when -race stretches the synchronous drive.
+		l.EjectTimeout = time.Minute
 		driveLB(l, 300)
 		assert.True(t, latEjected(l, 0), "the slow target is ejected")
 		for i := 1; i < 5; i++ {
@@ -149,6 +153,7 @@ func TestLatencyEjectingLoadBalancer(t *testing.T) {
 		slow := &fakeUpstream{}
 		slow.delay.Store(int64(latSlow))
 		l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		l.EjectTimeout = time.Minute // sticky (see DetectsAndEjectsTheSlowOne)
 		driveLB(l, 300)
 		require.True(t, latEjected(l, 0))
 		driveLB(l, 300)


### PR DESCRIPTION
## Problem

CI's `go test -race ./...` intermittently failed on **pre-existing**, timing-sensitive tests (unrelated to any feature) — re-running PRs surfaced a *different* flaky test each time. This de-flakes the two that hit CI.

## Fixes (test-only, no production change)

**1. `TestConcurrentQueueStrategy/"Take then Put"`** (`pkg/ratelimit`)
`Take` returns `false` only at the `QueueCount >= Size` drop-check. The test coordinated blocking `Take` goroutines with fixed `time.Sleep(5ms)`; after a queued goroutine was released by a `Put`, the next goroutine's `Take` could read a **stale `QueueCount==1`** (→ drop → false) if the released goroutine hadn't re-acquired the lock to run `QueueCount--` within 5ms. → Synchronize on the queued `Take`'s actual **return** (result channel) instead of sleeping.

**2. `TestLatencyEjectingLoadBalancer/DetectsAndEjectsTheSlowOne`** + `NoOscillationCascade` (`pkg/upstream`)
These drove a fixed number of synchronous requests then asserted the slow target was *currently* ejected, with a short 30ms `EjectTimeout`. Under `-race` contention the drive stretches past 30ms, the slow target's cooldown expires mid-drive, and it's re-admitted + re-probed (samples reset) — so the drive can end with `latEjected == false`. → Make `EjectTimeout` **sticky** (1 min) in those subtests: the slow target need only cross the bar once, then stays ejected (also hardens a marginal `slow/median` ratio). The recovery subtests that need the cooldown are untouched. Matches the #224 de-flake.

## Verification

`#230` CI is green; locally stable across **50× per subtest**, **80× `GOMAXPROCS=1`** (concurrentqueue), and repeated full-package `-race` runs.

> Note: merge this first, then "Update branch" on the redis (#228) and mirror (#229) PRs so they pick up the de-flakes before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)