### PR TITLE
fix(logger): honor Logger.OmitEmpty (was a dead field)

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -15,7 +15,13 @@ import (
 
 // Logger middleware
 type Logger struct {
-	Writer    io.Writer
+	Writer io.Writer
+
+	// OmitEmpty, when true, drops fields with empty/zero values (e.g. empty
+	// referer, realIp, forwardedFor) from the emitted log record. The Stdout
+	// and Stderr constructors default this to true; a bare Logger{} (or
+	// &Logger{Writer: x}) defaults it to false, so a zero-value logger emits
+	// empty fields rather than dropping them.
 	OmitEmpty bool
 }
 
@@ -87,7 +93,9 @@ func (m Logger) ServeHandler(h http.Handler) http.Handler {
 				d.Set("durationHeaderHuman", durationHeader.String())
 			}
 
-			d.omitEmpty()
+			if m.OmitEmpty {
+				d.omitEmpty()
+			}
 			json.NewEncoder(m.Writer).Encode(d.data)
 		}()
 		h.ServeHTTP(&nw, r.WithContext(ctx))

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -104,6 +104,27 @@ func TestLoggerOmitEmpty(t *testing.T) {
 	assert.False(t, hasRealIP)
 }
 
+func TestLoggerEmitsEmptyWhenNotOmitEmpty(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	m := &Logger{Writer: buf} // OmitEmpty defaults to false
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "127.0.0.1:1"
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	d := decodeLog(t, buf.Bytes())
+	_, hasReferer := d["referer"]
+	_, hasFF := d["forwardedFor"]
+	assert.True(t, hasReferer, "empty referer should be emitted when OmitEmpty is false")
+	assert.True(t, hasFF, "empty forwardedFor should be emitted when OmitEmpty is false")
+}
+
 func TestDisableSkipsRecord(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

`pkg/logger/logger.go` exported a `Logger.OmitEmpty bool` field, but the deferred log-emit called `d.omitEmpty()` **unconditionally**, so empty/zero-valued fields (e.g. `referer`, `realIp`, `forwardedFor` on a bare request) were always dropped regardless of the field's value. The field was dead and lied about its effect.

## The fix

One-line gate around the existing call:

```go
if m.OmitEmpty {
    d.omitEmpty()
}
```

Plus a godoc comment on the `OmitEmpty` field documenting the contract.

## Behavior

- `Stdout()` and `Stderr()` are **unchanged** — both already set `OmitEmpty: true`, so they still drop empty fields.
- **Behavior change:** a zero-value `Logger{}` (or `&Logger{Writer: x}`) defaults `OmitEmpty` to `false` and now **emits** empty fields instead of silently dropping them. This is the documented contract, finally honored.

`record.go`'s `omitEmpty()`/`isEmpty()` are untouched.

## Tests

- Added `TestLoggerEmitsEmptyWhenNotOmitEmpty`: drives a bare request through `&Logger{Writer: buf}` (OmitEmpty false) and asserts empty-valued keys (`referer`, `forwardedFor`) are present in the decoded JSON.
- Existing `TestLoggerOmitEmpty` (OmitEmpty true still drops empties) and `TestStdoutStderrConstructors` still pass.

## Validation

- `make` fully green (`go vet`, `golangci-lint` 0 issues with `fieldalignment` enabled, `go test -race ./...` all packages pass).
- Sensitivity-checked: temporarily reverting the gate to the unconditional `d.omitEmpty()` makes the new test **fail**; restoring the gate makes it pass again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)