### PR TITLE
docs(upstream): reliability primitive decision guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,39 @@ misconfigured probe path cannot black-hole a fresh deploy. The probe uses `http`
 for a target on the dynamic multi-scheme `Transport` set `ahc.Scheme` to `"h2c"` or
 `"unix"` (the dedicated transports force their own scheme and ignore it).
 
+## Choosing a reliability primitive
+
+`pkg/upstream` has grown a stack of reliability primitives; reach for one by the
+failure you are defending against. They **compose** — `ActiveHealthCheck` and
+`NewHedgingLoadBalancer` each wrap any balancer — so the owning balancer handles the
+dominant failure mode and the wrappers layer on top.
+
+| Failure mode | Reach for |
+|---|---|
+| Flaky backend, hard 5xx / errors | `NewEjectingLoadBalancer` (keeps routing during a total outage) — or the circuit breaker if you would rather shed |
+| Dead / brownout origin, fail fast and shed | `NewCircuitBreakingLoadBalancer` (rejects an open target with no round-trip) |
+| Tail latency (p99) on a healthy pool | `NewHedgingLoadBalancer` (race a duplicate after `HedgeDelay`) |
+| Gray failure: 200s but one host far slower than peers | `NewLatencyEjectingLoadBalancer` (relative to the pool median) |
+| Overload: a slow backend draining the pool | `Target.MaxConcurrent` on `NewLeastConnLoadBalancer` + a total-request-deadline middleware ([`pkg/timeout`](pkg/timeout)) |
+| Cold deploy / readiness / black-holing a fresh pod | `NewActiveHealthCheck` (probe out-of-band; route only to answering targets) |
+| Uneven backend capacity | `NewWeightedRoundRobinLoadBalancer` (by count) or `NewLeastConnLoadBalancer` (by concurrency) |
+
+**All-down semantics — know this before an incident.** When *every* target is out,
+the primitives diverge, and which one you ran decides whether a correlated outage
+degrades or hard-fails:
+
+| Primitive | When all targets are out |
+|---|---|
+| Round-robin / weighted / least-conn (health) / ejecting / latency-ejecting | **Fail open** — route best-effort (a degraded answer beats none; a broken signal must not black-hole a healthy pool) |
+| `NewLeastConnLoadBalancer` (capacity, every target at `MaxConcurrent`) | **Shed 503** (the bulkhead contract — independent of health) |
+| `NewCircuitBreakingLoadBalancer` (every target open) | **Shed 503** (don't hammer a dead origin) |
+
+`ActiveHealthCheck` never adds an all-down override: when its gate marks every target
+down, each balancer falls back to its **own** policy above. The full failure-mode and
+all-down guide, the composition rules, and the observability hooks
+(`OnRoundTrip` → `prom.Upstream()`, `OnStateChange` → `prom.UpstreamState()`) live in
+the [`pkg/upstream` package doc](pkg/upstream/doc.go).
+
 ## Traffic mirroring (shadowing)
 
 `mirror.New` tees a copy of matched/sampled **requests** to a separate destination

--- a/pkg/upstream/doc.go
+++ b/pkg/upstream/doc.go
@@ -1,0 +1,181 @@
+// Package upstream is parapet's reverse-proxy and load-balancing layer: it turns a
+// pool of backend targets into an http.RoundTripper that the proxy (upstream.New)
+// drives, and layers a stack of reliability primitives on top of plain
+// distribution.
+//
+// # The reliability stack
+//
+// Every balancer below is a drop-in http.RoundTripper for upstream.New, reads its
+// configuration once before the first request, and tracks state with per-target
+// atomics so the hot path stays lock-free. Two of them (ActiveHealthCheck and
+// HedgingLoadBalancer) WRAP another balancer rather than owning targets directly,
+// so the pieces compose (see "Composition" below).
+//
+//	Distribution (no health logic)
+//	  RoundRobinLoadBalancer          even spread, every target equal
+//	  WeightedRoundRobinLoadBalancer  bias request COUNT by Target.Weight (SWRR)
+//	  LeastConnLoadBalancer           bias by live in-flight CONNECTIONS; honours
+//	                                  Target.MaxConcurrent (the bulkhead cap)
+//
+//	Error-based reliability
+//	  EjectingLoadBalancer            passive outlier ejection on consecutive
+//	                                  failures, backed-off cooldown
+//	  CircuitBreakingLoadBalancer     fail-FAST: reject an open target with no
+//	                                  round-trip; Closed/Open/HalfOpen
+//
+//	Latency-based reliability
+//	  LatencyEjectingLoadBalancer     eject a "gray failure" (200s but slow) on a
+//	                                  decayed-mean TTFB vs the pool median
+//	  HedgingLoadBalancer             speculative retry after HedgeDelay to cut
+//	                                  tail latency (wraps any balancer)
+//
+//	Active probing (wraps any balancer)
+//	  ActiveHealthCheck               out-of-band probes; gates the wrapped
+//	                                  balancer's pick, only ever REMOVES candidates
+//
+// # Choosing a primitive by failure mode
+//
+// Pick by the failure you are defending against. An Upstream uses ONE balancer, so
+// for the owning balancer choose the dominant failure mode (then compose the
+// wrappers — active health and hedging — on top):
+//
+//	Failure mode                     Reach for
+//	------------------------------   --------------------------------------------
+//	flaky backend, hard 5xx/errors   EjectingLoadBalancer (keeps routing during a
+//	                                 total outage) — or CircuitBreakingLoadBalancer
+//	                                 if you would rather shed than hammer
+//	dead / brownout origin, want     CircuitBreakingLoadBalancer (fail fast; an
+//	to fail fast and shed            open target costs no connect+timeout)
+//	tail latency (p99) on an         HedgingLoadBalancer (race a duplicate after
+//	otherwise healthy pool           HedgeDelay, take the first answer)
+//	gray failure: 200s but one       LatencyEjectingLoadBalancer (relative-to-pool
+//	host is far slower than peers    median; error ejection / breakers miss it)
+//	overload: a slow backend         Target.MaxConcurrent on LeastConnLoadBalancer
+//	draining the pool                (hard per-target bulkhead cap) + a total-
+//	                                 request-deadline middleware (see "Overload")
+//	cold deploy / readiness /        ActiveHealthCheck (probe out-of-band; route
+//	black-holing a fresh pod         only to answering targets) — wraps any balancer
+//	uneven backend capacity          WeightedRoundRobinLoadBalancer (by request
+//	                                 count) or LeastConnLoadBalancer (by concurrency)
+//
+// Error ejection (EjectingLoadBalancer / CircuitBreakingLoadBalancer) is driven by
+// the IsFailure hook, which by default counts only transport errors other than a
+// client cancel; set it to also treat 5xx as failures. LatencyEjectingLoadBalancer
+// is latency-ONLY — a transport error is not timed and does not eject — so if hard
+// errors are your dominant mode, use an error balancer instead of (or, via an
+// ActiveHealthCheck gate, alongside) it.
+//
+// # All-down semantics — the load-bearing distinction
+//
+// When EVERY target is unavailable the primitives DIVERGE, and which one you ran
+// decides whether a correlated outage degrades or hard-fails. This is the single
+// most important property to know before an incident:
+//
+//	Primitive                       When all targets are out
+//	-----------------------------   --------------------------------------------
+//	RoundRobinLoadBalancer          FAIL OPEN — routes best-effort to the next
+//	WeightedRoundRobin (SWRR)       slot (a broken signal must not black-hole a
+//	LeastConnLoadBalancer (health)  healthy pool). Empty pool -> ErrUnavailable.
+//	EjectingLoadBalancer            FAIL OPEN — all ejected -> route anyway, so a
+//	LatencyEjectingLoadBalancer     transient outage / systemic slowdown can't
+//	                                black-hole all traffic (slow-but-up beats 503).
+//
+//	LeastConnLoadBalancer           SHEDS 503 — when every target is at its
+//	  (capacity, MaxConcurrent)     MaxConcurrent cap (the bulkhead contract;
+//	                                independent of health — a probe-dark pool still
+//	                                routes best-effort, a saturated one still sheds).
+//	CircuitBreakingLoadBalancer     SHEDS 503 — every target open or probe-
+//	                                saturated returns ErrUnavailable, deliberately
+//	                                shedding load instead of hammering a dead origin.
+//
+// So the ejecting balancers and plain distribution route BEST-EFFORT under a total
+// outage (preferring a degraded answer to none); the circuit breaker and the
+// least-conn capacity cap SHED a 503. That is intentional: a latency outlier or a
+// flaky host is still serving (route to it), but a hammered dead origin or a
+// saturated pool is better protected by shedding. ActiveHealthCheck never adds an
+// all-down OVERRIDE — when its gate marks every target down each balancer falls
+// back to its OWN policy above, so a broken probe path cannot turn a fail-open pool
+// into a black hole.
+//
+// A 503 surfaced this way is upstream.ErrUnavailable, which Upstream's error handler
+// maps to HTTP 503 (any other transport error maps to 502), and which
+// prom.Upstream() counts in upstream_fast_rejects_total before any round-trip.
+//
+// # Overload and the MaxConcurrent latch
+//
+// Target.MaxConcurrent (LeastConnLoadBalancer only) is a HARD per-target cap on
+// in-flight requests — the bulkhead pattern. It bounds blast radius: a slow backend
+// holds at most this many requests and cannot drain the pool; surplus routes to an
+// under-cap target, and only when EVERY target is full does the balancer shed 503.
+//
+// A slot is held until the response BODY is closed, not at the response headers, so
+// the cap bounds true end-to-end concurrency including slow body streams. Nothing
+// else reclaims a slot: a backend that sends headers then stalls mid-body keeps its
+// slot until the request context is cancelled. No http.Transport timeout covers
+// that stall (ResponseHeaderTimeout bounds only time-to-headers; IdleConnTimeout
+// reaps only idle pooled conns), and the existing write-header timeout in pkg/timeout
+// disarms once upstream headers are written — so it does NOT cover a mid-body stall
+// either. Without a bound on TOTAL request time, after MaxConcurrent stalled
+// requests the cap becomes a LATCH, not a limiter, and the target sheds all traffic
+// permanently. To defend against that, pair the cap with a total-request-deadline
+// middleware in pkg/timeout (a request-scoped context deadline the transport honors,
+// covering the whole request including the body) so a stalled request is cancelled
+// and its slot reclaimed.
+//
+// # Composition
+//
+// The primitives COMPOSE; reach for more than one when you face more than one
+// failure mode:
+//
+//   - ActiveHealthCheck wraps ANY balancer. It owns one probe goroutine per target
+//     and publishes a per-target up/down gate that the wrapped balancer consults
+//     inside its OWN pick. Active health only ever REMOVES candidates — it never
+//     overrides the balancer's own (passive) verdict — so a target must satisfy BOTH
+//     the active gate AND the balancer's strategy to be chosen: the two compose by
+//     AND. The wrapped balancer keeps its exact strategy over the survivors (a
+//     weighted balancer keeps its ratio, the breaker still trips, least-conn still
+//     balances). Pass the SAME []*Target to both the balancer and the wrapper so the
+//     gate's indices line up.
+//
+//   - HedgingLoadBalancer wraps ANY balancer. After HedgeDelay it duplicates the
+//     in-flight (idempotent, body-less) request via a second call to the wrapped
+//     balancer, which self-selects a different target, and returns the first winner.
+//     Hedging and the proxy's retry loop layer rather than multiply. If the wrapped
+//     balancer has a custom IsFailure, it MUST exclude context.Canceled or a
+//     cancelled losing leg slowly ejects/trips the healthy backend it raced.
+//
+//   - Passive + active gate together by AND: e.g. EjectingLoadBalancer's pick takes
+//     a target only when it is both not-ejected (passive) AND gate-up (active).
+//
+// A sensible production stack therefore reads outside-in as: ActiveHealthCheck ->
+// (Hedging ->) a CircuitBreaking or Ejecting balancer over the target pool. See the
+// runnable Example (ExampleNewActiveHealthCheck and the composition example) for how
+// the pieces wire together.
+//
+// # Observability
+//
+// Two hooks make the stack observable; both are nil-by-default (zero hot-path cost)
+// and the callee owns its own concurrency. Wire them to pkg/prom and leave
+// pkg/upstream free of any Prometheus dependency:
+//
+//   - Upstream.OnRoundTrip (a RoundTripFunc) fires once per attempt (each retry
+//     included) with the resolved host, status, time-to-headers, and error. Assign
+//     prom.Upstream() to it for upstream_requests{host,status},
+//     upstream_request_duration_seconds{host}, and upstream_fast_rejects_total{host}
+//     (the all-down 503s shed before any round-trip).
+//
+//   - A balancer's OnStateChange (a StateChangeFunc) fires once per per-target
+//     transition (concurrent threshold crossers collapse to one), after the new
+//     state is published. Assign prom.UpstreamState() to it for
+//     upstream_breaker_state{host} (gauge: 0 closed / 1 open / 2 half_open),
+//     upstream_state_transitions_total{host,from,to,reason} (the authoritative
+//     signal — alert on it), and upstream_probe_down_total{host,cause}. The cause
+//     label is ActiveHealthCheck's classified probe-down reason — one of timeout,
+//     refused, reset, dns, tls, status, error (a bounded closed set) — for telling a
+//     bad probe path from a dead backend from a too-tight Timeout mid-incident.
+//
+// The ejecting balancers report ReasonEject / ReasonRecover; the circuit breaker
+// reports the full Closed/Open/HalfOpen edge set (ReasonTrip, ReasonReopen,
+// ReasonHeal, ReasonProbe, ReasonExpire); ActiveHealthCheck reports
+// ReasonProbeDown (carrying the cause) and ReasonProbeRecover.
+package upstream

--- a/pkg/upstream/example_test.go
+++ b/pkg/upstream/example_test.go
@@ -199,6 +199,55 @@ func ExampleUpstream_onRoundTrip() {
 	s.Use(m)
 }
 
+// Compose a production reliability stack: ACTIVE health probing wrapping a CIRCUIT
+// BREAKER over the pool. The breaker fails fast (an open target costs no round-trip)
+// and sheds 503 when every target is open; active health probes out-of-band and only
+// REMOVES probe-down targets from the breaker's pick — the two gate together by AND.
+// Pass the SAME []*Target to both so their indices line up, and wire each layer's
+// OnStateChange to prom.UpstreamState() so trips, recoveries, and probe-downs are
+// observable. See pkg/upstream's package doc for the failure-mode / all-down-
+// semantics guide this example illustrates.
+func ExampleNewActiveHealthCheck_compose() {
+	tr := &upstream.HTTPTransport{}
+	targets := []*upstream.Target{
+		{Host: "10.0.0.1:8080", Transport: tr},
+		{Host: "10.0.0.2:8080", Transport: tr},
+		{Host: "10.0.0.3:8080", Transport: tr},
+	}
+
+	// Inner: a circuit breaker that fails fast and sheds 503 on a correlated outage.
+	cb := upstream.NewCircuitBreakingLoadBalancer(targets)
+	cb.FailureThreshold = 5
+	cb.OpenTimeout = 5 * time.Second
+	cb.IsFailure = func(resp *http.Response, err error) bool {
+		return err != nil || (resp != nil && resp.StatusCode >= 500)
+	}
+	cb.OnStateChange = func(c upstream.StateChange) {
+		_ = c.From // wire to prom.UpstreamState() in production
+		_ = c.To
+		_ = c.Reason // ReasonTrip / ReasonHeal / ReasonProbe / ...
+	}
+
+	// Outer: active probing that gates the breaker's pick (only removes candidates).
+	ahc := upstream.NewActiveHealthCheck(targets, cb)
+	ahc.Path = "/healthz"
+	ahc.Interval = 5 * time.Second
+	ahc.UnhealthyThld = 3
+	ahc.OnStateChange = func(c upstream.StateChange) {
+		_ = c.Reason // ReasonProbeDown / ReasonProbeRecover
+		_ = c.Cause  // classified failure cause on a probe-down (e.g. "timeout")
+	}
+
+	u := upstream.New(ahc) // ahc is the proxy's transport, like any balancer
+	u.OnRoundTrip = func(r *http.Request, info upstream.RoundTripInfo) {
+		_ = info.Host   // resolved target; "" when shed before any pick
+		_ = info.Status // wire to prom.Upstream() in production
+	}
+
+	s := parapet.New()
+	s.Use(u)
+}
+
 // Pick the transport for the backend's protocol. Transport auto-selects per the
 // request URL scheme (http/https, h2c for cleartext HTTP/2, unix sockets), so one
 // instance can front a mixed pool; the dedicated transports pin a single protocol.


### PR DESCRIPTION
## What

`pkg/upstream` has grown to a nine-piece reliability stack and there was no single doc explaining which primitive to reach for. This adds the canonical "choosing your reliability primitive" guide.

- **New `pkg/upstream/doc.go`** (package doc + the guide):
  - a **failure-mode → primitive table** (flaky 5xx → Ejecting; tail latency → Hedging; gray failure → LatencyEjecting; dead/brownout origin → CircuitBreaking; overload → `Target.MaxConcurrent` + a total-request-deadline middleware in `pkg/timeout`; cold deploy / readiness → ActiveHealthCheck; uneven capacity → Weighted / LeastConn)
  - an explicit **all-down-semantics table** — which primitives **fail open / route best-effort** (round-robin, weighted, least-conn on health, ejecting, latency-ejecting) vs which **shed 503** (the circuit breaker; least-conn's `MaxConcurrent` capacity cap)
  - the **MaxConcurrent latch / overload** note, cross-referencing `pkg/timeout`
  - **composition** rules (ActiveHealthCheck wraps any balancer and only *removes* candidates; Hedging wraps any balancer; passive + active gate together by AND)
  - **observability** (`OnRoundTrip` → `prom.Upstream()`; `OnStateChange` → `prom.UpstreamState()`, including the new ActiveHealthCheck probe-down cause label)
- **A runnable Example** (`ExampleNewActiveHealthCheck_compose`) showing a production stack: ActiveHealthCheck wrapping a circuit breaker, with both layers' `OnStateChange` and `OnRoundTrip` wired.
- **README** "Choosing a reliability primitive" subsection — a compact failure-mode + all-down table that points at the godoc as the canonical long form. Added as a self-contained section for clean merges.

## Why

The divergent all-down semantics are exactly the mid-incident confusion that turns a 20-minute outage into a 2-hour one (does this balancer route best-effort or shed a 503 when everything is down?). That distinction is now documented in one place.

Every behavioral claim was verified against the implementation (`loadbalancer.go`, `weighted.go`, `leastconn.go`, `ejecting.go`, `latencyejecting.go`, `circuitbreaker.go`, `hedging.go`, `healthcheck.go`, `state.go`, `observe.go`, `upstream.go`, `pkg/timeout/timeout.go`, `pkg/prom/upstream*.go`). `make` is green (vet + golangci-lint 0 issues + `go test -race ./...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)