### PR TITLE
test: de-flake 28 timing-sensitive -race tests across six packages

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -73,15 +73,21 @@ func do(c *Cache, h http.Handler, method, target string, reqHeader http.Header) 
 
 // eachBackend runs fn against both storage backends so the middleware behavior is
 // verified identically for memory and disk.
+//
+// LockTimeout is pinned far above any real fill duration so the single-flight
+// collapse tests can't flake when a slow CI leader (origin sleep + disk fsyncs
+// under -race) stretches a fill past the 2s production default and pushes
+// followers into self-fetch. Timeout behavior itself is covered by
+// TestCache_LockTimeoutConfigurable, which builds its own cache.
 func eachBackend(t *testing.T, fn func(t *testing.T, c *Cache)) {
 	t.Helper()
 	t.Run("memory", func(t *testing.T) {
-		fn(t, New(NewMemory(1<<20), Options{MaxFileSize: 1024}))
+		fn(t, New(NewMemory(1<<20), Options{MaxFileSize: 1024, LockTimeout: 30 * time.Second}))
 	})
 	t.Run("disk", func(t *testing.T) {
 		d, err := NewDisk(t.TempDir(), 1<<20)
 		require.NoError(t, err)
-		fn(t, New(d, Options{MaxFileSize: 1024}))
+		fn(t, New(d, Options{MaxFileSize: 1024, LockTimeout: 30 * time.Second}))
 	})
 }
 
@@ -270,30 +276,68 @@ func TestCache_SingleFlightCollapsesCrossVariant(t *testing.T) {
 
 // A short Options.LockTimeout makes followers give up on a slow leader and fetch
 // the origin themselves rather than wait (the default 2s would collapse them).
+//
+// The origin is gated on channels rather than a 200ms sleep: a sleeping leader
+// raced the followers' arrival (a stalled follower set could wake after the
+// leader's commit and HIT, leaving calls==1). Holding the leader inside the
+// origin until the followers finish makes the timeout path deterministic.
 func TestCache_LockTimeoutConfigurable(t *testing.T) {
 	c := New(NewMemory(1<<20), Options{MaxFileSize: 1024, LockTimeout: 20 * time.Millisecond})
 	var calls int32
-	h := origin(originSpec{body: []byte("slow"), header: hdr("Cache-Control", "max-age=60"), sleep: 200 * time.Millisecond}, &calls)
+	originEntered := make(chan struct{}) // closed when the leader is inside the origin
+	originGate := make(chan struct{})    // leader blocks here until followers finish
+	var leaderOnce sync.Once
+	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		isLeader := false
+		leaderOnce.Do(func() { isLeader = true; close(originEntered) })
+		if isLeader {
+			<-originGate // hold the fill lock for the whole follower phase
+		}
+		body := []byte("slow")
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		w.WriteHeader(200)
+		_, _ = w.Write(body)
+	})
 	mw := c.ServeHandler(h)
 
-	const n = 4
-	var wg, start sync.WaitGroup
-	start.Add(1)
-	for i := 0; i < n; i++ {
+	// Leader first: provably holds the fill lock before any follower starts.
+	leaderDone := make(chan struct{})
+	go func() {
+		defer close(leaderDone)
+		rec := httptest.NewRecorder()
+		mw.ServeHTTP(rec, httptest.NewRequest("GET", "http://acme.com/s", nil))
+		assert.Equal(t, "slow", rec.Body.String())
+	}()
+	<-originEntered
+
+	// Followers: the leader cannot commit, so each MUST take the timeout path and
+	// fetch the (ungated for them) origin itself.
+	startT := time.Now()
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			start.Wait()
 			rec := httptest.NewRecorder()
 			mw.ServeHTTP(rec, httptest.NewRequest("GET", "http://acme.com/s", nil))
 			assert.Equal(t, "slow", rec.Body.String())
 		}()
 	}
-	start.Done()
 	wg.Wait()
-	// The leader's 200ms fill far exceeds the 20ms timeout, so followers don't wait
-	// for it — they each contact the origin.
-	assert.Greater(t, atomic.LoadInt32(&calls), int32(1), "short LockTimeout: followers fetch the origin instead of waiting")
+	elapsed := time.Since(startT)
+	close(originGate)
+	<-leaderDone
+
+	// 1 leader + 3 followers, deterministically.
+	assert.EqualValues(t, 4, atomic.LoadInt32(&calls), "short LockTimeout: every follower fetched the origin instead of waiting")
+	// Sensitivity guard: if LockTimeout were ignored, all three followers would wait
+	// the full 2s default (concurrently) before self-fetching, so ANY bound < 2s
+	// detects the regression. 1.5s keeps a 0.5s guard band while tolerating ~1.5s of
+	// scheduler stall over a nominal ~22ms phase — the bound itself must not become
+	// the flake.
+	assert.Less(t, elapsed, 1500*time.Millisecond, "followers honored the configured 20ms LockTimeout, not the 2s default")
 }
 
 func TestCache_ExpiredEntryIsMiss(t *testing.T) {
@@ -637,10 +681,14 @@ func TestCache_HitCarriesAgeHeader(t *testing.T) {
 		req := httptest.NewRequest("GET", "http://acme.com/age", nil)
 		primary := c.primaryHash(req)
 		key := c.variantHash(primary, req)
+		// Anchor both seeded timestamps to one instant so the upper Age bound can
+		// be derived from measured elapsed time — a fixed `age <= 31` raced the
+		// real clock against storePut's disk fsyncs plus the request cycle.
+		seedAt := time.Now()
 		storePut(t, c.storage, key, Meta{
 			Status: 200, Header: http.Header{}, PrimaryHex: primary,
-			Created:    time.Now().Add(-30 * time.Second).UnixNano(),
-			FreshUntil: time.Now().Add(time.Hour).UnixNano(), Size: 3,
+			Created:    seedAt.Add(-30 * time.Second).UnixNano(),
+			FreshUntil: seedAt.Add(time.Hour).UnixNano(), Size: 3,
 		}, []byte("abc"))
 
 		r := do(c, http.NotFoundHandler(), "GET", "http://acme.com/age", nil)
@@ -648,7 +696,9 @@ func TestCache_HitCarriesAgeHeader(t *testing.T) {
 		age, err := strconv.Atoi(r.Header().Get("Age"))
 		require.NoError(t, err)
 		assert.GreaterOrEqual(t, age, 30)
-		assert.LessOrEqual(t, age, 31)
+		// Measured elapsed >= serve-time elapsed, so age = 30+floor(e_serve) is
+		// always <= 30+floor(measured)+1; in a fast run this bound stays ~31.
+		assert.LessOrEqual(t, age, 30+int(time.Since(seedAt).Seconds())+1)
 	})
 }
 
@@ -692,15 +742,18 @@ func TestCache_RangeRequestBypassesCache(t *testing.T) {
 }
 
 // eachBackendDecoupled runs fn against both backends with DecoupleFill enabled.
+// LockTimeout is pinned high for the same reason as eachBackend: a contended fill
+// (LeaderHeadersSanitized) must never push followers into the 2s-default timeout
+// self-fetch path when CI stalls the leader's commit.
 func eachBackendDecoupled(t *testing.T, fn func(t *testing.T, c *Cache)) {
 	t.Helper()
 	t.Run("memory", func(t *testing.T) {
-		fn(t, New(NewMemory(1<<20), Options{MaxFileSize: 1024, DecoupleFill: true}))
+		fn(t, New(NewMemory(1<<20), Options{MaxFileSize: 1024, DecoupleFill: true, LockTimeout: 30 * time.Second}))
 	})
 	t.Run("disk", func(t *testing.T) {
 		d, err := NewDisk(t.TempDir(), 1<<20)
 		require.NoError(t, err)
-		fn(t, New(d, Options{MaxFileSize: 1024, DecoupleFill: true}))
+		fn(t, New(d, Options{MaxFileSize: 1024, DecoupleFill: true, LockTimeout: 30 * time.Second}))
 	})
 }
 
@@ -763,14 +816,19 @@ func TestCache_DecoupleFill_MissThenHit(t *testing.T) {
 // The headline property: under contention, a leader whose own client is blocked
 // must NOT hold the fill lock — followers hit the just-committed entry immediately.
 func TestCache_DecoupleFill_SlowLeaderDoesNotBlockFollowers(t *testing.T) {
-	c := New(NewMemory(1<<20), Options{MaxFileSize: 1 << 20, DecoupleFill: true})
+	// LockTimeout is pinned high so a CI stall between the followers registering
+	// and the leader committing can't push them into the timeout/self-fetch path.
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1 << 20, DecoupleFill: true, LockTimeout: 30 * time.Second})
 	originEntered := make(chan struct{})
 	originGate := make(chan struct{})
 	var calls int32
+	var enteredOnce sync.Once
 	h := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		atomic.AddInt32(&calls, 1)
-		close(originEntered) // the leader is in origin (single-flight: called once)
-		<-originGate         // hold the leader here so followers can pile onto the lock
+		// Once-guarded so a single-flight regression fails the calls assert below
+		// instead of panicking on a double close.
+		enteredOnce.Do(func() { close(originEntered) }) // the leader is in origin
+		<-originGate                                    // hold the leader here so followers can pile onto the lock
 		w.Header().Set("Cache-Control", "max-age=60")
 		w.Header().Set("Content-Length", "7")
 		w.WriteHeader(200)
@@ -798,7 +856,21 @@ func TestCache_DecoupleFill_SlowLeaderDoesNotBlockFollowers(t *testing.T) {
 			mw.ServeHTTP(recs[i], httptest.NewRequest("GET", "http://acme.com/x", nil))
 		}(i)
 	}
-	time.Sleep(50 * time.Millisecond) // let the followers reach the wait
+	// White-box wait: a fixed sleep here raced follower scheduling — if none had
+	// registered yet, the leader's WriteHeader saw waiters==0 and fell back to
+	// lockstep (wedging on the blocked client while holding the fill lock).
+	// Waiting for waiters==5 proves every follower passed its storage lookup AND
+	// acquire(), so none can wake later as a second leader and re-run the origin.
+	require.Eventually(t, func() bool {
+		c.lockMu.Lock()
+		defer c.lockMu.Unlock()
+		for _, l := range c.locks {
+			if l.waiters.Load() == int32(len(recs)) {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, time.Millisecond, "all followers registered on the fill lock")
 
 	close(originGate) // leader proceeds; WriteHeader sees waiters>0 -> decouple, commit, release
 	fwg.Wait()        // followers complete WITHOUT the leader's blocked client being released
@@ -898,14 +970,28 @@ func decoupledContended(t *testing.T, c *Cache, target string, write func(w http
 	<-originEntered // leader holds the lock, blocked in origin
 
 	var fwg sync.WaitGroup
-	for i := 0; i < 3; i++ {
+	const followers = 3
+	for i := 0; i < followers; i++ {
 		fwg.Add(1)
 		go func() {
 			defer fwg.Done()
 			mw.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", target, nil))
 		}()
 	}
-	time.Sleep(50 * time.Millisecond) // let the followers reach the wait
+	// White-box wait: a fixed sleep here raced follower scheduling — a starved
+	// follower set would make the leader's WriteHeader see waiters==0 and stream
+	// in lockstep (raw headers), silently skipping the decoupled path under test.
+	// The helper drives a single in-flight fill, so c.locks holds exactly one entry.
+	require.Eventually(t, func() bool {
+		c.lockMu.Lock()
+		defer c.lockMu.Unlock()
+		for _, l := range c.locks {
+			if l.waiters.Load() == followers {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, time.Millisecond, "followers blocked on the fill lock")
 
 	close(originGate)
 	<-leaderDone

--- a/pkg/cache/disk_test.go
+++ b/pkg/cache/disk_test.go
@@ -33,7 +33,12 @@ func TestDisk_RestartPersistence(t *testing.T) {
 	assert.Equal(t, "HIT", r.Header().Get("X-Cache"), "survived restart")
 	assert.EqualValues(t, 0, atomic.LoadInt32(&callsB), "served from disk, origin not contacted")
 
-	assert.Eventually(t, func() bool { return b.lru.size() > 0 }, time.Second, 10*time.Millisecond,
+	// 2s matches the repo's Eventually norm (1s was an outlier that an fsync- or
+	// scheduler-stalled background scan could overrun under -race CI load). The
+	// condition is monotonic, so a longer budget has zero false-pass risk. Kept
+	// async on purpose: this is the only coverage that NewDisk launches the
+	// startup scan goroutine at all.
+	assert.Eventually(t, func() bool { return b.lru.size() > 0 }, 2*time.Second, 10*time.Millisecond,
 		"startup scan re-seeds the LRU byte accounting")
 }
 

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -1,11 +1,14 @@
 package healthz_test
 
 import (
+	"io"
+	"net"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/moonrhythm/parapet"
 	. "github.com/moonrhythm/parapet/pkg/healthz"
@@ -16,23 +19,30 @@ func TestHealthz(t *testing.T) {
 
 	m := New()
 	s := parapet.Server{
-		Addr:               "127.0.0.1:10100",
-		WaitBeforeShutdown: 200 * time.Millisecond,
+		// WaitBeforeShutdown must stay comfortably above the shutdown poll
+		// deadline below, so the listener is guaranteed to still be
+		// accepting while the post-shutdown asserts run.
+		WaitBeforeShutdown: 2 * time.Second,
 		Handler:            http.NotFoundHandler(),
 	}
-	defer s.Shutdown()
 	s.Use(m)
-	go s.ListenAndServe()
-	time.Sleep(50 * time.Millisecond)
+
+	// bind synchronously on an ephemeral port: no sleep can reliably wait
+	// for ListenAndServe's goroutine to finish the listen syscall, and a
+	// hardcoded port collides across concurrently running test binaries.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go s.Serve(ln)
+	baseURL := "http://" + ln.Addr().String()
 
 	// not found
-	resp, err := http.Get("http://127.0.0.1:10100")
+	resp, err := http.Get(baseURL)
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, http.StatusNotFound, resp.StatusCode)
 	}
 
 	// with host
-	req, _ := http.NewRequest("GET", "http://127.0.0.1:10100/healthz", nil)
+	req, _ := http.NewRequest("GET", baseURL+"/healthz", nil)
 	req.Host = "localhost"
 	resp, err = http.DefaultClient.Do(req)
 	if assert.NoError(t, err) {
@@ -40,45 +50,63 @@ func TestHealthz(t *testing.T) {
 	}
 
 	// liveness
-	resp, err = http.Get("http://127.0.0.1:10100/healthz")
+	resp, err = http.Get(baseURL + "/healthz")
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, http.StatusOK, resp.StatusCode)
 	}
 
 	// liveness false
 	m.Set(false)
-	resp, err = http.Get("http://127.0.0.1:10100/healthz")
+	resp, err = http.Get(baseURL + "/healthz")
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, http.StatusServiceUnavailable, resp.StatusCode)
 	}
 	m.Set(true)
 
 	// readiness
-	resp, err = http.Get("http://127.0.0.1:10100/healthz?ready=1")
+	resp, err = http.Get(baseURL + "/healthz?ready=1")
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, http.StatusOK, resp.StatusCode)
 	}
 
 	// readiness false
 	m.SetReady(false)
-	resp, err = http.Get("http://127.0.0.1:10100/healthz?ready=1")
+	resp, err = http.Get(baseURL + "/healthz?ready=1")
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, http.StatusServiceUnavailable, resp.StatusCode)
 	}
 	m.SetReady(true)
 
-	go s.Shutdown()
-	time.Sleep(20 * time.Millisecond)
+	// run Shutdown exactly once and wait for it before returning, instead
+	// of the old go s.Shutdown() + defer s.Shutdown() pair which shut down
+	// twice and let the test return while the server was still draining.
+	shutdownDone := make(chan struct{})
+	go func() {
+		s.Shutdown()
+		close(shutdownDone)
+	}()
+	defer func() { <-shutdownDone }()
 
-	// liveness while shutdown
-	resp, err = http.Get("http://127.0.0.1:10100/healthz")
+	// readiness while shutdown: the shutdown flag is flipped on a
+	// doubly-spawned goroutine (go s.Shutdown() -> go onShutdown()), so a
+	// fixed sleep races the scheduler; poll for the observable 503 instead.
+	// The deadline is strictly less than WaitBeforeShutdown, so a missing
+	// flag flip fails here as a timeout rather than as a confusing
+	// connection-refused after the listener closes.
+	assert.Eventually(t, func() bool {
+		resp, err := http.Get(baseURL + "/healthz?ready=1")
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode == http.StatusServiceUnavailable
+	}, time.Second, 5*time.Millisecond)
+
+	// liveness while shutdown: the poll above succeeded inside the
+	// WaitBeforeShutdown window, so the listener is still accepting here.
+	resp, err = http.Get(baseURL + "/healthz")
 	if assert.NoError(t, err) {
 		assert.EqualValues(t, http.StatusOK, resp.StatusCode)
-	}
-
-	// readiness while shutdown
-	resp, err = http.Get("http://127.0.0.1:10100/healthz?ready=1")
-	if assert.NoError(t, err) {
-		assert.EqualValues(t, http.StatusServiceUnavailable, resp.StatusCode)
 	}
 }

--- a/pkg/mirror/mirror_test.go
+++ b/pkg/mirror/mirror_test.go
@@ -227,15 +227,22 @@ func TestSlowMirrorNeverBlocksPrimary(t *testing.T) {
 	rc := newRecorder()
 	rc.gate = make(chan struct{}) // workers block until released at the end
 	defer close(rc.gate)
-	m := newMirror(rc) // Workers=4, QueueSize=16
+	m := newMirror(rc)                  // Workers=4, QueueSize=16
+	m.Timeout = 200 * time.Millisecond // gated workers free fast if a regression blocks dispatch
 
 	const n = 200
+	loopStart := time.Now()
 	for range n {
-		start := time.Now()
 		serve(m, func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
 			httptest.NewRequest("GET", "/", nil))
-		assert.Less(t, time.Since(start), 200*time.Millisecond, "the primary never waits on the mirror")
 	}
+	// Watchdog only: a per-iteration wall-clock bound gives a CI stall 200 chances to
+	// fail a non-blocking path, so we bound the WHOLE loop instead. With all 4 workers
+	// gated and the 16-slot queue full, a blocking dispatch would stall in 200ms
+	// ctx-Timeout waves of 4 (the gated canary honors ctx.Done) — ~9s for 180 blocked
+	// sends, comfortably past this bound — so 200 serves finishing inside it proves
+	// the primary never waits; dropFull>0 below proves the drop path was exercised.
+	assert.Less(t, time.Since(loopStart), 5*time.Second, "the primary never waits on the mirror")
 
 	// Most are dropped (queue full); the pool never grows unbounded (Workers, not n).
 	_, dropFull, _, _, _ := m.Stats()
@@ -271,12 +278,12 @@ func TestHungMirrorRespectsTimeout(t *testing.T) {
 	m := newMirror(rc)
 	m.Timeout = 50 * time.Millisecond
 
-	start := time.Now()
 	serve(m, func(http.ResponseWriter, *http.Request) {}, httptest.NewRequest("GET", "/", nil))
 
+	// The bounded Eventually alone proves "the timeout frees the worker"; a separate
+	// wall-clock cap raced worker scheduling against an inconsistent (smaller) budget.
 	require.Eventually(t, func() bool { return rc.ctxCanceled.Load() }, 2*time.Second, 5*time.Millisecond,
-		"the detached Timeout fires and frees the worker")
-	assert.Less(t, time.Since(start), time.Second, "no permanent worker pin")
+		"the detached Timeout fires and frees the worker (no permanent worker pin)")
 }
 
 func TestHopByHopStrippedMarkedAndReframed(t *testing.T) {
@@ -338,10 +345,11 @@ func TestRequestURIClearedAndIntegration(t *testing.T) {
 	// exercised end to end against a real transport (not just the clone).
 	want := bytes.Repeat([]byte("z"), 3000)
 	var (
-		gotMirror  atomic.Bool
-		gotBody    atomic.Bool
-		gotLen     atomic.Int64
-		gotChunked atomic.Bool
+		gotMirror   atomic.Bool
+		gotBody     atomic.Bool
+		gotLen      atomic.Int64
+		gotChunked  atomic.Bool
+		handlerDone atomic.Bool // set LAST: the completion signal the test gates on
 	)
 	canary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("X-Mirror") == "1" {
@@ -352,6 +360,7 @@ func TestRequestURIClearedAndIntegration(t *testing.T) {
 		b, _ := io.ReadAll(r.Body)
 		gotBody.Store(bytes.Equal(b, want))
 		w.WriteHeader(http.StatusOK)
+		handlerDone.Store(true)
 	}))
 	defer canary.Close()
 
@@ -366,8 +375,12 @@ func TestRequestURIClearedAndIntegration(t *testing.T) {
 	r.ContentLength = -1
 	serve(m, func(w http.ResponseWriter, r *http.Request) { _, _ = io.ReadAll(r.Body); w.WriteHeader(http.StatusOK) }, r)
 
-	require.Eventually(t, gotMirror.Load, 2*time.Second, 10*time.Millisecond,
+	// Gate on handler COMPLETION, not its first side effect: gating on gotMirror alone
+	// let the asserts below read gotBody/gotLen/gotChunked before the canary handler
+	// had stored them.
+	require.Eventually(t, handlerDone.Load, 2*time.Second, 10*time.Millisecond,
 		"the mirrored request reached a real reverse-proxy destination (RequestURI cleared, no panic)")
+	assert.True(t, gotMirror.Load(), "the mirrored request carried the mark to the canary")
 	assert.True(t, gotBody.Load(), "the canary received the byte-identical body")
 	assert.EqualValues(t, len(want), gotLen.Load(), "fixed Content-Length, not chunked-reframed")
 	assert.False(t, gotChunked.Load(), "TransferEncoding=nil prevented chunked re-framing")

--- a/pkg/ratelimit/concurrentqueue_test.go
+++ b/pkg/ratelimit/concurrentqueue_test.go
@@ -61,9 +61,12 @@ func TestConcurrentQueueStrategy(t *testing.T) {
 		// A 3rd Take queues and blocks until a slot frees.
 		q := make(chan bool, 1)
 		go func() { q <- s.Take("") }()
-		// Let the queued goroutine reach the block (increment QueueCount to 1). There
-		// is no external signal for "now blocked"; a generous wait covers CI load.
-		time.Sleep(100 * time.Millisecond)
+		// Wait until the queued goroutine has actually reached the block (QueueCount
+		// is 1) instead of sleeping: with a fixed sleep, a goroutine stalled past it
+		// would let the drop-Take below grab the queue slot itself and deadlock on the
+		// full Process channel.
+		require.Eventually(t, func() bool { return s.QueueCountForTest("") == 1 },
+			2*time.Second, time.Millisecond, "the queued Take never reached the block")
 
 		require.False(t, s.Take(""), "queue full (Size=1) -> drop")
 		require.False(t, s.Take(""), "still dropping")
@@ -73,9 +76,12 @@ func TestConcurrentQueueStrategy(t *testing.T) {
 		s.Put("") // free a slot -> unblock the queued Take
 		require.True(t, recvBool(t, q), "the queued Take acquired the freed slot")
 
-		// Repeat: another queued Take, again released by a Put.
+		// Repeat: another queued Take, again released by a Put. Same synchronization:
+		// QueueCount returned to 0 after the first cycle, so 1 means this Take queued
+		// (guaranteeing the second cycle really exercises the queued path).
 		go func() { q <- s.Take("") }()
-		time.Sleep(100 * time.Millisecond)
+		require.Eventually(t, func() bool { return s.QueueCountForTest("") == 1 },
+			2*time.Second, time.Millisecond, "the second queued Take never reached the block")
 		require.True(t, s.Take("other"), "a different key is still independent")
 		s.Put("")
 		require.True(t, recvBool(t, q), "the second queued Take acquired its slot")

--- a/pkg/ratelimit/export_test.go
+++ b/pkg/ratelimit/export_test.go
@@ -1,0 +1,15 @@
+package ratelimit
+
+// QueueCountForTest is a white-box probe for the external (ratelimit_test) concurrent
+// queue tests: it reports how many Takes are queued for key, so they can synchronize
+// on "the queued Take has reached the block" instead of sleeping and hoping the
+// scheduler ran the goroutine. Exported test-only identifiers here are visible to the
+// sibling ratelimit_test package and stay out of the shipped API.
+func (b *ConcurrentQueueStrategy) QueueCountForTest(key string) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if t := b.storage[key]; t != nil {
+		return t.QueueCount
+	}
+	return 0
+}

--- a/pkg/ratelimit/redis_test.go
+++ b/pkg/ratelimit/redis_test.go
@@ -91,13 +91,21 @@ func TestRedisFixedWindowAdmitsThenDenies(t *testing.T) {
 	assert.True(t, b.Take("a"))
 	assert.True(t, b.Take("a"))
 	assert.False(t, b.Take("a"), "3rd over Max=2 denied")
-	assert.True(t, b.Take("b"), "a different key is independent")
 
-	// The key is namespaced and epoch-suffixed.
-	epoch := time.Now().UnixNano() / int64(time.Hour)
+	// The key is namespaced and epoch-suffixed. Take reads the clock internally, so
+	// bracket it with both candidate epochs: if the top of the hour falls between
+	// Take's read and ours, the suffix is e1 or e2 (e2-e1 <= 1 for any stall under an
+	// hour) — a single post-hoc epoch read raced that crossing.
+	e1 := time.Now().UnixNano() / int64(time.Hour)
+	assert.True(t, b.Take("b"), "a different key is independent")
+	e2 := time.Now().UnixNano() / int64(time.Hour)
+
 	require.Len(t, f.lastKeys, 1)
 	assert.True(t, strings.HasPrefix(f.lastKeys[0], "parapet:rl:"), "default prefix")
-	assert.True(t, strings.HasSuffix(f.lastKeys[0], ":"+strconv.FormatInt(epoch, 10)), "epoch suffix")
+	assert.True(t,
+		strings.HasSuffix(f.lastKeys[0], ":"+strconv.FormatInt(e1, 10)) ||
+			strings.HasSuffix(f.lastKeys[0], ":"+strconv.FormatInt(e2, 10)),
+		"epoch suffix (either side of a possible hour crossing)")
 	assert.Contains(t, f.lastKeys[0], "b")
 }
 
@@ -133,14 +141,28 @@ func TestRedisFixedWindowRollsToFreshWindow(t *testing.T) {
 	const size = 50 * time.Millisecond
 	b := &RedisFixedWindowStrategy{Runner: f, Max: 1, Size: size}
 
-	// Align to just after a window boundary so the two same-window Takes below cannot
-	// straddle one (epochs are absolute now/Size, not relative to the first call).
-	now := time.Now().UnixNano()
-	time.Sleep(time.Duration((now/int64(size)+1)*int64(size) - now))
-
-	require.True(t, b.Take("k"))
-	require.False(t, b.Take("k"), "window exhausted")
-	time.Sleep(size) // cross into the next epoch
+	// Epochs are absolute now/Size and Take reads the clock internally, so a scheduler
+	// stall between the two Takes can push the second into a fresh epoch (which admits
+	// and breaks the exhaustion assert). Bracket the pair with epoch reads — e1 == e2
+	// proves both internal reads shared one window — and retry on a straddle: each
+	// attempt re-aligns to the NEXT boundary, so its epoch key is always virgin (a
+	// straddled prior attempt only ever incremented strictly earlier epochs).
+	var ok1, ok2, sameEpoch bool
+	for range 5 {
+		now := time.Now().UnixNano()
+		time.Sleep(time.Duration((now/int64(size)+1)*int64(size) - now))
+		e1 := time.Now().UnixNano() / int64(size)
+		ok1 = b.Take("k")
+		ok2 = b.Take("k")
+		if e2 := time.Now().UnixNano() / int64(size); e1 == e2 {
+			sameEpoch = true
+			break
+		}
+	}
+	require.True(t, sameEpoch, "could not land both Takes in one 50ms epoch after 5 attempts")
+	require.True(t, ok1)
+	require.False(t, ok2, "window exhausted")
+	time.Sleep(size) // cross into the next epoch (one-sided safe: any later epoch is fresh)
 	assert.True(t, b.Take("k"), "a fresh epoch key starts at 0")
 }
 
@@ -160,17 +182,22 @@ func TestRedisFixedWindowAfterEpochAnchored(t *testing.T) {
 	t.Parallel()
 	for _, size := range []time.Duration{time.Second, 7 * time.Second, 13 * time.Minute, time.Hour} {
 		b := &RedisFixedWindowStrategy{Runner: newFakeRedis(), Max: 1, Size: size}
-		now := time.Now()
+		before := time.Now()
 		got := b.After("k")
-		// After reads the clock again internally; if that read crossed an epoch
-		// boundary (astronomically rare), `want` and `got` reference different windows.
-		// Skip that vanishing case rather than flake.
-		if now.UnixNano()/int64(size) != time.Now().UnixNano()/int64(size) {
+		after := time.Now()
+		// After's internal clock read lies in [before, after]. If both brackets share
+		// an epoch, the internal read does too, and since After is strictly decreasing
+		// within an epoch, got must land in [end-after, end-before] — bounds that hold
+		// under ARBITRARY stalls, unlike the old fixed 5ms delta off a single pre-call
+		// read (the want-got gap there was exactly the inter-read stall). Skip only the
+		// vanishing boundary-crossing case.
+		if before.UnixNano()/int64(size) != after.UnixNano()/int64(size) {
 			continue
 		}
-		epoch := now.UnixNano() / int64(size)
-		want := time.Unix(0, (epoch+1)*int64(size)).Sub(now)
-		assert.InDelta(t, float64(want), float64(got), float64(5*time.Millisecond),
+		end := time.Unix(0, (before.UnixNano()/int64(size)+1)*int64(size))
+		assert.LessOrEqual(t, got, end.Sub(before),
+			"After is anchored to the integer epoch boundary for Size=%s", size)
+		assert.GreaterOrEqual(t, got, end.Sub(after),
 			"After is anchored to the integer epoch boundary for Size=%s", size)
 		assert.Positive(t, got)
 		assert.LessOrEqual(t, got, size)

--- a/pkg/ratelimit/slidingwindow_internal_test.go
+++ b/pkg/ratelimit/slidingwindow_internal_test.go
@@ -143,13 +143,24 @@ func TestSlidingWindowEvictStale(t *testing.T) {
 	require.True(t, b.Take("stale"))
 	require.True(t, b.Take("fresh"))
 
-	cur := time.Now().UnixNano() / b.size()
-	b.mu.Lock()
-	b.storage["stale"].window = 0       // epoch: many windows old
-	b.storage["fresh"].window = cur - 1 // exactly one window old: still has a live prev
-	b.mu.Unlock()
+	// evictStale re-reads the clock internally; if the top of the hour fell between
+	// computing cur and that read, deleteBefore would advance to cur and wrongly evict
+	// "fresh" (window cur-1). Bracket the call with epoch reads and re-stage on a
+	// crossing — a retry starts just past the boundary, so it cannot cross again.
+	for attempt := 0; ; attempt++ {
+		cur := time.Now().UnixNano() / b.size()
+		b.mu.Lock()
+		b.storage["stale"] = &slidingItem{window: 0, curr: 1}       // epoch: many windows old
+		b.storage["fresh"] = &slidingItem{window: cur - 1, curr: 1} // exactly one window old: still has a live prev
+		b.mu.Unlock()
 
-	b.evictStale()
+		b.evictStale()
+
+		if time.Now().UnixNano()/b.size() == cur {
+			break
+		}
+		require.Less(t, attempt, 3, "the hour boundary kept crossing the evictStale bracket")
+	}
 
 	b.mu.RLock()
 	_, staleExists := b.storage["stale"]
@@ -157,6 +168,60 @@ func TestSlidingWindowEvictStale(t *testing.T) {
 	b.mu.RUnlock()
 	assert.False(t, staleExists, ">= 2 windows old is evicted")
 	assert.True(t, freshExists, "one window old survives (its prev is still live)")
+}
+
+// TestSlidingWindowSuppressesBoundaryBurst proves, through the public Take and the
+// REAL d==1 roll inside it, that the previous window's spent budget suppresses the
+// up-to-2x burst a fixed window admits at its boundary. The rolled state is seeded
+// directly (a window that already spent Max, one roll away) instead of sleeping a
+// real 100ms window across a boundary, which raced the wall clock: with
+// Size=time.Hour, the admit condition Max*(1-e)+curr+1 <= Max caps curr at
+// Max*e-1 < Max-1 for any elapsed fraction e<1, hence burst < Max no matter where in
+// the hour the test runs. The exact smoothing math stays pinned by the deterministic
+// tests above.
+func TestSlidingWindowSuppressesBoundaryBurst(t *testing.T) {
+	t.Parallel()
+
+	const max = 10
+	b := &SlidingWindowStrategy{Max: max, Size: time.Hour}
+
+	for attempt := 0; ; attempt++ {
+		cur := time.Now().UnixNano() / b.size()
+		b.mu.Lock()
+		if b.storage == nil {
+			b.storage = make(map[string]*slidingItem)
+		}
+		// The previous window spent exactly Max; the first Take below performs the
+		// genuine curr->prev shift on roll's d==1 path.
+		b.storage["k"] = &slidingItem{window: cur - 1, curr: max}
+		b.mu.Unlock()
+
+		burst := 0
+		for range 100 {
+			if b.Take("k") {
+				burst++
+			}
+		}
+
+		// Retry only if the top of the hour fell inside the hammer loop (roll would
+		// then see d>=2, clear both counters, and spuriously grant a fresh Max). A
+		// retry starts just past the boundary, so it cannot cross again.
+		if time.Now().UnixNano()/b.size() == cur {
+			assert.Less(t, burst, max, "the previous window suppresses the boundary burst (no 2x)")
+			// And the d==1 roll genuinely executed inside Take: the seeded curr=Max
+			// moved to prev and the item advanced to the current window. A frozen or
+			// mis-wired window computation in Take would leave window==cur-1 (and
+			// could pass the burst assert above by never granting at all).
+			b.mu.RLock()
+			it := b.storage["k"]
+			b.mu.RUnlock()
+			require.NotNil(t, it)
+			assert.EqualValues(t, cur, it.window, "Take's clock read advanced the item to the current window")
+			assert.EqualValues(t, max, it.prev, "the spent budget shifted curr->prev on the d==1 roll")
+			break
+		}
+		require.Less(t, attempt, 3, "the hour boundary kept crossing the burst loop")
+	}
 }
 
 // TestSlidingWindowSingleCleanupGoroutine: the cleanup loop is started exactly once,

--- a/pkg/ratelimit/slidingwindow_test.go
+++ b/pkg/ratelimit/slidingwindow_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	. "github.com/moonrhythm/parapet/pkg/ratelimit"
 )
@@ -56,43 +55,10 @@ func TestSlidingWindowBurstAdmitsExactlyMax(t *testing.T) {
 	assert.Zero(t, b.After("other"), "an unknown key can take now")
 }
 
-// TestSlidingWindowSuppressesBoundaryBurst is the integration proof, through the
-// public Take across a REAL window roll, that the previous window's spent budget
-// suppresses the up-to-2x burst a fixed window admits at its boundary. Timing-loose
-// by construction (the assertion tolerates landing anywhere in the first ~90% of the
-// next window); the exact smoothing math is pinned deterministically in the internal
-// tests.
-func TestSlidingWindowSuppressesBoundaryBurst(t *testing.T) {
-	t.Parallel()
-
-	const max = 10
-	size := 100 * time.Millisecond
-	b := &SlidingWindowStrategy{Max: max, Size: size}
-
-	// Land ~2ms into a fresh window so the fill below stays within one window.
-	now := time.Now().UnixNano()
-	toBoundary := (now/int64(size)+1)*int64(size) - now
-	time.Sleep(time.Duration(toBoundary) + 2*time.Millisecond)
-
-	filled := 0
-	for range 100 {
-		if b.Take("k") {
-			filled++
-		}
-	}
-	require.Equal(t, max, filled, "window N admits exactly Max")
-
-	// Cross into window N+1 (prev is now Max) and hammer immediately: a fixed window
-	// would grant another fresh Max here; the sliding window must admit far fewer.
-	time.Sleep(size)
-	burst := 0
-	for range 100 {
-		if b.Take("k") {
-			burst++
-		}
-	}
-	assert.Less(t, burst, max, "the previous window suppresses the boundary burst (no 2x)")
-}
+// TestSlidingWindowSuppressesBoundaryBurst lives in slidingwindow_internal_test.go:
+// the real-clock version here raced 100ms wall-clock windows against the scheduler
+// (a ~100ms stall mid-loop straddled a boundary and broke both phases); the internal
+// version seeds the rolled state deterministically and still drives the public Take.
 
 // TestSlidingWindowMaxZero: a zero limit admits nothing (the honest reading,
 // matching FixedWindow's no-magic-default stance).

--- a/pkg/upstream/circuitbreaker_test.go
+++ b/pkg/upstream/circuitbreaker_test.go
@@ -380,11 +380,20 @@ func TestCircuitBreaker_OpenCooldownRateLimitsProbes(t *testing.T) {
 	l := &CircuitBreakingLoadBalancer{
 		Targets: newEjectTargets(t0), FailureThreshold: 1, OpenTimeout: 20 * time.Millisecond, MaxOpenTimeout: 20 * time.Millisecond, HalfOpenMaxProbes: 1,
 	}
+	// Bound the probe count by the MEASURED wall-clock window, not the goroutine
+	// count: the budget is ~one probe per OpenTimeout for as long as the hammer
+	// actually runs, and time.Sleep(200ms) can oversleep arbitrarily on a saturated
+	// runner — a fixed bound of 40 fails once the window stretches past ~780ms even
+	// though the cooldown gating worked. Measuring from the trip (where the first
+	// cooldown starts) makes the bound exact at any execution speed, while a
+	// zero-cooldown stale-timer flood still exceeds it by orders of magnitude.
+	start := time.Now()
 	driveLB(l, 1) // trip
 	hammer(l, 40, 200*time.Millisecond)
+	elapsed := time.Since(start)
 
 	total := t0.calls.Load()
-	assert.Less(t, total, int64(40), "cooldown rate-limits probes; no stale-timer flood")
+	assert.Less(t, total, int64(elapsed/l.OpenTimeout)+5, "cooldown rate-limits probes; no stale-timer flood")
 	assert.Greater(t, total, int64(1), "probes are admitted after each cooldown")
 }
 

--- a/pkg/upstream/ejecting_test.go
+++ b/pkg/upstream/ejecting_test.go
@@ -106,18 +106,25 @@ func TestEjectingLoadBalancer(t *testing.T) {
 		t0, t1 := &fakeUpstream{}, &fakeUpstream{}
 		t0.down.Store(true)
 		l := &EjectingLoadBalancer{
-			Targets:      newEjectTargets(t0, t1),
-			MaxFails:     3,
-			EjectTimeout: 20 * time.Millisecond,
+			Targets:  newEjectTargets(t0, t1),
+			MaxFails: 3,
+			// Sticky cooldown: with a real 20ms window, a single >=20ms scheduler stall
+			// between the ejecting drive and the "still ejected" drive lets pick()
+			// re-admit the still-down target and fail the equality assert.
+			EjectTimeout: time.Hour,
 		}
 
 		drive(l, 6) // eject t0
 		ejected := t0.calls.Load()
 		drive(l, 4)
 		assert.Equal(t, ejected, t0.calls.Load(), "still ejected")
+		assert.Greater(t, l.targets[0].ejectedUntil.Load(), time.Now().UnixNano(), "eject set a future deadline")
 
 		t0.down.Store(false)
-		time.Sleep(40 * time.Millisecond) // let the cooldown expire
+		// Expire the cooldown deterministically by rewinding the deadline instead of
+		// sleeping past a real window (the latencyejecting_test.go pattern). A NONZERO
+		// past value, not 0, so recovery still exercises the wasEjected/ReasonRecover path.
+		l.targets[0].ejectedUntil.Store(time.Now().UnixNano() - 1)
 		drive(l, 6)
 		assert.Greater(t, t0.calls.Load(), ejected, "target back in rotation after cooldown")
 	})

--- a/pkg/upstream/hedging_test.go
+++ b/pkg/upstream/hedging_test.go
@@ -111,7 +111,10 @@ func TestHedging_PrimaryWinsNoHedge(t *testing.T) {
 	fast := &ctxFake{}
 	hedge := &ctxFake{}
 	h := NewHedgingLoadBalancer(rrLB(fast, hedge))
-	h.HedgeDelay = 200 * time.Millisecond // primary returns well within this
+	// The no-hedge property must hold at any scheduler speed: a real 200ms timer can
+	// beat a stalled primary leg under -race contention and spuriously launch the
+	// hedge, so make the timer unreachable instead of racing it.
+	h.HedgeDelay = time.Hour
 	resp, err := h.RoundTrip(httptest.NewRequest("GET", "/", nil))
 	require.NoError(t, err)
 	resp.Body.Close()
@@ -124,7 +127,7 @@ func TestHedging_FailFastOnError(t *testing.T) {
 	boom := &ctxFake{err: errors.New("dial fail")} // primary errors immediately
 	fast := &ctxFake{}
 	h := NewHedgingLoadBalancer(rrLB(boom, fast))
-	h.HedgeDelay = 500 * time.Millisecond // long: only fail-fast can make the hedge fire quickly
+	h.HedgeDelay = 10 * time.Second // long: only fail-fast can make the hedge fire quickly
 	h.HedgeOnError = true
 
 	start := time.Now()
@@ -132,7 +135,13 @@ func TestHedging_FailFastOnError(t *testing.T) {
 	elapsed := time.Since(start)
 	require.NoError(t, err, "the hedge wins after the primary errors")
 	resp.Body.Close()
-	assert.Less(t, elapsed, 200*time.Millisecond, "the hedge fired immediately on the error, not after HedgeDelay")
+	assert.EqualValues(t, 1, boom.calls.Load(), "the primary leg ran (and errored)")
+	assert.EqualValues(t, 1, fast.calls.Load(), "exactly one hedge leg served the winner")
+	// Bound the duration against the config, not a magic constant: the old
+	// 200ms-vs-500ms discriminator was bridgeable by scheduler stalls alone. A broken
+	// fail-fast fires the hedge on the ~10s timer and fails this cleanly, while the
+	// pass-side jitter margin is now 5s — out of reach of any realistic stall.
+	assert.Less(t, elapsed, h.HedgeDelay/2, "the hedge fired on the error, not after HedgeDelay")
 }
 
 func TestHedging_AllFailReturnsError(t *testing.T) {

--- a/pkg/upstream/latencyejecting_test.go
+++ b/pkg/upstream/latencyejecting_test.go
@@ -75,15 +75,28 @@ func TestLatencyEjectingLoadBalancer(t *testing.T) {
 
 	t.Run("DetectsAndEjectsTheSlowOne", func(t *testing.T) {
 		t.Parallel()
-		slow := &fakeUpstream{}
-		slow.delay.Store(int64(latSlow))
-		fast := []*fakeUpstream{slow, {}, {}, {}, {}}
-		l := latTestLB(newEjectTargets(fast...))
+		l := latTestLB(newEjectTargets(&fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
 		// Sticky cooldown: the slow target need only cross the ejection bar ONCE during
 		// the drive and then stays ejected, so the assert cannot race a re-admission /
 		// re-probe (which resets samples) when -race stretches the synchronous drive.
 		l.EjectTimeout = time.Minute
-		driveLB(l, 300)
+		l.once.Do(l.init)
+		// Feed deterministic synthetic durations through record() instead of timing real
+		// round-trips: observe() seeds the EWMA exactly from the FIRST sample, so a
+		// single >=1.2ms scheduler stall inside a fast peer's first ~µs measured request
+		// would seed it above the ~1ms bar and steal the single MaxEjectionPercent slot
+		// from the slow target before its first eligible record. Constant samples pin
+		// each EWMA at exactly that constant for any decay weight, making the verdict
+		// wall-clock independent while still exercising the MinSamples/MinHosts
+		// eligibility-ordering, poolMedian, and cap paths. (The RoundTrip-times-latency
+		// wiring stays covered by TestLatencyEjectingConcurrent.)
+		resp := httptest.NewRecorder().Result()
+		for range 60 {
+			l.record(&l.peers[0], latSlow, resp, nil) // slow peer first, mirroring pick order
+			for i := 1; i < 5; i++ {
+				l.record(&l.peers[i], 100*time.Microsecond, resp, nil)
+			}
+		}
 		assert.True(t, latEjected(l, 0), "the slow target is ejected")
 		for i := 1; i < 5; i++ {
 			assert.False(t, latEjected(l, i), "fast targets stay in rotation")
@@ -94,14 +107,18 @@ func TestLatencyEjectingLoadBalancer(t *testing.T) {
 		t.Parallel()
 		// THE headline anti-outage-amplifier test: everyone slow by the same amount,
 		// the median rises with them, nobody is an outlier.
-		var trs []*fakeUpstream
-		for range 5 {
-			u := &fakeUpstream{}
-			u.delay.Store(int64(latMild))
-			trs = append(trs, u)
+		l := latTestLB(newEjectTargets(&fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		l.once.Do(l.init)
+		// Synthetic constant durations through record(): when timing real round-trips, a
+		// single ~100ms stall inside one peer's measured section near the END of the
+		// drive lifts that EWMA past 3x median and the 30ms cooldown outlives the test.
+		// Identical synthetic samples pin every EWMA at exactly latMild (a convex
+		// combination of equal values), so no stall can manufacture an outlier.
+		// (Deliberately NOT sticky: keep latTestLB's EjectTimeout as-is.)
+		resp := httptest.NewRecorder().Result()
+		for i := range 300 {
+			l.record(&l.peers[i%5], latMild, resp, nil)
 		}
-		l := latTestLB(newEjectTargets(trs...))
-		driveLB(l, 300)
 		assert.Zero(t, latEjectedCount(l), "a uniform slowdown ejects no one")
 	})
 
@@ -148,15 +165,34 @@ func TestLatencyEjectingLoadBalancer(t *testing.T) {
 
 	t.Run("NoOscillationCascade", func(t *testing.T) {
 		t.Parallel()
-		// One clear outlier among otherwise-equal targets; removing it must not make a
+		// One clear outlier among otherwise-similar targets; removing it must not make a
 		// peer the new outlier (the median is robust).
-		slow := &fakeUpstream{}
-		slow.delay.Store(int64(latSlow))
-		l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+		l := latTestLB(newEjectTargets(&fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
 		l.EjectTimeout = time.Minute // sticky (see DetectsAndEjectsTheSlowOne)
-		driveLB(l, 300)
+		l.once.Do(l.init)
+		// Synthetic durations through record() — same first-sample-poison cap-steal race
+		// as DetectsAndEjectsTheSlowOne (cap = floor(6*0.3) = 1 slot a poisoned fast peer
+		// could consume forever). The fast peers get a small deterministic SPREAD, not
+		// identical latencies, so poolMedian sorts genuinely unequal survivor baselines
+		// in phase 2. (The spread alone cannot flag a non-robust baseline statistic:
+		// MinEjectDelta=1ms floors the bar above every ~100-200µs survivor regardless,
+		// and the sticky-ejected peer 0 holds the single cap slot.)
+		resp := httptest.NewRecorder().Result()
+		fastLat := func(i int) time.Duration { return 100*time.Microsecond + time.Duration(i)*20*time.Microsecond }
+		for range 60 {
+			l.record(&l.peers[0], latSlow, resp, nil)
+			for i := 1; i < 6; i++ {
+				l.record(&l.peers[i], fastLat(i), resp, nil)
+			}
+		}
 		require.True(t, latEjected(l, 0))
-		driveLB(l, 300)
+		// Phase 2: the ejected peer receives no traffic (pick skips it); the survivors
+		// keep their spread of baselines.
+		for range 60 {
+			for i := 1; i < 6; i++ {
+				l.record(&l.peers[i], fastLat(i), resp, nil)
+			}
+		}
 		for i := 1; i < 6; i++ {
 			assert.False(t, latEjected(l, i), "no cascade onto the next-slowest")
 		}
@@ -165,19 +201,53 @@ func TestLatencyEjectingLoadBalancer(t *testing.T) {
 	t.Run("RecoversAfterCooldownNoImmediateReEject", func(t *testing.T) {
 		t.Parallel()
 		// A VERY slow host (the critique's flapping case): it must not re-eject on its
-		// first post-cooldown sample once it has recovered — eject() reseeds the EWMA.
+		// first post-cooldown samples once it has recovered — eject() reseeds the EWMA.
+		// Wall-clock races are designed out: the cooldown is "expired" by rewinding
+		// ejectedUntil (not by sleeping past a real 30ms window the drive can outlast),
+		// and both phases feed deterministic synthetic durations through record() —
+		// timing real 2ms sleeps lets contention inflate the fast peers' sleep-wake
+		// latency multiplicatively, collapsing the 20ms-vs-2ms ratio below the 3x bar
+		// so the host never ejects at all. The peers' baseline stays at latMild (not
+		// ~0µs) so the recovered host sits well under a bar a stale 20ms EWMA (the bug
+		// this guards against) would still trip.
 		slow := &fakeUpstream{}
-		slow.delay.Store(int64(20 * time.Millisecond)) // ~10x the others
-		l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
-		driveLB(l, 200)
+		peers := []*fakeUpstream{slow, {}, {}, {}}
+		l := latTestLB(newEjectTargets(peers...))
+		l.EjectTimeout = time.Minute // sticky (see DetectsAndEjectsTheSlowOne)
+		rec := &stateRecorder{}
+		l.OnStateChange = rec.fn()
+		l.once.Do(l.init)
+		resp := httptest.NewRecorder().Result()
+		for range 50 {
+			for i := 1; i < 4; i++ {
+				l.record(&l.peers[i], latMild, resp, nil)
+			}
+			// Mirror pick() semantics: an ejected peer receives no traffic, so its
+			// stale samples/EWMA must not keep rebuilding after the eject — feeding it
+			// anyway would silently re-arm a phase-2 re-eject and the test would then
+			// pass only via the later heal, not the no-flap property in its name.
+			if !latEjected(l, 0) {
+				l.record(&l.peers[0], 20*time.Millisecond, resp, nil) // ~10x the others
+			}
+		}
 		require.True(t, latEjected(l, 0), "very-slow host is ejected")
 
-		slow.delay.Store(0) // recovered
-		time.Sleep(40 * time.Millisecond) // past the 30ms cooldown
-		base := slow.calls.Load()
-		driveLB(l, 200) // re-probe + accumulate fresh fast samples
-
+		l.peers[0].ejectedUntil.Store(time.Now().UnixNano() - 1) // cooldown elapsed, deterministically
+		for range 50 {                                           // recovered to peer level: fresh post-cooldown samples
+			for i := range 4 {
+				l.record(&l.peers[i], latMild, resp, nil)
+			}
+		}
 		assert.False(t, latEjected(l, 0), "a recovered host is not re-ejected on stale data")
+		// Pin the no-flap property itself: exactly one eject episode, one recovery —
+		// a flap-then-heal implementation cannot sneak past the final state assert.
+		assert.Equal(t, 1, rec.count(ReasonEject), "no second eject on stale data")
+		assert.Equal(t, 1, rec.count(ReasonRecover), "exactly one recovery")
+
+		// And pick() must actually re-admit it: an expired deadline puts it back in
+		// round-robin rotation (real round-trips; ejection already asserted above).
+		base := slow.calls.Load()
+		driveLB(l, 8)
 		assert.Greater(t, slow.calls.Load(), base, "the recovered host serves traffic again")
 	})
 
@@ -255,17 +325,21 @@ func TestLatencyPoolMedian(t *testing.T) {
 func TestLatencyEjectingConcurrent(t *testing.T) {
 	t.Parallel()
 	slow := &fakeUpstream{}
-	// A clear outlier (much slower than its peers) so the verdict survives -race
-	// timing noise: under -race the "fast" peers' measured latency rises, lifting the
-	// pool median, so a small gap can leave the slow one under the EjectionFactor bar.
+	// A clear outlier so the eject path (almost always) runs under the hammer too.
 	slow.delay.Store(int64(30 * time.Millisecond))
 	l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
 	l.MinSamples = 10
-	l.EjectTimeout = time.Minute // sticky: once ejected it stays, so the check never races a re-admit
+	l.EjectTimeout = time.Minute // sticky: once ejected it stays, so the poll never races a re-admit
 	l.once.Do(l.init)            // build peers now so the poll goroutine never races lazy init
 
-	// Hammer in the background and poll for ejection (rather than asserting at one
-	// racy instant, where the slow target may be momentarily re-admitted/re-probing).
+	// This test exists for -race coverage of concurrent pick/observe/eject and for
+	// the RoundTrip-measures-and-records wiring. It does NOT assert the ejection
+	// verdict: under heavy co-test contention every MEASURED latency inflates by
+	// scheduler stall, so the slow:median ratio can sit under EjectionFactor for the
+	// whole deadline and an "eventually ejected" assert flakes (observed under a
+	// 6-package -race stress). The verdict is asserted deterministically with
+	// synthetic samples in DetectsAndEjectsTheSlowOne; here we assert only facts
+	// that hold at any execution speed.
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 	for range 16 {
@@ -285,8 +359,21 @@ func TestLatencyEjectingConcurrent(t *testing.T) {
 			}
 		}()
 	}
-	require.Eventually(t, func() bool { return latEjected(l, 0) }, 3*time.Second, 10*time.Millisecond,
-		"the slow target gets ejected under concurrency")
+	require.Eventually(t, func() bool {
+		for i := 1; i < len(l.peers); i++ {
+			// A "fast" peer whose first measured sample caught a scheduler stall can
+			// itself be ejected (seed poison) — eject() zeroes its EWMA and, sticky,
+			// it never records again. ejectedUntil != 0 proves the full
+			// record->eject pipeline ran for it, which is the wiring fact we want.
+			if l.peers[i].ewmaBits.Load() == 0 && l.peers[i].ejectedUntil.Load() == 0 {
+				return false // this peer's measured latency never reached its EWMA
+			}
+		}
+		// The slow peer was sampled too — or was already ejected, which resets its
+		// counts (and proves the whole record->eject pipeline ran end to end).
+		return latEjected(l, 0) || l.peers[0].samples.Load() > 0
+	}, 3*time.Second, 10*time.Millisecond,
+		"every peer's measured latency reaches its EWMA under concurrency")
 	close(stop)
 	wg.Wait()
 }

--- a/pkg/upstream/state_test.go
+++ b/pkg/upstream/state_test.go
@@ -2,6 +2,7 @@ package upstream
 
 import (
 	"errors"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -150,14 +151,26 @@ func TestEjectingLoadBalancer_StateChangeConcurrentOneEject(t *testing.T) {
 func TestLatencyEjectingLoadBalancer_StateChange(t *testing.T) {
 	t.Parallel()
 	var rec stateRecorder
-	slow := &fakeUpstream{}
-	slow.delay.Store(int64(latSlow))
-	l := latTestLB(newEjectTargets(slow, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
+	l := latTestLB(newEjectTargets(&fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}, &fakeUpstream{}))
 	l.OnStateChange = rec.fn()
-	driveLB(l, 300)
-	assert.GreaterOrEqual(t, rec.count(ReasonEject), 1, "the slow target's ejection emits ReasonEject")
+	l.once.Do(l.init)
+	// Synthetic constant durations through record(): timing real round-trips lets
+	// scheduler stalls inflate the fast peers' EWMA seeds (lifting the median so the
+	// 5ms outlier never ejects and the count stays 0). Constant samples pin each EWMA,
+	// so the whole record -> poolMedian -> guard-rails -> eject -> OnStateChange path
+	// runs deterministically. Fast peers first each round so the slow peer's
+	// MinSamples-th record sees a valid >=MinHosts baseline and ejects exactly once.
+	resp := httptest.NewRecorder().Result()
+	for range int(l.MinSamples) {
+		for p := 1; p < 4; p++ {
+			l.record(&l.peers[p], 100*time.Microsecond, resp, nil)
+		}
+		l.record(&l.peers[0], latSlow, resp, nil)
+	}
+	assert.Equal(t, 1, rec.count(ReasonEject), "the slow target's ejection emits ReasonEject")
 	for _, c := range rec.all() {
 		if c.Reason == ReasonEject {
+			assert.Equal(t, StateClosed, c.From, "first ejection comes from closed")
 			assert.Equal(t, StateOpen, c.To)
 		}
 	}

--- a/pkg/upstream/upstream_test.go
+++ b/pkg/upstream/upstream_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/moonrhythm/parapet"
 	"github.com/moonrhythm/parapet/pkg/logger"
@@ -304,19 +306,25 @@ func TestIssue115(t *testing.T) {
 	}))
 	defer upstreamServer.Close()
 
-	frontendServer := parapet.Server{
-		Addr: "127.0.0.1:3002",
-	}
+	// Bind the listener in the test on an OS-assigned port: net.Listen returning means
+	// the kernel already accepts into the backlog (before Serve even runs), which
+	// designs out both the sleep-vs-listener-goroutine startup race and the fixed-port
+	// (3002) collision — the old 1s sleep was the only readiness signal, and a stalled
+	// listener goroutine made the unchecked http.Get nil-pointer panic.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	frontendServer := parapet.Server{}
 	frontendServer.Use(&Upstream{
 		Transport: SingleHost(strings.TrimPrefix(upstreamServer.URL, "http://"), &HTTPTransport{}),
 	})
-	go frontendServer.ListenAndServe()
+	go frontendServer.Serve(ln)
 	defer frontendServer.Shutdown()
 
-	time.Sleep(time.Second)
-
-	resp, _ := http.Get("http://127.0.0.1:3002")
+	resp, err := http.Get("http://" + ln.Addr().String())
+	require.NoError(t, err)
+	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
 	assert.Equal(t, "ok", string(body))
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,7 +1,9 @@
 package parapet_test
 
 import (
+	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -20,16 +22,61 @@ func TestServer(t *testing.T) {
 		called = true
 		w.WriteHeader(200)
 	})
-	srv.Addr = "127.0.0.1:8081"
-	go srv.ListenAndServe()
-	time.Sleep(100 * time.Millisecond)
+	// Pre-bind an ephemeral listener and Serve it: removes the
+	// bind-vs-Get race (sleep was the only sync) and the fixed-port
+	// collision; once Listen returns the kernel backlog queues the dial.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer ln.Close()
+	srv.Addr = ln.Addr().String()
+	go srv.Serve(ln)
 
-	resp, err := http.Get("http://localhost:8081")
+	resp, err := http.Get("http://" + srv.Addr)
 	if assert.NoError(t, err) {
 		assert.Equal(t, 200, resp.StatusCode)
 		assert.True(t, called)
 		assert.NoError(t, srv.Shutdown())
 	}
+}
+
+func TestListenAndServe(t *testing.T) {
+	t.Parallel()
+
+	// TestServer/TestServerTLS pre-bind and call Serve, so this is the ONE test
+	// exercising the ListenAndServe path (addr resolve, ListenConfig bind, the
+	// modifyConnListener decision). Addr :0 keeps it collision-free, and the
+	// BaseContext hook — invoked with the BOUND listener before accepting —
+	// delivers the real address without sleeping; errCh turns an early bind
+	// failure into a fast, explicit failure instead of a deadlock.
+	srv := &Server{}
+	srv.Addr = "127.0.0.1:0"
+	srv.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+	addrCh := make(chan string, 1)
+	srv.BaseContext = func(l net.Listener) context.Context {
+		addrCh <- l.Addr().String()
+		return context.Background()
+	}
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.ListenAndServe() }()
+
+	var addr string
+	select {
+	case addr = <-addrCh:
+	case err := <-errCh:
+		t.Fatalf("ListenAndServe failed before binding: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("ListenAndServe never bound a listener")
+	}
+	resp, err := http.Get("http://" + addr)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 200, resp.StatusCode)
+		resp.Body.Close()
+	}
+	assert.NoError(t, srv.Shutdown())
 }
 
 func TestServerTLS(t *testing.T) {
@@ -43,7 +90,6 @@ func TestServerTLS(t *testing.T) {
 		assert.Equal(t, "https", r.Header.Get("X-Forwarded-Proto"))
 		w.WriteHeader(200)
 	})
-	srv.Addr = "127.0.0.1:8082"
 	cert, err := GenerateSelfSignCertificate(SelfSign{
 		CommonName: "localhost",
 		Hosts:      []string{"localhost"},
@@ -52,8 +98,15 @@ func TestServerTLS(t *testing.T) {
 	srv.TLSConfig = &tls.Config{
 		Certificates: []tls.Certificate{cert},
 	}
-	go srv.ListenAndServe()
-	time.Sleep(100 * time.Millisecond)
+	// Same de-flake as TestServer: pre-bind ephemeral, Serve the bound
+	// listener (Serve routes through ServeTLS when TLSConfig is set).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer ln.Close()
+	srv.Addr = ln.Addr().String()
+	go srv.Serve(ln)
 
 	client := http.Client{
 		Transport: &http.Transport{
@@ -62,7 +115,7 @@ func TestServerTLS(t *testing.T) {
 			},
 		},
 	}
-	resp, err := client.Get("https://localhost:8082")
+	resp, err := client.Get("https://" + srv.Addr)
 	if assert.NoError(t, err) {
 		assert.Equal(t, 200, resp.StatusCode)
 		assert.True(t, called)


### PR DESCRIPTION
## What

Closes out the known-flaky `RecoversAfterCooldownNoImmediateReEject` race and 27 more latent timing flakes found by an adversarial sweep (parallel finders → refuting verifiers; every mechanism empirically reproduced — e.g. a single injected 25 ms stall fails `ejecting_test.go`'s cooldown assert deterministically). Test files only; no implementation changes.

## Flake classes fixed (by mechanism, never by widening sleeps)

| Class | Tests | Fix |
|---|---|---|
| Real-clock window racing the assert | ejecting/latency cooldowns, sliding-window rolls, cache Age/TTL | Expire state deterministically (rewind `ejectedUntil` to a past nanos, seed rolled window state) instead of sleeping past a real window |
| Measured latency within scheduler jitter | latency-ejection verdicts (EWMA first-sample seed poisoning could steal the single ejection-cap slot) | Feed fixed synthetic durations through `record()` — constant samples pin each EWMA exactly while still exercising eligibility ordering, `poolMedian`, and the cap; the concurrent hammer now asserts only speed-independent wiring facts |
| Sleep-then-assert / schedule assumptions | concurrent-queue (could deadlock on failure), cache decoupled fill, mirror, healthz shutdown | Synchronize on the observable event: channels, `Eventually` on served state, a test-only queue-depth probe (`export_test.go`) |
| Bind races + fixed-port collisions | `TestServer`, `TestServerTLS`, `TestIssue115`, `TestHealthz` | Pre-bind an ephemeral listener and `Serve` it; new `TestListenAndServe` keeps the `ListenAndServe` path covered via the `BaseContext` bound-listener hook |
| Epoch-boundary hazards | redis fixed window, sliding window | Bracket with epoch reads; a genuine boundary crossing retries instead of failing falsely |

## Sensitivity preserved (the tests still catch real regressions)

For each substantial rewrite the guarded implementation mechanism was broken one-mutation-at-a-time (EWMA reseed removed, `pick()` never re-admitting, breaker cooldown gate disabled, hedge launched eagerly, window roll regressed to fixed-window, mirror `Timeout`/`TransferEncoding`/drop-path regressions, readiness flag ignored, …) and the fixed test confirmed to FAIL, then the mutation reverted to an empty diff.

An adversarial scrutiny pass over the diff itself caught and fixed 3 further defects in the fixes: a re-eject flap that made `RecoversAfterCooldownNoImmediateReEject` pass for the wrong reason (now pinned with `stateRecorder`: exactly one eject, one recover), a wedge case in the concurrent hammer's poll (an ejected seed-poisoned peer zeroes its EWMA forever), and `eachBackendDecoupled` missing the `LockTimeout` pin its sibling helper got.

## Validation

- `make` fully green (vet + lint + `-race` suite)
- Every fixed test: `go test -race -count=20` green
- Six packages run concurrently at `-count=3..5`, repeatedly — the contention profile that reproduced the original failures — zero failures (and this stress caught one extra real flake the sweep had wrongly rejected, fixed here too)

## Known follow-up (out of scope: implementation change)

The sweep surfaced a latent data race in `Server`: `RegisterOnShutdown` appends to `s.onShutdown` from request goroutines while `Shutdown` reads the slice unsynchronized (`server.go:223` vs `server.go:204`). Needs a mutex in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)