### PR TITLE
feat(timeout)!: total-request deadline middleware + rename Timout→Timeout (breaking)

### DIFF
--- a/pkg/timeout/example_test.go
+++ b/pkg/timeout/example_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/location"
 	"github.com/moonrhythm/parapet/pkg/timeout"
 )
 
@@ -27,4 +28,30 @@ func ExampleTimout() {
 
 	s := parapet.New()
 	s.Use(m)
+}
+
+// timeout.Timeout is a non-breaking alias for the (typo'd) Timout struct, so new
+// code can spell the type correctly while existing Timout users keep working.
+func ExampleTimeout() {
+	var m timeout.Timeout // same type as timeout.Timout
+	m.Timeout = 5 * time.Second
+
+	s := parapet.New()
+	s.Use(m)
+}
+
+// RequestDeadline bounds the TOTAL request time (headers AND body) via the
+// request context, so it also aborts a backend that writes headers then stalls
+// mid-body — unlike timeout.New/Timout, which disarms once headers are written.
+//
+// Apply it PER-ROUTE, never globally: a blanket total deadline would kill
+// legitimate long-lived responses (SSE, streaming, large downloads). Here only
+// the /api prefix is bounded; streaming routes elsewhere are left untouched.
+func ExampleRequestDeadline() {
+	api := location.Prefix("/api")
+	api.Use(timeout.NewRequestDeadline(30 * time.Second))
+	// api.Use(upstream.SingleHost(...)) — the bounded handler.
+
+	s := parapet.New()
+	s.Use(api)
 }

--- a/pkg/timeout/example_test.go
+++ b/pkg/timeout/example_test.go
@@ -19,7 +19,7 @@ func ExampleNew() {
 }
 
 // Replace the default 504 response with a custom one by setting TimeoutHandler.
-func ExampleTimout() {
+func ExampleTimeout() {
 	m := timeout.New(5 * time.Second)
 	m.TimeoutHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Retry-After", "10")
@@ -30,19 +30,9 @@ func ExampleTimout() {
 	s.Use(m)
 }
 
-// timeout.Timeout is a non-breaking alias for the (typo'd) Timout struct, so new
-// code can spell the type correctly while existing Timout users keep working.
-func ExampleTimeout() {
-	var m timeout.Timeout // same type as timeout.Timout
-	m.Timeout = 5 * time.Second
-
-	s := parapet.New()
-	s.Use(m)
-}
-
 // RequestDeadline bounds the TOTAL request time (headers AND body) via the
 // request context, so it also aborts a backend that writes headers then stalls
-// mid-body — unlike timeout.New/Timout, which disarms once headers are written.
+// mid-body — unlike timeout.New/Timeout, which disarms once headers are written.
 //
 // Apply it PER-ROUTE, never globally: a blanket total deadline would kill
 // legitimate long-lived responses (SSE, streaming, large downloads). Here only

--- a/pkg/timeout/requestdeadline.go
+++ b/pkg/timeout/requestdeadline.go
@@ -1,0 +1,75 @@
+package timeout
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// NewRequestDeadline creates a [RequestDeadline] middleware that bounds the
+// TOTAL request time to d.
+func NewRequestDeadline(d time.Duration) *RequestDeadline {
+	return &RequestDeadline{Timeout: d}
+}
+
+// RequestDeadline arms a deadline over the ENTIRE request — response headers AND
+// the body stream — by deriving a [context.WithTimeout] from the request context
+// and serving the downstream handler with it. When the deadline elapses the
+// request context is cancelled; a transport that honors the request context
+// (parapet's upstream transports do) then aborts the in-flight call, including a
+// backend that has already written headers but stalls mid-body.
+//
+// # How it differs from Timout
+//
+//   - [Timout] is a write-header deadline: it fires only until the upstream
+//     writes response headers, then stops mattering (its timeoutRW is irrelevant
+//     once headers are written). A backend that sends headers and then stalls
+//     mid-body is NOT bounded by Timout. On expiry Timout writes its own 504
+//     Gateway Timeout response.
+//   - RequestDeadline is a TOTAL request deadline (headers + body). It is a bare
+//     context wrapper: no SSE detection, no streaming heuristics, no response
+//     buffering. It does NOT write a custom timeout response of its own — the
+//     context deadline simply propagates and the downstream handler / transport
+//     surfaces the resulting error (typically a 502/504 from pkg/upstream once
+//     the context-cancelled call fails).
+//
+// # Motivation
+//
+// pkg/upstream's LeastConnLoadBalancer MaxConcurrent bulkhead holds a slot until
+// the response body is closed. A backend that writes headers then stalls
+// mid-body keeps its slot indefinitely — no http.Transport timeout covers that
+// stall (ResponseHeaderTimeout bounds only time-to-headers; IdleConnTimeout reaps
+// only idle pooled connections). After MaxConcurrent such stalls the target sheds
+// all traffic permanently: the cap becomes a latch, not a limiter. Capping TOTAL
+// request time via a request-scoped context deadline the transport honors is the
+// in-tree mitigation, and that is exactly what RequestDeadline provides — which
+// Timout cannot, since it disarms once upstream headers are written.
+//
+// # WARNING: do not blanket-deploy
+//
+// A total request deadline will KILL legitimate long-lived responses — Server-Sent
+// Events, streaming responses, WebSocket-style upgrades, and large file downloads
+// — because those intentionally keep the body open far longer than any sane
+// header-to-completion bound. Do NOT apply RequestDeadline globally. Apply it
+// PER-ROUTE (via pkg/location or pkg/block) only to endpoints whose total time
+// genuinely should be bounded, and exclude streaming/download routes.
+//
+// A Timeout (this field) of <= 0 makes ServeHandler a pass-through no-op,
+// matching [Timout].
+type RequestDeadline struct {
+	Timeout time.Duration
+}
+
+// ServeHandler implements middleware interface
+func (m RequestDeadline) ServeHandler(h http.Handler) http.Handler {
+	if m.Timeout <= 0 {
+		return h
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), m.Timeout)
+		defer cancel()
+
+		h.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/pkg/timeout/requestdeadline.go
+++ b/pkg/timeout/requestdeadline.go
@@ -19,12 +19,12 @@ func NewRequestDeadline(d time.Duration) *RequestDeadline {
 // (parapet's upstream transports do) then aborts the in-flight call, including a
 // backend that has already written headers but stalls mid-body.
 //
-// # How it differs from Timout
+// # How it differs from Timeout
 //
-//   - [Timout] is a write-header deadline: it fires only until the upstream
+//   - [Timeout] is a write-header deadline: it fires only until the upstream
 //     writes response headers, then stops mattering (its timeoutRW is irrelevant
 //     once headers are written). A backend that sends headers and then stalls
-//     mid-body is NOT bounded by Timout. On expiry Timout writes its own 504
+//     mid-body is NOT bounded by Timeout. On expiry Timeout writes its own 504
 //     Gateway Timeout response.
 //   - RequestDeadline is a TOTAL request deadline (headers + body). It is a bare
 //     context wrapper: no SSE detection, no streaming heuristics, no response
@@ -43,7 +43,7 @@ func NewRequestDeadline(d time.Duration) *RequestDeadline {
 // all traffic permanently: the cap becomes a latch, not a limiter. Capping TOTAL
 // request time via a request-scoped context deadline the transport honors is the
 // in-tree mitigation, and that is exactly what RequestDeadline provides — which
-// Timout cannot, since it disarms once upstream headers are written.
+// Timeout cannot, since it disarms once upstream headers are written.
 //
 // # WARNING: do not blanket-deploy
 //
@@ -55,7 +55,7 @@ func NewRequestDeadline(d time.Duration) *RequestDeadline {
 // genuinely should be bounded, and exclude streaming/download routes.
 //
 // A Timeout (this field) of <= 0 makes ServeHandler a pass-through no-op,
-// matching [Timout].
+// matching [Timeout].
 type RequestDeadline struct {
 	Timeout time.Duration
 }

--- a/pkg/timeout/requestdeadline_test.go
+++ b/pkg/timeout/requestdeadline_test.go
@@ -1,0 +1,127 @@
+package timeout_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/moonrhythm/parapet/pkg/timeout"
+)
+
+// handlerPtr returns the underlying code pointer of an http.Handler so two
+// handlers can be compared for identity (http.HandlerFunc values are not
+// comparable with ==).
+func handlerPtr(h http.Handler) uintptr {
+	return reflect.ValueOf(h).Pointer()
+}
+
+func TestRequestDeadlineCancelsContext(t *testing.T) {
+	t.Parallel()
+
+	m := NewRequestDeadline(20 * time.Millisecond)
+
+	var ctxErr error
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Block until the deadline cancels the request context. This
+		// synchronizes deterministically (no sleep-and-hope): the handler
+		// only returns once the deadline fires.
+		<-r.Context().Done()
+		ctxErr = r.Context().Err()
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.ErrorIs(t, ctxErr, context.DeadlineExceeded)
+}
+
+func TestRequestDeadlineFastHandlerCompletes(t *testing.T) {
+	t.Parallel()
+
+	// A generous deadline with a fast handler must complete normally and the
+	// context must NOT be errored when the handler runs.
+	m := NewRequestDeadline(time.Minute)
+
+	called := false
+	var ctxErr error
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		ctxErr = r.Context().Err()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.True(t, called)
+	assert.NoError(t, ctxErr)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "ok", w.Body.String())
+}
+
+func TestRequestDeadlineZeroIsPassThrough(t *testing.T) {
+	t.Parallel()
+
+	m := NewRequestDeadline(0)
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := m.ServeHandler(inner)
+
+	// <= 0 duration is a pass-through: the exact same handler instance is
+	// returned, with no context deadline armed.
+	assert.Equal(t,
+		handlerPtr(inner),
+		handlerPtr(h),
+		"zero-duration RequestDeadline must return the handler unchanged",
+	)
+
+	// And it must not arm a deadline.
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	hadDeadline := true
+	wrapped := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadDeadline = r.Context().Deadline()
+	}))
+	wrapped.ServeHTTP(w, r)
+	assert.False(t, hadDeadline, "pass-through must not set a context deadline")
+}
+
+func TestRequestDeadlineNegativeIsPassThrough(t *testing.T) {
+	t.Parallel()
+
+	m := NewRequestDeadline(-time.Second)
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+	h := m.ServeHandler(inner)
+
+	assert.Equal(t, handlerPtr(inner), handlerPtr(h))
+}
+
+func TestTimeoutAliasUsable(t *testing.T) {
+	t.Parallel()
+
+	// The Timeout alias is interchangeable with Timout: a Timout value is
+	// accepted where a Timeout is required (they are the same underlying type),
+	// and a Timeout value is usable as a middleware.
+	takesTimeout := func(Timeout) {}
+	takesTimeout(Timout{Timeout: time.Second})
+
+	m := Timeout{Timeout: time.Second}
+	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusTeapot, w.Code)
+}

--- a/pkg/timeout/requestdeadline_test.go
+++ b/pkg/timeout/requestdeadline_test.go
@@ -104,24 +104,3 @@ func TestRequestDeadlineNegativeIsPassThrough(t *testing.T) {
 
 	assert.Equal(t, handlerPtr(inner), handlerPtr(h))
 }
-
-func TestTimeoutAliasUsable(t *testing.T) {
-	t.Parallel()
-
-	// The Timeout alias is interchangeable with Timout: a Timout value is
-	// accepted where a Timeout is required (they are the same underlying type),
-	// and a Timeout value is usable as a middleware.
-	takesTimeout := func(Timeout) {}
-	takesTimeout(Timout{Timeout: time.Second})
-
-	m := Timeout{Timeout: time.Second}
-	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusTeapot)
-	}))
-
-	r := httptest.NewRequest("GET", "/", nil)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, r)
-
-	assert.Equal(t, http.StatusTeapot, w.Code)
-}

--- a/pkg/timeout/timeout.go
+++ b/pkg/timeout/timeout.go
@@ -10,23 +10,20 @@ import (
 )
 
 // New creates timeout middleware
-func New(timeout time.Duration) *Timout {
-	return &Timout{Timeout: timeout}
+func New(timeout time.Duration) *Timeout {
+	return &Timeout{Timeout: timeout}
 }
 
-// Timout sets a write header timeout
-type Timout struct {
+// Timeout sets a write header timeout. It fires only until the upstream writes
+// response headers; a backend that writes headers then stalls mid-body is NOT
+// bounded by it — use [RequestDeadline] for a total-request deadline.
+type Timeout struct {
 	TimeoutHandler http.Handler
 	Timeout        time.Duration
 }
 
-// Timeout is a non-breaking alias for [Timout] (the struct name carries a
-// long-standing typo). New code should spell it Timeout; existing Timout users
-// keep working unchanged, since this is a type alias, not a new type.
-type Timeout = Timout
-
 // ServeHandler implements middleware interface
-func (m Timout) ServeHandler(h http.Handler) http.Handler {
+func (m Timeout) ServeHandler(h http.Handler) http.Handler {
 	if m.Timeout <= 0 {
 		return h
 	}

--- a/pkg/timeout/timeout.go
+++ b/pkg/timeout/timeout.go
@@ -20,6 +20,11 @@ type Timout struct {
 	Timeout        time.Duration
 }
 
+// Timeout is a non-breaking alias for [Timout] (the struct name carries a
+// long-standing typo). New code should spell it Timeout; existing Timout users
+// keep working unchanged, since this is a type alias, not a new type.
+type Timeout = Timout
+
 // ServeHandler implements middleware interface
 func (m Timout) ServeHandler(h http.Handler) http.Handler {
 	if m.Timeout <= 0 {

--- a/pkg/timeout/timeout_test.go
+++ b/pkg/timeout/timeout_test.go
@@ -83,7 +83,7 @@ func TestTimeoutCustomHandler(t *testing.T) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte("custom"))
 	})
-	m := &Timout{Timeout: 20 * time.Millisecond, TimeoutHandler: custom}
+	m := &Timeout{Timeout: 20 * time.Millisecond, TimeoutHandler: custom}
 
 	h := m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-r.Context().Done()


### PR DESCRIPTION
## Why (backlog item #5 — tag blocker)

`pkg/timeout` had two issues this PR fixes before the v0.18.0 tag freezes the surface:

1. **The exported struct `Timout` carried a long-standing typo.** Now renamed to **`Timeout`** as an intentional **BREAKING CHANGE** (per maintainer call — fix it outright rather than carry an alias forever). `timeout.New` is unchanged; no other package in this repo referenced the type, so the break is confined to the `pkg/timeout` exported surface. External callers (e.g. parapet-ingress-controller) referencing `timeout.Timout` must update to `timeout.Timeout`.

2. **No total-request deadline existed.** The renamed `Timeout` is a WRITE-HEADER deadline: it disarms once the upstream writes response headers, so a backend that writes headers then stalls **mid-body** is unbounded — and `pkg/upstream`'s loadbalancer docs warn this latches a `MaxConcurrent` bulkhead slot forever, with no in-tree mitigation.

## What

- **`type Timout` → `type Timeout`** (breaking rename), `New` returns `*Timeout`, `ServeHandler` receiver updated; the non-breaking alias from the first revision is removed.
- **New `RequestDeadline` middleware** (`NewRequestDeadline(d)`) arms `context.WithTimeout(r.Context(), d)` over the ENTIRE request — headers AND body — and `defer cancel()`s after the handler returns. Because the deadline rides the request context, a context-honoring transport aborts a mid-body stall too. `<= 0` is a pass-through. It writes no custom response (the context deadline propagates), unlike `Timeout`'s 504.
- **godoc** distinguishes the two (write-header vs total deadline) and loudly warns that blanket-deploying the total deadline kills SSE / streaming / large downloads — apply it per-route (via `location`/`block`).

## Validation

- Full `make` green (vet + lint + `-race`); `pkg/timeout` 10× `-race`
- No `Timout` reference remains anywhere in the repo
- Sensitivity-checked: with the deadline not armed, the cancel test hangs→fails; restored → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)