### PR TITLE
feat(upstream): observe ActiveHealthCheck gate flips with classified probe cause

### DIFF
--- a/pkg/prom/upstream_state.go
+++ b/pkg/prom/upstream_state.go
@@ -13,6 +13,7 @@ type upstreamStateMetrics struct {
 	once        sync.Once
 	state       *prometheus.GaugeVec
 	transitions *prometheus.CounterVec
+	probeDowns  *prometheus.CounterVec
 }
 
 var _upstreamState upstreamStateMetrics
@@ -27,7 +28,11 @@ func (p *upstreamStateMetrics) init() {
 			Namespace: Namespace,
 			Name:      "upstream_state_transitions_total",
 		}, []string{"host", "from", "to", "reason"})
-		reg.MustRegister(p.state, p.transitions)
+		p.probeDowns = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "upstream_probe_down_total",
+		}, []string{"host", "cause"})
+		reg.MustRegister(p.state, p.transitions, p.probeDowns)
 	})
 }
 
@@ -43,6 +48,14 @@ func (p *upstreamStateMetrics) observe(c upstream.StateChange) {
 	}); err == nil {
 		ctr.Inc()
 	}
+	if c.Cause != upstream.CauseNone {
+		if ctr, err := p.probeDowns.GetMetricWith(prometheus.Labels{
+			"host":  c.Host,
+			"cause": c.Cause.String(),
+		}); err == nil {
+			ctr.Inc()
+		}
+	}
 }
 
 // UpstreamState returns an upstream.StateChangeFunc that records per-target
@@ -53,10 +66,11 @@ func (p *upstreamStateMetrics) observe(c upstream.StateChange) {
 //	lb.OnStateChange = prom.UpstreamState()
 //	s.Use(upstream.New(lb))
 //
-// It registers two metrics (lazily, once per process):
+// It registers three metrics (lazily, once per process):
 //
 //	{namespace}_upstream_breaker_state{host}                           gauge: 0 closed, 1 open, 2 half_open
 //	{namespace}_upstream_state_transitions_total{host,from,to,reason}  counter of transitions
+//	{namespace}_upstream_probe_down_total{host,cause}                  counter of active-HC probe-down events by cause
 //
 // The transitions counter is the authoritative signal: its increments are exact and
 // order-independent, so alert on it. The gauge is a best-effort convenience — under
@@ -66,6 +80,13 @@ func (p *upstreamStateMetrics) observe(c upstream.StateChange) {
 // rotation membership (a target whose cooldown expired but has not yet served a
 // successful request reads open). A target that has never transitioned has no gauge
 // sample. The host label is the operator-configured upstream target (bounded).
+//
+// The probe_down counter breaks ActiveHealthCheck down-events out by classified
+// failure cause (one of: timeout, refused, reset, dns, tls, status, error — a bounded
+// closed set) for mid-incident triage; it is populated only by
+// ActiveHealthCheck.OnStateChange and never by the circuit-breaker or ejecting
+// balancers. Probe transitions still flow into transitions_total as
+// reason="probe_down"/"probe_recover" with no change to that counter.
 func UpstreamState() upstream.StateChangeFunc {
 	_upstreamState.init()
 	return _upstreamState.observe

--- a/pkg/prom/upstream_state_test.go
+++ b/pkg/prom/upstream_state_test.go
@@ -62,6 +62,69 @@ func TestUpstreamFastRejects(t *testing.T) {
 		"only ErrUnavailable (shed-before-round-trip) counts")
 }
 
+// countDelta treats counterValue's -1 (absent series) as 0 so the positive-count
+// assertions are safe to run repeatedly (-count) against the process-global registry.
+func countDelta(before, after float64) float64 {
+	if before < 0 {
+		before = 0
+	}
+	return after - before
+}
+
+func TestUpstreamState_ProbeDownCause(t *testing.T) {
+	observe := UpstreamState()
+	const host = "prom-probedown-test.backend"
+	downLbl := map[string]string{"host": host, "cause": "timeout"}
+	transLbl := map[string]string{"host": host, "from": "closed", "to": "open", "reason": "probe_down"}
+	baseDown := counterValue(t, "parapet_upstream_probe_down_total", downLbl)
+	baseTrans := counterValue(t, "parapet_upstream_state_transitions_total", transLbl)
+
+	observe(upstream.StateChange{
+		Host: host, From: upstream.StateClosed, To: upstream.StateOpen,
+		Reason: upstream.ReasonProbeDown, Cause: upstream.CauseTimeout,
+	})
+
+	// The cause rides on the focused probe-down counter...
+	assert.EqualValues(t, 1, countDelta(baseDown, counterValue(t, "parapet_upstream_probe_down_total", downLbl)))
+	// ...and the transition still flows into the UNCHANGED authoritative counter.
+	assert.EqualValues(t, 1, countDelta(baseTrans, counterValue(t, "parapet_upstream_state_transitions_total", transLbl)))
+	assert.EqualValues(t, 1, gaugeValue(t, "parapet_upstream_breaker_state", map[string]string{"host": host}),
+		"gauge reflects To=open (1)")
+}
+
+func TestUpstreamState_RecoverNoProbeDownSeries(t *testing.T) {
+	observe := UpstreamState()
+	const host = "prom-proberecover-test.backend"
+	transLbl := map[string]string{"host": host, "from": "open", "to": "closed", "reason": "probe_recover"}
+	baseTrans := counterValue(t, "parapet_upstream_state_transitions_total", transLbl)
+
+	observe(upstream.StateChange{
+		Host: host, From: upstream.StateOpen, To: upstream.StateClosed,
+		Reason: upstream.ReasonProbeRecover, // Cause defaults to CauseNone
+	})
+
+	assert.EqualValues(t, 1, countDelta(baseTrans, counterValue(t, "parapet_upstream_state_transitions_total", transLbl)))
+	assert.EqualValues(t, -1, counterValue(t, "parapet_upstream_probe_down_total", map[string]string{"host": host}),
+		"a recover (CauseNone) creates no probe_down series")
+	assert.EqualValues(t, 0, gaugeValue(t, "parapet_upstream_breaker_state", map[string]string{"host": host}),
+		"gauge reflects To=closed (0)")
+}
+
+func TestUpstreamState_EjectDoesNotTouchProbeDown(t *testing.T) {
+	observe := UpstreamState()
+	const host = "prom-eject-noprobe-test.backend"
+	transLbl := map[string]string{"host": host, "from": "closed", "to": "open", "reason": "eject"}
+	baseTrans := counterValue(t, "parapet_upstream_state_transitions_total", transLbl)
+
+	observe(upstream.StateChange{
+		Host: host, From: upstream.StateClosed, To: upstream.StateOpen, Reason: upstream.ReasonEject,
+	})
+
+	assert.EqualValues(t, 1, countDelta(baseTrans, counterValue(t, "parapet_upstream_state_transitions_total", transLbl)))
+	assert.EqualValues(t, -1, counterValue(t, "parapet_upstream_probe_down_total", map[string]string{"host": host}),
+		"a non-probe emitter never populates the probe_down counter")
+}
+
 // Make circuit-breaker / ejection state observable: count transitions and track
 // the current state per backend.
 func ExampleUpstreamState() {

--- a/pkg/upstream/example_test.go
+++ b/pkg/upstream/example_test.go
@@ -131,7 +131,7 @@ func ExampleNewLatencyEjectingLoadBalancer() {
 		{Host: "10.0.0.2:8080", Transport: tr},
 		{Host: "10.0.0.3:8080", Transport: tr},
 	})
-	lb.EjectionFactor = 3      // eject a target 3x slower than the pool median
+	lb.EjectionFactor = 3 // eject a target 3x slower than the pool median
 	lb.HalfLife = 10 * time.Second
 
 	s := parapet.New()
@@ -172,6 +172,12 @@ func ExampleNewActiveHealthCheck() {
 	ahc.Path = "/healthz"
 	ahc.Interval = 5 * time.Second
 	ahc.UnhealthyThld = 3 // down after 3 consecutive failed probes
+	// Observe gate flips (probe-down with a classified cause / probe-recover); wire to
+	// prom.UpstreamState in production for upstream_probe_down_total{host,cause}.
+	ahc.OnStateChange = func(c upstream.StateChange) {
+		_ = c.Reason // ReasonProbeDown or ReasonProbeRecover
+		_ = c.Cause  // classified failure cause on a down event, e.g. "timeout"
+	}
 
 	s := parapet.New()
 	s.Use(upstream.New(ahc)) // ahc is the proxy's transport, like any balancer

--- a/pkg/upstream/healthcheck.go
+++ b/pkg/upstream/healthcheck.go
@@ -2,10 +2,14 @@ package upstream
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/moonrhythm/parapet"
@@ -128,6 +132,19 @@ type ActiveHealthCheck struct {
 	// IsHealthy decides whether a probe result is healthy; nil treats a non-error
 	// response with status < 400 as healthy.
 	IsHealthy func(resp *http.Response, err error) bool
+
+	// OnStateChange observes this target's active-health gate flipping: ReasonProbeDown
+	// (UnhealthyThld consecutive failing probes took an up target down, From StateClosed
+	// To StateOpen, carrying a classified ProbeCause) and ReasonProbeRecover (HealthyThld
+	// consecutive successes readmitted a down one, From StateOpen To StateClosed,
+	// CauseNone). nil disables it at zero cost. It fires synchronously on the target's
+	// sole prober goroutine, exactly once per crossing, AFTER the gate bit is published;
+	// the callee owns its own concurrency across targets (see prom.UpstreamState). The
+	// initial gate (StartUnhealthy or not) is NOT a transition and fires nothing — with
+	// StartUnhealthy the first admitting probe is a genuine ReasonProbeRecover. A
+	// graceful shutdown / Close never emits a spurious ReasonProbeDown. The ProbeCause
+	// label is a bounded closed set.
+	OnStateChange StateChangeFunc
 }
 
 // probeTarget holds one target's probe state. up is the only cross-goroutine field
@@ -303,7 +320,11 @@ func (a *ActiveHealthCheck) probe(ctx context.Context, pt *probeTarget) {
 	// parsed from a URL string, and the dynamic Transport dispatches on the right scheme.
 	req, err := http.NewRequestWithContext(pctx, a.Method, "http://"+probePlaceholderHost+a.Path, http.NoBody)
 	if err != nil {
-		a.observe(pt, false)
+		// A malformed request config is a real failure, not a backend verdict — but
+		// check the parent ctx first so a Close racing here is still suppressed.
+		if ctx.Err() == nil {
+			a.observe(pt, false, CauseError)
+		}
 		return
 	}
 	req.URL.Scheme = a.Scheme
@@ -323,24 +344,49 @@ func (a *ActiveHealthCheck) probe(ctx context.Context, pt *probeTarget) {
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, probeDrainLimit))
 		_ = resp.Body.Close()
 	}
-	a.observe(pt, a.healthy(resp, rerr))
+
+	// Shutting down: the PARENT ctx (prober lifetime) was cancelled by Close /
+	// graceful shutdown, so the in-flight RoundTrip returns context.Canceled. That is
+	// not a backend verdict — drop it so Close never darkens the gate or fires a
+	// spurious ReasonProbeDown on the way out. A per-probe Timeout differs: only pctx
+	// expired, ctx.Err() is nil here, so it falls through as a real failure.
+	if ctx.Err() != nil {
+		return
+	}
+
+	ok := a.healthy(resp, rerr)
+	var cause ProbeCause
+	if !ok {
+		cause = classifyProbeCause(resp, rerr)
+	}
+	a.observe(pt, ok, cause)
 }
 
-// observe applies one probe verdict to pt's consecutive-run counters and flips the
-// published up bit on a threshold crossing. Runs only on pt's own goroutine.
-func (a *ActiveHealthCheck) observe(pt *probeTarget, ok bool) {
+// observe applies one probe verdict to pt's consecutive-run counters, flips the
+// published up bit on a threshold crossing, and (only then) fires OnStateChange for
+// that crossing. cause classifies a failing probe and is consulted only on the down
+// crossing (a recover carries CauseNone). Runs only on pt's own goroutine, so the run
+// counters stay single-writer and the hook fires on the goroutine that commits the
+// transition.
+func (a *ActiveHealthCheck) observe(pt *probeTarget, ok bool, cause ProbeCause) {
 	if ok {
 		pt.failRun = 0
 		pt.okRun++
 		if pt.okRun >= a.HealthyThld && !pt.up.Load() {
-			pt.up.Store(true)
+			pt.up.Store(true) // down -> up (covers the StartUnhealthy first-success recover)
+			if a.OnStateChange != nil {
+				a.OnStateChange(StateChange{Host: pt.target.Host, From: StateOpen, To: StateClosed, Reason: ReasonProbeRecover})
+			}
 		}
 		return
 	}
 	pt.okRun = 0
 	pt.failRun++
 	if pt.failRun >= a.UnhealthyThld && pt.up.Load() {
-		pt.up.Store(false)
+		pt.up.Store(false) // up -> down
+		if a.OnStateChange != nil {
+			a.OnStateChange(StateChange{Host: pt.target.Host, From: StateClosed, To: StateOpen, Reason: ReasonProbeDown, Cause: cause})
+		}
 	}
 }
 
@@ -349,4 +395,48 @@ func (a *ActiveHealthCheck) healthy(resp *http.Response, err error) bool {
 		return a.IsHealthy(resp, err)
 	}
 	return err == nil && resp != nil && resp.StatusCode < 400
+}
+
+// classifyProbeCause maps a failed probe result to a bounded ProbeCause for the
+// down-event label. Called only on the cold unhealthy path, after probe() has
+// filtered the shutdown-cancel, so context.Canceled is unreachable here. The ladder
+// is most-specific-first and traverses wrapping via errors.Is/errors.As; the
+// catch-all is CauseError so the label set stays closed.
+func classifyProbeCause(resp *http.Response, err error) ProbeCause {
+	if err == nil {
+		return CauseStatus // no transport error, but healthy() rejected the response (default: status >= 400, or a custom IsHealthy returned false)
+	}
+	// A *net.DNSError is a name-resolution failure by construction, so classify it as
+	// dns regardless of whether it timed out. This MUST precede the DeadlineExceeded
+	// rung: a resolver lookup timeout wraps context.DeadlineExceeded (Go 1.23+
+	// DNSError.Unwrap), so the deadline rung would otherwise swallow it and mislabel a
+	// DNS outage as a too-tight Timeout — the exact triage misdirection ProbeCause
+	// exists to prevent. A genuinely too-tight Timeout still surfaces as timeout on the
+	// non-DNS dial/response paths below.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return CauseDNS
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return CauseTimeout // the per-probe pctx deadline (non-DNS); parent-cancel was already filtered in probe()
+	}
+	var certErr *tls.CertificateVerificationError
+	var recErr tls.RecordHeaderError
+	if errors.As(err, &certErr) || errors.As(err, &recErr) {
+		return CauseTLS // cert distrust/expiry, or TLS spoken to a plaintext port (or vice-versa)
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return CauseRefused
+	}
+	if errors.Is(err, syscall.ECONNRESET) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return CauseReset // peer reset or closed the connection unexpectedly
+	}
+	// Defensive catch-all for a non-stdlib net.Error that reports Timeout() without
+	// wrapping context.DeadlineExceeded; stdlib transport timeouts already satisfy the
+	// DeadlineExceeded rung above.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return CauseTimeout
+	}
+	return CauseError
 }

--- a/pkg/upstream/healthcheck_statechange_test.go
+++ b/pkg/upstream/healthcheck_statechange_test.go
@@ -1,0 +1,200 @@
+package upstream
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// downPt builds a probeTarget whose gate bit starts up (the common case for a
+// down-crossing test) or down, for driving observe()/probe() directly.
+func hcPeer(host string, up bool) *probeTarget {
+	var b atomic.Bool
+	b.Store(up)
+	return &probeTarget{target: &Target{Host: host}, up: &b}
+}
+
+func TestActiveHealthCheck_OnStateChange_DownCrossing(t *testing.T) {
+	t.Parallel()
+	var rec stateRecorder
+	a := &ActiveHealthCheck{UnhealthyThld: 2, HealthyThld: 1, OnStateChange: rec.fn()}
+	pt := hcPeer("h", true)
+
+	a.observe(pt, false, CauseTimeout) // failRun 1 < 2: sub-threshold, no event
+	assert.Empty(t, rec.all(), "no event before UnhealthyThld is reached")
+	assert.True(t, pt.up.Load())
+
+	a.observe(pt, false, CauseTimeout) // failRun 2 == 2: crosses
+	require.Equal(t, 1, rec.count(ReasonProbeDown))
+	c := rec.all()[0]
+	assert.Equal(t, "h", c.Host)
+	assert.Equal(t, StateClosed, c.From)
+	assert.Equal(t, StateOpen, c.To)
+	assert.Equal(t, CauseTimeout, c.Cause, "the down event carries the classified cause")
+	assert.False(t, pt.up.Load())
+
+	a.observe(pt, false, CauseRefused) // already down: the && up.Load() guard blocks a duplicate
+	assert.Equal(t, 1, rec.count(ReasonProbeDown), "no duplicate down event while already down")
+}
+
+func TestActiveHealthCheck_OnStateChange_RecoverCrossing(t *testing.T) {
+	t.Parallel()
+	var rec stateRecorder
+	a := &ActiveHealthCheck{UnhealthyThld: 1, HealthyThld: 2, OnStateChange: rec.fn()}
+	pt := hcPeer("h", false)
+
+	a.observe(pt, true, CauseNone) // okRun 1 < 2: sub-threshold
+	assert.Empty(t, rec.all(), "no event before HealthyThld is reached")
+	assert.False(t, pt.up.Load())
+
+	a.observe(pt, true, CauseNone) // okRun 2 == 2: crosses
+	require.Equal(t, 1, rec.count(ReasonProbeRecover))
+	c := rec.all()[0]
+	assert.Equal(t, StateOpen, c.From)
+	assert.Equal(t, StateClosed, c.To)
+	assert.Equal(t, CauseNone, c.Cause, "a recover carries no cause")
+	assert.True(t, pt.up.Load())
+
+	a.observe(pt, true, CauseNone)
+	assert.Equal(t, 1, rec.count(ReasonProbeRecover), "no duplicate recover event while already up")
+}
+
+func TestActiveHealthCheck_OnStateChange_NilHookNoPanic(t *testing.T) {
+	t.Parallel()
+	a := &ActiveHealthCheck{UnhealthyThld: 1, HealthyThld: 1} // OnStateChange nil
+	pt := hcPeer("h", true)
+	assert.NotPanics(t, func() {
+		a.observe(pt, false, CauseError) // down crossing, nil hook
+		a.observe(pt, true, CauseNone)   // recover crossing, nil hook
+	})
+	assert.True(t, pt.up.Load(), "the gate still flips with a nil hook")
+}
+
+func TestActiveHealthCheck_OnStateChange_NoEventAtInit(t *testing.T) {
+	t.Parallel()
+	for _, startUnhealthy := range []bool{false, true} {
+		var rec stateRecorder
+		a := &ActiveHealthCheck{
+			Targets:        []*Target{{Host: "t", Transport: freshBody()}},
+			StartUnhealthy: startUnhealthy,
+			OnStateChange:  rec.fn(),
+		}
+		a.init() // builds the initial gate; an initial state is not a transition
+		assert.Empty(t, rec.all(), "init fires no event (StartUnhealthy=%v)", startUnhealthy)
+	}
+}
+
+func TestActiveHealthCheck_OnStateChange_StartUnhealthyFirstRecover(t *testing.T) {
+	t.Parallel()
+	var rec stateRecorder
+	a := &ActiveHealthCheck{HealthyThld: 1, UnhealthyThld: 3, OnStateChange: rec.fn()}
+	pt := hcPeer("t", false) // StartUnhealthy => begins down
+
+	a.observe(pt, true, CauseNone) // the first admitting probe
+	assert.Equal(t, 1, rec.count(ReasonProbeRecover), "cold-start admission emits exactly one recover")
+	assert.True(t, pt.up.Load())
+}
+
+func TestClassifyProbeCause(t *testing.T) {
+	t.Parallel()
+
+	// A real url.Error -> net.OpError -> os.SyscallError -> syscall.Errno chain, the
+	// shape an http.Transport actually returns, to prove errors.Is/As traverse it.
+	wrappedRefused := &url.Error{Op: "Get", URL: "http://x", Err: &net.OpError{
+		Op: "dial", Err: os.NewSyscallError("connect", syscall.ECONNREFUSED),
+	}}
+
+	cases := []struct {
+		name string
+		resp *http.Response
+		err  error
+		want ProbeCause
+	}{
+		{"no-error-unhealthy", &http.Response{StatusCode: 503}, nil, CauseStatus},
+		{"deadline", nil, context.DeadlineExceeded, CauseTimeout},
+		{"deadline-wrapped", nil, fmt.Errorf("probe: %w", context.DeadlineExceeded), CauseTimeout},
+		{"dns-nxdomain", nil, &net.DNSError{Err: "no such host"}, CauseDNS},
+		// The real shape a resolver returns on a lookup timeout: a *net.DNSError that
+		// WRAPS context.DeadlineExceeded (Go 1.23+ DNSError.Unwrap). It must classify as
+		// dns, not timeout — the DNSError branch precedes the deadline branch. (The old
+		// synthetic {IsTimeout:true} with a nil UnwrapErr did not wrap a deadline, so it
+		// never exercised this ordering and gave false confidence.)
+		{"dns-timeout-wraps-deadline", nil, &net.DNSError{Err: "timeout", IsTimeout: true, UnwrapErr: context.DeadlineExceeded}, CauseDNS},
+		{"refused", nil, syscall.ECONNREFUSED, CauseRefused},
+		{"refused-wrapped", nil, wrappedRefused, CauseRefused},
+		{"reset", nil, syscall.ECONNRESET, CauseReset},
+		{"eof", nil, io.EOF, CauseReset},
+		{"unexpected-eof", nil, io.ErrUnexpectedEOF, CauseReset},
+		{"tls-record", nil, tls.RecordHeaderError{Msg: "first record does not look like a TLS handshake"}, CauseTLS},
+		{"tls-cert", nil, &tls.CertificateVerificationError{}, CauseTLS},
+		{"net-timeout-no-deadline", nil, timeoutOnlyErr{}, CauseTimeout},
+		{"other", nil, errors.New("boom"), CauseError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, classifyProbeCause(tc.resp, tc.err))
+		})
+	}
+}
+
+// timeoutOnlyErr is a net.Error reporting a timeout WITHOUT wrapping
+// context.DeadlineExceeded — e.g. a transport dial i/o timeout.
+type timeoutOnlyErr struct{}
+
+func (timeoutOnlyErr) Error() string   { return "i/o timeout" }
+func (timeoutOnlyErr) Timeout() bool   { return true }
+func (timeoutOnlyErr) Temporary() bool { return false }
+
+func TestActiveHealthCheck_ProbeSuppressedOnParentCancel(t *testing.T) {
+	t.Parallel()
+	// A probe in flight when the prober's PARENT ctx is cancelled (Close / graceful
+	// shutdown) returns context.Canceled; that must NOT darken the gate or emit a
+	// spurious ReasonProbeDown. delay forces the probe to block until ctx is done.
+	var rec stateRecorder
+	a := &ActiveHealthCheck{
+		Path: "/hz", Method: "GET", Scheme: "http", Timeout: time.Second,
+		UnhealthyThld: 1, OnStateChange: rec.fn(),
+	}
+	pt := hcPeer("t", true)
+	pt.target.Transport = &healthFake{healthPath: "/hz", delay: time.Hour}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // shutting down before the probe runs
+
+	a.probe(ctx, pt) // synchronous: RoundTrip returns Canceled via the cancelled pctx
+
+	assert.Empty(t, rec.all(), "a shutdown-cancelled probe emits no event")
+	assert.True(t, pt.up.Load(), "a shutdown-cancelled probe does not darken the gate")
+}
+
+func TestActiveHealthCheck_ProbeTimeoutClassifiesTimeout(t *testing.T) {
+	t.Parallel()
+	// A genuine per-probe Timeout (parent ctx alive, only pctx expired) is a real
+	// failure classified as timeout — distinct from the shutdown-cancel above.
+	var rec stateRecorder
+	a := &ActiveHealthCheck{
+		Path: "/hz", Method: "GET", Scheme: "http", Timeout: 20 * time.Millisecond,
+		UnhealthyThld: 1, OnStateChange: rec.fn(),
+	}
+	pt := hcPeer("t", true)
+	pt.target.Transport = &healthFake{healthPath: "/hz", delay: 200 * time.Millisecond}
+
+	a.probe(context.Background(), pt) // parent alive; pctx deadline fires at 20ms
+
+	require.Equal(t, 1, rec.count(ReasonProbeDown))
+	assert.Equal(t, CauseTimeout, rec.all()[0].Cause, "a per-probe timeout classifies as timeout, not suppressed")
+	assert.False(t, pt.up.Load())
+}

--- a/pkg/upstream/healthcheck_test.go
+++ b/pkg/upstream/healthcheck_test.go
@@ -112,13 +112,13 @@ func TestActiveHealthCheck_FlapResetsOppositeCounter(t *testing.T) {
 	pt := &probeTarget{up: &up}
 
 	for _, ok := range []bool{true, false, true, false, true, false, true} {
-		a.observe(pt, ok) // strictly alternating: neither run ever reaches its threshold
+		a.observe(pt, ok, CauseNone) // strictly alternating: neither run ever reaches its threshold
 	}
 	assert.True(t, up.Load(), "an alternating ok/fail sequence never crosses a threshold")
 
-	a.observe(pt, false)
-	a.observe(pt, false)
-	a.observe(pt, false) // three consecutive failures now
+	a.observe(pt, false, CauseError)
+	a.observe(pt, false, CauseError)
+	a.observe(pt, false, CauseError) // three consecutive failures now
 	assert.False(t, up.Load(), "UnhealthyThld consecutive failures mark it down")
 }
 

--- a/pkg/upstream/state.go
+++ b/pkg/upstream/state.go
@@ -28,13 +28,15 @@ func (s State) String() string {
 type Reason uint8
 
 const (
-	ReasonTrip    Reason = iota // closed -> open: failure threshold crossed (circuit breaker)
-	ReasonReopen                // half_open -> open: a probe failed (circuit breaker)
-	ReasonHeal                  // half_open -> closed: success threshold met (circuit breaker)
-	ReasonProbe                 // open -> half_open: cooldown expired, probing (circuit breaker)
-	ReasonExpire                // half_open -> open: a probe overstayed ProbeTimeout (circuit breaker)
-	ReasonEject                 // -> open: an ejecting balancer took a target out of rotation
-	ReasonRecover               // open -> closed: an ejecting balancer returned a target to rotation
+	ReasonTrip         Reason = iota // closed -> open: failure threshold crossed (circuit breaker)
+	ReasonReopen                     // half_open -> open: a probe failed (circuit breaker)
+	ReasonHeal                       // half_open -> closed: success threshold met (circuit breaker)
+	ReasonProbe                      // open -> half_open: cooldown expired, probing (circuit breaker)
+	ReasonExpire                     // half_open -> open: a probe overstayed ProbeTimeout (circuit breaker)
+	ReasonEject                      // -> open: an ejecting balancer took a target out of rotation
+	ReasonRecover                    // open -> closed: an ejecting balancer returned a target to rotation
+	ReasonProbeDown                  // closed -> open: an active health probe failed UnhealthyThld times in a row
+	ReasonProbeRecover               // open -> closed: an active health probe succeeded HealthyThld times in a row
 )
 
 func (r Reason) String() string {
@@ -51,8 +53,54 @@ func (r Reason) String() string {
 		return "eject"
 	case ReasonRecover:
 		return "recover"
+	case ReasonProbeDown:
+		return "probe_down"
+	case ReasonProbeRecover:
+		return "probe_recover"
 	default:
 		return "trip"
+	}
+}
+
+// ProbeCause classifies WHY an ActiveHealthCheck probe failed. It is carried on a
+// ReasonProbeDown StateChange (StateChange.Cause) so an operator can tell a bad
+// probe path from a dead backend from a too-tight Timeout mid-incident. It is a
+// CLOSED set — a bounded Prometheus label, never unbounded. The zero value,
+// CauseNone, means "not a probe-down event": every non-ActiveHealthCheck emitter
+// (circuit breaker, ejecting, latency-ejecting) leaves it zero, and a probe
+// RECOVER carries CauseNone too. A transport error matching none of the specific
+// cases collapses into CauseError, so the label set can never grow.
+type ProbeCause uint8
+
+const (
+	CauseNone    ProbeCause = iota // not a probe-down event (the zero value)
+	CauseTimeout                   // per-probe Timeout deadline fired (context.DeadlineExceeded / net.Error.Timeout)
+	CauseRefused                   // connection refused (syscall.ECONNREFUSED): nothing listening
+	CauseReset                     // connection reset / closed mid-probe (syscall.ECONNRESET, io.EOF, io.ErrUnexpectedEOF)
+	CauseDNS                       // name resolution failed (*net.DNSError)
+	CauseTLS                       // TLS handshake / certificate failure (tls.RecordHeaderError, *tls.CertificateVerificationError)
+	CauseStatus                    // a response arrived but healthy() rejected it (e.g. status >= 400)
+	CauseError                     // any other transport error (catch-all, keeps the set closed)
+)
+
+func (c ProbeCause) String() string {
+	switch c {
+	case CauseTimeout:
+		return "timeout"
+	case CauseRefused:
+		return "refused"
+	case CauseReset:
+		return "reset"
+	case CauseDNS:
+		return "dns"
+	case CauseTLS:
+		return "tls"
+	case CauseStatus:
+		return "status"
+	case CauseError:
+		return "error"
+	default:
+		return "none"
 	}
 }
 
@@ -62,6 +110,10 @@ type StateChange struct {
 	From   State
 	To     State
 	Reason Reason
+	// Cause classifies a probe failure on the ActiveHealthCheck down crossing
+	// (Reason == ReasonProbeDown). It is CauseNone (the zero value) on every other
+	// event, including a probe recover and all circuit-breaker / ejecting transitions.
+	Cause ProbeCause
 }
 
 // StateChangeFunc observes a per-target reliability state transition. Assign one to

--- a/pkg/upstream/state_test.go
+++ b/pkg/upstream/state_test.go
@@ -21,16 +21,35 @@ func TestStateString(t *testing.T) {
 func TestReasonString(t *testing.T) {
 	t.Parallel()
 	for r, s := range map[Reason]string{
-		ReasonTrip:    "trip",
-		ReasonReopen:  "reopen",
-		ReasonHeal:    "heal",
-		ReasonProbe:   "probe",
-		ReasonExpire:  "expire",
-		ReasonEject:   "eject",
-		ReasonRecover: "recover",
+		ReasonTrip:         "trip",
+		ReasonReopen:       "reopen",
+		ReasonHeal:         "heal",
+		ReasonProbe:        "probe",
+		ReasonExpire:       "expire",
+		ReasonEject:        "eject",
+		ReasonRecover:      "recover",
+		ReasonProbeDown:    "probe_down",
+		ReasonProbeRecover: "probe_recover",
 	} {
 		assert.Equal(t, s, r.String())
 	}
+}
+
+func TestProbeCauseString(t *testing.T) {
+	t.Parallel()
+	for c, s := range map[ProbeCause]string{
+		CauseNone:    "none",
+		CauseTimeout: "timeout",
+		CauseRefused: "refused",
+		CauseReset:   "reset",
+		CauseDNS:     "dns",
+		CauseTLS:     "tls",
+		CauseStatus:  "status",
+		CauseError:   "error",
+	} {
+		assert.Equal(t, s, c.String())
+	}
+	assert.Equal(t, "none", ProbeCause(200).String(), "an out-of-range value collapses to none, never an unbounded label")
 }
 
 // stateRecorder captures StateChange events for assertions.


### PR DESCRIPTION
## Why (backlog item #2 — tag blocker)

`ActiveHealthCheck` gates **all six balancers**, but unlike `EjectingLoadBalancer` (`ejecting.go:72`) and `CircuitBreakingLoadBalancer` (`circuitbreaker.go:132`) it emitted **no state-change signal**. A misconfigured probe path (wrong scheme, wrong `Path`, too-tight `Timeout`) could silently darken a healthy pool with nothing in metrics to explain it. Mid-incident the operator's question is *bad probe path vs dead backend vs too-tight Timeout* — so the down event also carries a **classified cause**.

## What

**`state.go`** — appended `ReasonProbeDown` / `ReasonProbeRecover` (existing `Reason` iota values and `String()` outputs unchanged → label-stable), a bounded `ProbeCause` enum `{none,timeout,refused,reset,dns,tls,status,error}` with `String()`, and a trailing `StateChange.Cause` field (zero value `CauseNone` for every non-probe emitter and for a recover; the struct stays 24 bytes / field-aligned).

**`healthcheck.go`** — `OnStateChange StateChangeFunc` fires after the gate bit is published, only on the real bit flip, on the target's sole prober goroutine (matches the `StateChangeFunc` contract). Two subtleties handled:
- **Shutdown suppression:** when the parent ctx is cancelled by `Close`/graceful shutdown the in-flight probe returns `context.Canceled`; `probe()` drops it (no spurious `ReasonProbeDown`, no gate darkening) — while a genuine per-probe `Timeout` has the parent alive and still classifies as `timeout`. This also fixes a latent gate bug (no spurious down on the way out).
- **DNS-before-deadline ordering:** a resolver lookup timeout is a `*net.DNSError` that **wraps `context.DeadlineExceeded`** (Go 1.23+ `DNSError.Unwrap`). The `*net.DNSError` rung is checked *before* the deadline rung so a DNS outage classifies as `dns`, not `timeout` — the exact triage misdirection the feature exists to prevent. (Caught by scrutiny: the original test used a synthetic `*net.DNSError` that didn't wrap a deadline and gave false confidence; now a real-shape regression case guards it.)

**`prom`** — a focused `parapet_upstream_probe_down_total{host,cause}` counter, incremented only when `Cause != CauseNone`. The authoritative `upstream_state_transitions_total` / gauge schema is **byte-for-byte unchanged** — the new reasons flow into it as `reason="probe_down"/"probe_recover"` for free, so existing dashboards are untouched and the bounded `{host,cause}` cardinality is quarantined to its own series.

Zero new `go.mod` dependencies (stdlib `errors`/`net`/`crypto/tls`/`syscall` classification).

## Validation

- Full `make` green (vet + lint + `-race`)
- New upstream tests 10× `-race`; new prom tests count-safe (baseline-then-delta) and 8× `-race`
- Sensitivity-checked by mutation: neutering the shutdown-cancel guard fails the suppression test; reverting the DNS-before-deadline order fails the real-shape DNS-timeout case
- Design + 3-lens adversarial scrutiny ran as multi-agent passes; the one confirmed major (DNS misclassification) is fixed in this commit, plus two comment-accuracy nits

🤖 Generated with [Claude Code](https://claude.com/claude-code)