### PR TITLE
feat(waf): per-request eval-latency observability (Observe hook + prom.WAF)

### DIFF
--- a/pkg/prom/waf.go
+++ b/pkg/prom/waf.go
@@ -1,0 +1,89 @@
+package prom
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/moonrhythm/parapet/pkg/waf"
+)
+
+//nolint:govet
+type wafMetrics struct {
+	once sync.Once
+	eval *prometheus.HistogramVec
+}
+
+var _waf wafMetrics
+
+// wafEvalBuckets are tuned for WAF rule-evaluation latency, which runs from
+// sub-microsecond (a single cheap string compare) up to WAF.EvalTimeout
+// (default 5ms). prometheus.DefBuckets is useless here: its smallest boundary is
+// 5ms, so against the default timeout nearly every eval lands in the first
+// (le="0.005") bucket and the histogram has zero resolution. These boundaries
+// are dense below 1ms (where the bulk of evals sit, so a p99 regression from a
+// newly-added expensive rule actually shows), place an edge ON the 5ms default
+// timeout (the dashboard SLO line — samples above it are brushing the deadline,
+// which under FailClosed turn into 500s), and keep 10ms/25ms headroom so raised
+// timeouts or FailOpen-swallowed slow rules don't collapse the whole tail into
+// +Inf and hide the "is the WAF adding tail latency" signal.
+var wafEvalBuckets = []float64{
+	0.000025, // 25us
+	0.00005,  // 50us
+	0.0001,   // 100us
+	0.00025,  // 250us
+	0.0005,   // 500us
+	0.001,    // 1ms
+	0.0025,   // 2.5ms
+	0.005,    // 5ms  — default EvalTimeout (SLO line)
+	0.01,     // 10ms — past-timeout tail
+	0.025,    // 25ms — raised-timeout / FailOpen slow-rule headroom
+}
+
+func (p *wafMetrics) init() {
+	p.once.Do(func() {
+		p.eval = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Name:      "waf_eval_duration_seconds",
+			Buckets:   wafEvalBuckets,
+		}, []string{"outcome"})
+		reg.MustRegister(p.eval)
+	})
+}
+
+func (p *wafMetrics) observe(ev waf.EvalEvent) {
+	if h, err := p.eval.GetMetricWith(prometheus.Labels{
+		"outcome": ev.Outcome.String(),
+	}); err == nil {
+		h.Observe(ev.Duration.Seconds())
+	}
+}
+
+// WAF returns a waf.ObserveFunc that records per-request WAF rule-evaluation
+// latency on the shared registry, for wiring into WAF.Observe — keeping pkg/waf
+// Prometheus-free (the prom.Mirror / prom.Cache convention):
+//
+//	w := waf.New()
+//	w.Observe = prom.WAF()
+//
+// It registers one metric (lazily, once per process):
+//
+//	{namespace}_waf_eval_duration_seconds{outcome}   histogram of rule-eval latency
+//	    (outcome = pass|allow|block|error — pass is the no-match fall-through
+//	     plus log-only matches plus FailOpen-swallowed errors; error is only a
+//	     FailClosed terminating error). The span is rule evaluation ONLY: it
+//	     excludes client body buffering and geo/ASN/request-map construction,
+//	     matching waf.MatchEvent.Elapsed; the no-rules fast path is not recorded.
+//	     Each outcome's _count child doubles as a per-outcome request rate, so no
+//	     separate counter is registered.
+//
+// Buckets are sub-ms..25ms, sized to the default 5ms EvalTimeout (DefBuckets
+// would collapse the whole distribution into one bucket). A per-outcome
+// tail-latency panel is:
+//
+//	histogram_quantile(0.99, sum by (le, outcome)
+//	  (rate(parapet_waf_eval_duration_seconds_bucket[5m])))
+func WAF() waf.ObserveFunc {
+	_waf.init()
+	return _waf.observe
+}

--- a/pkg/prom/waf_test.go
+++ b/pkg/prom/waf_test.go
@@ -1,0 +1,92 @@
+package prom_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/waf"
+
+	. "github.com/moonrhythm/parapet/pkg/prom"
+)
+
+// bucketCount returns the cumulative count of the histogram series matching want
+// at the bucket whose upper bound == le, or 0 if absent. Like the other prom
+// helpers it reads the process-global registry, so callers baseline-then-delta.
+func bucketCount(t *testing.T, name string, want map[string]string, le float64) uint64 {
+	t.Helper()
+	mfs, err := Registry().Gather()
+	require.NoError(t, err)
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, p := range m.GetLabel() {
+				got[p.GetName()] = p.GetValue()
+			}
+			if !subset(want, got) {
+				continue
+			}
+			for _, b := range m.GetHistogram().GetBucket() {
+				if b.GetUpperBound() == le {
+					return b.GetCumulativeCount()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+func TestWAF(t *testing.T) {
+	observe := WAF()
+	require.NotNil(t, observe)
+
+	const name = "parapet_waf_eval_duration_seconds"
+	outcomes := map[waf.Outcome]string{
+		waf.OutcomePass:  "pass",
+		waf.OutcomeAllow: "allow",
+		waf.OutcomeBlock: "block",
+		waf.OutcomeError: "error",
+	}
+	for o, label := range outcomes {
+		base := histogramCount(t, name, map[string]string{"outcome": label})
+		observe(waf.EvalEvent{Outcome: o, Duration: time.Millisecond})
+		got := histogramCount(t, name, map[string]string{"outcome": label})
+		assert.Equal(t, base+1, got, "outcome %q records into its own series exactly once", label)
+	}
+}
+
+func TestWAF_BucketResolution(t *testing.T) {
+	observe := WAF()
+	lbl := map[string]string{"outcome": "pass"}
+
+	// Fine sub-ms buckets discriminate a 30us eval from a 6ms eval — resolution
+	// DefBuckets (smallest boundary 5ms) cannot provide. This guards against a
+	// regression that swaps wafEvalBuckets back to DefBuckets.
+	base500us := bucketCount(t, "parapet_waf_eval_duration_seconds", lbl, 0.0005)
+	base5ms := bucketCount(t, "parapet_waf_eval_duration_seconds", lbl, 0.005)
+	base10ms := bucketCount(t, "parapet_waf_eval_duration_seconds", lbl, 0.01)
+
+	observe(waf.EvalEvent{Outcome: waf.OutcomePass, Duration: 30 * time.Microsecond})
+	observe(waf.EvalEvent{Outcome: waf.OutcomePass, Duration: 6 * time.Millisecond})
+
+	assert.Equal(t, base500us+1, bucketCount(t, "parapet_waf_eval_duration_seconds", lbl, 0.0005),
+		"only the 30us sample is <= 500us")
+	assert.Equal(t, base5ms+1, bucketCount(t, "parapet_waf_eval_duration_seconds", lbl, 0.005),
+		"the 6ms sample is above the 5ms SLO-line bucket")
+	assert.Equal(t, base10ms+2, bucketCount(t, "parapet_waf_eval_duration_seconds", lbl, 0.01),
+		"both samples are <= 10ms")
+}
+
+// WAF observability: a per-request rule-eval latency histogram, split by outcome
+// (pass|allow|block|error), so a dashboard can show whether the WAF is adding
+// tail latency and on which path.
+func ExampleWAF() {
+	w := waf.New()
+	w.Observe = WAF() // prom.WAF(): records parapet_waf_eval_duration_seconds{outcome}
+	_ = w             // s.Use(w)
+}

--- a/pkg/waf/example_test.go
+++ b/pkg/waf/example_test.go
@@ -114,3 +114,23 @@ func ExampleWAF_geo() {
 	s := parapet.NewFrontend()
 	s.Use(w)
 }
+
+// Observe fires once per evaluated request regardless of outcome, so it can
+// answer "how much is the WAF costing me" on the common no-match path that
+// OnMatch never sees. Wire prom.WAF() for a histogram, or a custom hook.
+func ExampleWAF_observe() {
+	w := waf.New()
+	_ = w.SetRules([]waf.Rule{{
+		ID:         "block-sqli",
+		Expression: `request.query.contains("' OR '1'='1")`,
+		Action:     waf.ActionBlock,
+	}})
+
+	w.Observe = func(ev waf.EvalEvent) {
+		// Fires on pass/allow/block/error alike; ev.Duration is rule-eval time.
+		log.Printf("waf eval outcome=%s took=%s", ev.Outcome, ev.Duration)
+	}
+
+	s := parapet.NewFrontend()
+	s.Use(w)
+}

--- a/pkg/waf/observe.go
+++ b/pkg/waf/observe.go
@@ -1,0 +1,78 @@
+package waf
+
+import (
+	"net/http"
+	"time"
+)
+
+// Outcome classifies the terminal disposition of one WAF evaluation, reported
+// once per request via WAF.Observe regardless of whether any rule matched. It is
+// a small, bounded set so it is safe as a Prometheus label; it is NEVER the rule
+// ID (which is unbounded and lives on MatchEvent.RuleID instead).
+type Outcome uint8
+
+const (
+	// OutcomePass: evaluation finished without a terminating match and the
+	// request was forwarded to the next handler. This is the common case and
+	// also subsumes ActionLog-only matches (which never terminate) and any
+	// FailOpen-swallowed rule errors along the way (which also do not
+	// terminate). It is the silent-majority path OnMatch cannot see.
+	OutcomePass Outcome = iota
+	// OutcomeAllow: an ActionAllow rule fired; evaluation short-circuited and
+	// the request was forwarded without running the remaining rules.
+	OutcomeAllow
+	// OutcomeBlock: an ActionBlock rule fired; the request was rejected with
+	// the rule's status.
+	OutcomeBlock
+	// OutcomeError: a rule errored (panic recovered, timeout, cost exceeded,
+	// type mismatch) under FailMode=FailClosed, terminating the request with
+	// 500. Under the default FailOpen a rule error is swallowed and the request
+	// continues, so it is NOT OutcomeError — it folds into the eventual
+	// Pass/Allow/Block outcome. An EvalTimeout firing is just such an eval
+	// error, so "timeout" is not a distinct outcome.
+	OutcomeError
+)
+
+// String implements fmt.Stringer; the returned values are exactly the
+// Prometheus label values used by prom.WAF.
+func (o Outcome) String() string {
+	switch o {
+	case OutcomePass:
+		return "pass"
+	case OutcomeAllow:
+		return "allow"
+	case OutcomeBlock:
+		return "block"
+	case OutcomeError:
+		return "error"
+	default:
+		return "unknown"
+	}
+}
+
+// EvalEvent is delivered to WAF.Observe (if set) exactly ONCE per request that
+// reaches rule evaluation, after evaluation terminates, regardless of outcome.
+// Unlike MatchEvent (which fires per matched rule and only on a match), it makes
+// the WAF's per-request overhead visible on EVERY path — including the common
+// no-match fall-through and the allow/error short-circuits.
+//
+//nolint:govet // fields ordered for readability, not alignment
+type EvalEvent struct {
+	// Request is the request that was evaluated. The hook may read it (e.g. to
+	// derive a custom label) but must not mutate it; prom.WAF ignores it.
+	Request *http.Request
+	// Outcome is how evaluation terminated. Bounded; safe as a metric label.
+	Outcome Outcome
+	// Duration is the wall time spent evaluating rules — the SAME span as
+	// MatchEvent.Elapsed. It is time.Since(start) where start is taken AFTER
+	// body buffering, Country/ASN lookup and request-map construction, measured
+	// at the terminating decision point BEFORE the request is handed to the next
+	// handler. It therefore EXCLUDES client body I/O, geo/ASN/map-build cost, and
+	// downstream-handler latency, and measures rule evaluation only.
+	Duration time.Duration
+}
+
+// ObserveFunc is the per-request evaluation-observation hook shape, returned by
+// prom.WAF for wiring into WAF.Observe (the prom.Mirror / prom.Cache
+// convention), keeping pkg/waf free of any Prometheus dependency.
+type ObserveFunc func(EvalEvent)

--- a/pkg/waf/observe_test.go
+++ b/pkg/waf/observe_test.go
@@ -1,0 +1,190 @@
+package waf_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/waf"
+)
+
+// recordObserve installs a capturing Observe hook and returns the slice it fills.
+func recordObserve(w *waf.WAF) *[]waf.EvalEvent {
+	var events []waf.EvalEvent
+	w.Observe = func(e waf.EvalEvent) { events = append(events, e) }
+	return &events
+}
+
+func driveWAF(w *waf.WAF, method, target string) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(method, target, nil)
+	w.ServeHandler(passthroughHandler).ServeHTTP(rr, req)
+	return rr
+}
+
+func TestObserve_Pass_NoMatch(t *testing.T) {
+	t.Parallel()
+	// The silent-majority path OnMatch cannot see: a rule that doesn't match,
+	// request falls through to downstream.
+	w := newWAF(t, []waf.Rule{{ID: "r", Expression: `request.method == "POST"`, Action: waf.ActionBlock}})
+	ev := recordObserve(w)
+	rr := driveWAF(w, http.MethodGet, "/")
+
+	require.Len(t, *ev, 1, "exactly one Observe per request, even with no match")
+	assert.Equal(t, waf.OutcomePass, (*ev)[0].Outcome)
+	assert.GreaterOrEqual(t, (*ev)[0].Duration, time.Duration(0))
+	assert.NotNil(t, (*ev)[0].Request)
+	assert.Equal(t, "downstream-ok", rr.Body.String())
+}
+
+func TestObserve_Block(t *testing.T) {
+	t.Parallel()
+	w := newWAF(t, []waf.Rule{{ID: "r", Expression: `request.path.startsWith("/admin")`, Action: waf.ActionBlock, Status: http.StatusForbidden}})
+	ev := recordObserve(w)
+	var matches int
+	w.OnMatch = func(waf.MatchEvent) { matches++ }
+	rr := driveWAF(w, http.MethodGet, "/admin/x")
+
+	require.Len(t, *ev, 1)
+	assert.Equal(t, waf.OutcomeBlock, (*ev)[0].Outcome)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Equal(t, 1, matches, "OnMatch and Observe are independent hooks, each fires once")
+}
+
+func TestObserve_Allow(t *testing.T) {
+	t.Parallel()
+	// An allow rule (lower Priority => runs first) short-circuits ahead of a
+	// matching block rule, which must NOT be recorded.
+	w := newWAF(t, []waf.Rule{
+		{ID: "allow", Expression: `true`, Action: waf.ActionAllow, Priority: 0},
+		{ID: "block", Expression: `true`, Action: waf.ActionBlock, Priority: 10},
+	})
+	ev := recordObserve(w)
+	rr := driveWAF(w, http.MethodGet, "/")
+
+	require.Len(t, *ev, 1, "allow short-circuits; only one event, not one per rule")
+	assert.Equal(t, waf.OutcomeAllow, (*ev)[0].Outcome)
+	assert.Equal(t, "downstream-ok", rr.Body.String())
+}
+
+func TestObserve_LogThenPass(t *testing.T) {
+	t.Parallel()
+	// A log-only match does not terminate; it must fold into a SINGLE pass event.
+	w := newWAF(t, []waf.Rule{{ID: "log", Expression: `true`, Action: waf.ActionLog}})
+	ev := recordObserve(w)
+	var matches int
+	w.OnMatch = func(waf.MatchEvent) { matches++ }
+	rr := driveWAF(w, http.MethodGet, "/")
+
+	require.Len(t, *ev, 1, "a non-terminating log match emits no extra Observe event")
+	assert.Equal(t, waf.OutcomePass, (*ev)[0].Outcome)
+	assert.Equal(t, 1, matches)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestObserve_FiresOnce_MultiMatch(t *testing.T) {
+	t.Parallel()
+	// Two log matches then a block match: OnMatch fires 3x but Observe once.
+	w := newWAF(t, []waf.Rule{
+		{ID: "log1", Expression: `true`, Action: waf.ActionLog, Priority: 0},
+		{ID: "log2", Expression: `true`, Action: waf.ActionLog, Priority: 1},
+		{ID: "block", Expression: `true`, Action: waf.ActionBlock, Priority: 2},
+	})
+	ev := recordObserve(w)
+	var matches int
+	w.OnMatch = func(waf.MatchEvent) { matches++ }
+	driveWAF(w, http.MethodGet, "/")
+
+	assert.Equal(t, 3, matches, "OnMatch fires per matched rule")
+	require.Len(t, *ev, 1, "Observe fires exactly once regardless of match count")
+	assert.Equal(t, waf.OutcomeBlock, (*ev)[0].Outcome)
+}
+
+func TestObserve_ErrorFailClosed(t *testing.T) {
+	t.Parallel()
+	// CostLimit=1 + a request.*-touching rule forces a runtime eval error; under
+	// FailClosed it is the only path to OutcomeError (a 500).
+	w := waf.New()
+	w.CostLimit = 1
+	w.FailMode = waf.FailClosed
+	require.NoError(t, w.SetRules([]waf.Rule{{ID: "expensive", Expression: `request.path == request.method`, Action: waf.ActionBlock}}))
+	ev := recordObserve(w)
+	rr := driveWAF(w, http.MethodGet, "/some/path")
+
+	require.Len(t, *ev, 1)
+	assert.Equal(t, waf.OutcomeError, (*ev)[0].Outcome)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestObserve_ErrorFailOpen(t *testing.T) {
+	t.Parallel()
+	// The SAME error under the default FailOpen is swallowed and must NOT become
+	// OutcomeError — it folds into pass.
+	w := waf.New()
+	w.CostLimit = 1 // FailMode defaults to FailOpen
+	require.NoError(t, w.SetRules([]waf.Rule{{ID: "expensive", Expression: `request.path == request.method`, Action: waf.ActionBlock}}))
+	ev := recordObserve(w)
+	rr := driveWAF(w, http.MethodGet, "/some/path")
+
+	require.Len(t, *ev, 1)
+	assert.Equal(t, waf.OutcomePass, (*ev)[0].Outcome, "a FailOpen-swallowed error is not OutcomeError")
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestObserve_NoRulesFastPath(t *testing.T) {
+	t.Parallel()
+	// No rules loaded: the WAF does no evaluation, so Observe must not fire.
+	w := waf.New()
+	ev := recordObserve(w)
+	rr := driveWAF(w, http.MethodGet, "/")
+
+	assert.Empty(t, *ev, "the no-rules fast path performs no evaluation and emits no event")
+	assert.Equal(t, "downstream-ok", rr.Body.String())
+}
+
+func TestObserve_NilHook(t *testing.T) {
+	t.Parallel()
+	// A nil Observe is a no-op, not a panic.
+	w := newWAF(t, []waf.Rule{{ID: "r", Expression: `true`, Action: waf.ActionBlock, Status: http.StatusForbidden}})
+	// w.Observe left nil
+	assert.NotPanics(t, func() {
+		rr := driveWAF(w, http.MethodGet, "/")
+		assert.Equal(t, http.StatusForbidden, rr.Code)
+	})
+}
+
+func TestObserve_DurationExcludesDownstream(t *testing.T) {
+	t.Parallel()
+	// Duration is measured at the decision point, BEFORE h.ServeHTTP, so a slow
+	// downstream handler must not leak into the WAF eval duration.
+	w := newWAF(t, []waf.Rule{{ID: "r", Expression: `request.method == "POST"`, Action: waf.ActionBlock}})
+	ev := recordObserve(w)
+	slow := http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		time.Sleep(30 * time.Millisecond)
+		rw.WriteHeader(http.StatusOK)
+	})
+	rr := httptest.NewRecorder()
+	w.ServeHandler(slow).ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	require.Len(t, *ev, 1)
+	assert.Equal(t, waf.OutcomePass, (*ev)[0].Outcome)
+	assert.Less(t, (*ev)[0].Duration, 30*time.Millisecond,
+		"eval Duration excludes downstream latency (the 30ms sleep dwarfs eval, so any leak is caught)")
+}
+
+func TestOutcomeString(t *testing.T) {
+	t.Parallel()
+	for o, s := range map[waf.Outcome]string{
+		waf.OutcomePass:  "pass",
+		waf.OutcomeAllow: "allow",
+		waf.OutcomeBlock: "block",
+		waf.OutcomeError: "error",
+	} {
+		assert.Equal(t, s, o.String())
+	}
+	assert.Equal(t, "unknown", waf.Outcome(200).String(), "an out-of-range value never produces an unbounded label")
+}

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -70,6 +70,16 @@ type WAF struct {
 	// Runs synchronously on the request goroutine — keep it cheap.
 	OnMatch func(MatchEvent)
 
+	// Observe is invoked exactly once per request that reaches rule evaluation,
+	// after evaluation terminates, with the terminal Outcome and the rule-eval
+	// Duration. Optional. Runs synchronously on the request goroutine just
+	// before the request is forwarded or rejected — keep it cheap. Unlike
+	// OnMatch (per matched rule, only on a match), it fires on every path, so it
+	// answers "how much does the WAF cost per request". Wire prom.WAF() here for
+	// a latency histogram. The no-rules fast path does NOT call Observe (no
+	// evaluation happened).
+	Observe func(EvalEvent)
+
 	// EvalTimeout is the per-request deadline for evaluating the entire
 	// ruleset. Defaults to 5ms. A timeout treats the request as Allow
 	// (i.e. fails open) but logs the error — this is the safer default for
@@ -295,6 +305,11 @@ func (w *WAF) ServeHandler(h http.Handler) http.Handler {
 			}
 			return ipOnce
 		}
+		observe := func(o Outcome) {
+			if w.Observe != nil {
+				w.Observe(EvalEvent{Request: r, Outcome: o, Duration: time.Since(start)})
+			}
+		}
 		for _, rule := range rs.rules {
 			matched, err := evalRule(ctx, rule, input)
 			if err != nil {
@@ -302,6 +317,7 @@ func (w *WAF) ServeHandler(h http.Handler) http.Handler {
 					w.Logger.Logf("waf: rule %q eval error: %v", rule.id, err)
 				}
 				if w.FailMode == FailClosed {
+					observe(OutcomeError)
 					http.Error(rw, "WAF Error", http.StatusInternalServerError)
 					return
 				}
@@ -329,9 +345,11 @@ func (w *WAF) ServeHandler(h http.Handler) http.Handler {
 
 			switch rule.action {
 			case ActionAllow:
+				observe(OutcomeAllow)
 				h.ServeHTTP(rw, r)
 				return
 			case ActionBlock:
+				observe(OutcomeBlock)
 				http.Error(rw, rule.message, rule.status)
 				return
 			case ActionLog:
@@ -339,6 +357,7 @@ func (w *WAF) ServeHandler(h http.Handler) http.Handler {
 			}
 		}
 
+		observe(OutcomePass)
 		h.ServeHTTP(rw, r)
 	})
 }


### PR DESCRIPTION
## Why (backlog item #11)

The WAF times rule evaluation but surfaced it only via `OnMatch` → `MatchEvent.Elapsed`, which fires **only on a rule match** and stops at the matching rule. So the per-request overhead on the common no-match fall-through and on the allow/error short-circuits — literally "how much does the WAF cost per request" — was invisible.

## What

**`WAF.Observe func(EvalEvent)`** (new `pkg/waf/observe.go`) fires **exactly once** per request that reaches rule evaluation, after evaluation terminates, regardless of outcome. It carries a bounded `Outcome {pass, allow, block, error}` and the rule-eval `Duration`. The four post-`start` `ServeHandler` exits map cleanly:

| exit | outcome |
|---|---|
| FailClosed eval error → 500 | `error` |
| `ActionAllow` short-circuit | `allow` |
| `ActionBlock` | `block` |
| fall-through (no terminating match) — incl. log-only matches **and** FailOpen-swallowed errors | `pass` |

The no-rules fast path performs no evaluation and does **not** fire. The closure measures `time.Since(start)` at each decision point **before** handing off downstream, so downstream latency, client body buffering, and geo/ASN/map-build are all excluded — the span is rule evaluation only, the same as `MatchEvent.Elapsed` (hence the metric is named `_eval_`, to be honest about the span).

**`prom.WAF()`** → `parapet_waf_eval_duration_seconds{outcome}`, a `HistogramVec` with **fine sub-ms..25ms buckets**. `prometheus.DefBuckets` (5ms floor) would collapse every eval into one bucket against the 5ms default `EvalTimeout`; the custom buckets are dense below 1ms, place an edge on the 5ms SLO line, and keep 10/25ms tail headroom. Each outcome's `_count` child doubles as a per-outcome request rate, so no separate counter is registered. `pkg/waf` stays Prometheus-free (the `prom.Mirror`/`prom.Cache` convention).

## Validation

- Full `make` green (vet + lint + `-race`)
- waf + prom tests 20× `-race`; prom tests count-safe (baseline-then-delta), including a **bucket-resolution test that fails if the buckets regress to DefBuckets**, and a downstream-30ms-sleep test proving `Duration` excludes downstream latency
- Design + 3-lens adversarial scrutiny ran as multi-agent passes; scrutiny found **no blocker/major** — the once-and-only-once / measured-before-write / bounded-label invariants are proven on every path (incl. recovered panics, FailOpen-continue, multi-match)

Zero new `go.mod` dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)