### PR TITLE
feat(ratelimit): Observe hook + prom.RateLimit() + Redis fail-open visibility

### DIFF
--- a/pkg/prom/ratelimit.go
+++ b/pkg/prom/ratelimit.go
@@ -1,0 +1,101 @@
+package prom
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/moonrhythm/parapet/pkg/ratelimit"
+)
+
+//nolint:govet
+type rateLimitMetrics struct {
+	once       sync.Once
+	decisions  *prometheus.CounterVec
+	redisError prometheus.Counter
+}
+
+var _rateLimit rateLimitMetrics
+
+func (p *rateLimitMetrics) init() {
+	p.once.Do(func() {
+		p.decisions = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "ratelimit_total",
+		}, []string{"name", "result"})
+		p.redisError = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "ratelimit_redis_errors_total",
+		})
+		reg.MustRegister(p.decisions, p.redisError)
+	})
+}
+
+func (p *rateLimitMetrics) observe(e ratelimit.Event) {
+	if c, err := p.decisions.GetMetricWith(prometheus.Labels{
+		"name":   e.Name,
+		"result": e.Result.String(),
+	}); err == nil {
+		c.Inc()
+	}
+}
+
+func (p *rateLimitMetrics) observeRedisError(error) {
+	p.redisError.Inc()
+}
+
+// RateLimit returns a ratelimit.ObserveFunc that records rate-limit decisions on the
+// shared registry, for wiring into RateLimiter.Observe — keeping pkg/ratelimit
+// Prometheus-free (the prom.Mirror/prom.UpstreamState convention).
+//
+//	rl := ratelimit.FixedWindowPerSecond(100)
+//	rl.Name = "api"            // bounded label; "" is fine
+//	rl.Observe = prom.RateLimit()
+//	s.Use(rl)
+//
+// It records one metric (lazily, once per process):
+//
+//	{namespace}_ratelimit_total{name,result}  counter, result = allowed | limited
+//
+// The hook is NON-replacing: it fires on every Take decision IN ADDITION to
+// ExceededHandler, so an operator can count rejections (result="limited") without
+// reimplementing the 429 response. Both labels are bounded — name is operator-set
+// (RateLimiter.Name) and result is the two-value closed set; the client key, whose
+// cardinality is unbounded, is never a label.
+//
+// IMPORTANT (the silent fail-open): a RedisFixedWindowStrategy with FailOpen=true
+// (the constructor default) ADMITS every request when Redis is down — and those
+// admits land in result="allowed", indistinguishable here from genuinely-under-limit
+// admits. Also wire RateLimitRedisError into RedisFixedWindowStrategy.OnError to make
+// Redis-down a distinct, alertable series.
+func RateLimit() ratelimit.ObserveFunc {
+	_rateLimit.init()
+	return _rateLimit.observe
+}
+
+// RateLimitRedisError returns a func(error) for wiring into
+// RedisFixedWindowStrategy.OnError, so a swallowed Redis error (timeout, dial, script
+// error) — which RedisFixedWindowStrategy.Take folds into the FailOpen bool and the
+// RateLimiter therefore cannot see — surfaces as a distinct counter on the shared
+// registry:
+//
+//	{namespace}_ratelimit_redis_errors_total  counter
+//
+//	s := &ratelimit.RedisFixedWindowStrategy{Runner: r, Max: 100, Size: time.Second, FailOpen: true}
+//	s.OnError = prom.RateLimitRedisError()
+//	rl := ratelimit.New(s)
+//	rl.Observe = prom.RateLimit()
+//
+// It is a SEPARATE counter rather than a result="error" row on ratelimit_total by
+// design: the OnError hook fires on the strategy, which has no access to the
+// RateLimiter.Name, and at a different granularity (once per failed Redis op, while a
+// fail-open request ALSO increments result="allowed") — folding the two together
+// would carry a permanently-empty name label and double-count the request. As its own
+// series it stays honest: when Redis degrades it climbs while result="limited" stays
+// flat, which is exactly the otherwise-invisible silent-admit signal to alert on. The
+// error value is intentionally not labelled (unbounded). Optional and zero-cost when
+// unset (a nil OnError is never called).
+func RateLimitRedisError() func(error) {
+	_rateLimit.init()
+	return _rateLimit.observeRedisError
+}

--- a/pkg/prom/ratelimit_test.go
+++ b/pkg/prom/ratelimit_test.go
@@ -1,0 +1,68 @@
+package prom_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/ratelimit"
+
+	. "github.com/moonrhythm/parapet/pkg/prom"
+)
+
+func TestRateLimit(t *testing.T) {
+	observe := RateLimit()
+	require.NotNil(t, observe)
+	onError := RateLimitRedisError()
+	require.NotNil(t, onError)
+
+	// A unique name isolates these assertions from any other test sharing the
+	// process-global registry, and baselines keep them order- and -count-independent.
+	const name = "prom-ratelimit-test"
+	baseAllowed := baseline(t, "parapet_ratelimit_total", map[string]string{"name": name, "result": "allowed"})
+	baseLimited := baseline(t, "parapet_ratelimit_total", map[string]string{"name": name, "result": "limited"})
+	baseErrors := baseline(t, "parapet_ratelimit_redis_errors_total", nil)
+
+	observe(ratelimit.Event{Name: name, Result: ratelimit.ResultAllowed})
+	observe(ratelimit.Event{Name: name, Result: ratelimit.ResultLimited})
+	observe(ratelimit.Event{Name: name, Result: ratelimit.ResultLimited})
+	onError(errors.New("redis down"))
+
+	assert.EqualValues(t, baseAllowed+1, counterValue(t, "parapet_ratelimit_total",
+		map[string]string{"name": name, "result": "allowed"}), "one allowed decision counted")
+	assert.EqualValues(t, baseLimited+2, counterValue(t, "parapet_ratelimit_total",
+		map[string]string{"name": name, "result": "limited"}), "two limited decisions counted")
+	assert.EqualValues(t, baseErrors+1, counterValue(t, "parapet_ratelimit_redis_errors_total", nil),
+		"the swallowed redis error surfaces as its own series, not a silent admit")
+}
+
+// baseline reads the current value of a counter series, treating an absent series
+// (counterValue returns -1) as 0, so delta assertions survive the process-global
+// registry across tests and -count reruns.
+func baseline(t *testing.T, name string, want map[string]string) float64 {
+	t.Helper()
+	v := counterValue(t, name, want)
+	if v < 0 {
+		return 0
+	}
+	return v
+}
+
+func ExampleRateLimit() {
+	rl := ratelimit.FixedWindowPerSecond(100)
+	rl.Name = "api"            // bounded label carried on every Event; "" is fine
+	rl.Observe = RateLimit()   // prom.RateLimit(): count decisions by name+result
+	_ = rl                     // s.Use(rl)
+}
+
+func ExampleRateLimitRedisError() {
+	s := &ratelimit.RedisFixedWindowStrategy{Max: 100, Size: time.Second, FailOpen: true}
+	s.OnError = RateLimitRedisError() // count Redis-down so silent fail-open admits are visible
+	rl := ratelimit.New(s)
+	rl.Name = "api"
+	rl.Observe = RateLimit()
+	_ = rl // s.Use(rl)
+}

--- a/pkg/ratelimit/observe.go
+++ b/pkg/ratelimit/observe.go
@@ -1,0 +1,45 @@
+package ratelimit
+
+// Result classifies the outcome of one rate-limit decision, reported via
+// RateLimiter.Observe.
+type Result uint8
+
+const (
+	// ResultAllowed: the request was admitted (Strategy.Take returned true). Under a
+	// Redis fail-open this includes requests admitted because Redis was unreachable —
+	// wire RedisFixedWindowStrategy.OnError (prom.RateLimitRedisError) to tell those
+	// apart from genuinely-under-limit admits.
+	ResultAllowed Result = iota
+	// ResultLimited: the request was rejected (Strategy.Take returned false); the
+	// ExceededHandler ran (a 429 by default).
+	ResultLimited
+)
+
+// String renders a Result as a stable, bounded metric-label value.
+func (r Result) String() string {
+	switch r {
+	case ResultAllowed:
+		return "allowed"
+	case ResultLimited:
+		return "limited"
+	default:
+		return "unknown"
+	}
+}
+
+// Event reports one rate-limit decision to RateLimiter.Observe. It carries only
+// bounded fields: the operator-set limiter Name and the Result. It deliberately
+// does NOT carry the client key, whose cardinality is unbounded and would blow up
+// any per-key metric label set.
+type Event struct {
+	// Name is the operator-set RateLimiter.Name (may be ""), so several rate limiters
+	// can be told apart in metrics. It is bounded by construction (operators set it).
+	Name string
+	// Result is allowed or limited.
+	Result Result
+}
+
+// ObserveFunc is the rate-limit observation-hook shape, returned by prom.RateLimit
+// for wiring into RateLimiter.Observe. It fires once per Take decision, IN ADDITION
+// to (never replacing) ExceededHandler, on the request goroutine — keep it cheap.
+type ObserveFunc func(Event)

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -20,9 +20,22 @@ func New(strategy Strategy) *RateLimiter {
 
 // RateLimiter middleware
 type RateLimiter struct {
-	Key                  func(r *http.Request) string
-	ExceededHandler      ExceededHandler
-	Strategy             Strategy
+	Key             func(r *http.Request) string
+	ExceededHandler ExceededHandler
+	Strategy        Strategy
+
+	// Observe, if set, is fired on EVERY Take decision with a bounded Event (the Name
+	// below and allowed/limited). Unlike ExceededHandler it does NOT replace the
+	// response — observability is independent of what the client sees, so merely
+	// COUNTING rejections no longer means reimplementing the 429. It runs synchronously
+	// on the request goroutine; keep it cheap. nil disables it. See prom.RateLimit.
+	Observe ObserveFunc
+
+	// Name is an operator-set, bounded label carried on every Event so several rate
+	// limiters are distinguishable in metrics; "" is fine (the prom adapter maps it).
+	// NEVER derived from the client key (unbounded cardinality).
+	Name string
+
 	ReleaseOnWriteHeader bool // release token when write response's header
 	ReleaseOnHijacked    bool // release token when hijacked
 }
@@ -78,9 +91,11 @@ func (m RateLimiter) ServeHandler(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			key := m.Key(r)
 			if !m.Strategy.Take(key) {
+				m.observe(ResultLimited)
 				m.ExceededHandler(w, r, m.Strategy.After(key))
 				return
 			}
+			m.observe(ResultAllowed)
 			defer m.Strategy.Put(key) // use defer to always put token back when panic
 			h.ServeHTTP(w, r)
 		})
@@ -89,9 +104,11 @@ func (m RateLimiter) ServeHandler(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		key := m.Key(r)
 		if !m.Strategy.Take(key) {
+			m.observe(ResultLimited)
 			m.ExceededHandler(w, r, m.Strategy.After(key))
 			return
 		}
+		m.observe(ResultAllowed)
 
 		// Release state lives inside the responseWriter, which already
 		// escapes — avoids allocating a separate closure + bool.
@@ -105,6 +122,15 @@ func (m RateLimiter) ServeHandler(h http.Handler) http.Handler {
 		defer nw.release() // use defer to always put token back when panic
 		h.ServeHTTP(nw, r)
 	})
+}
+
+// observe fires the Observe hook (nil-checked) with a bounded Event carrying the
+// limiter Name and result. It is the single fire point for both ServeHandler
+// branches, so the allowed/limited accounting can never diverge between them.
+func (m RateLimiter) observe(result Result) {
+	if m.Observe != nil {
+		m.Observe(Event{Name: m.Name, Result: result})
+	}
 }
 
 type responseWriter struct {

--- a/pkg/ratelimit/ratelimit_test.go
+++ b/pkg/ratelimit/ratelimit_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/moonrhythm/parapet/pkg/ratelimit"
 )
@@ -230,6 +231,100 @@ func TestRateLimiter(t *testing.T) {
 		})).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusTooManyRequests, w.Code)
 	})
+}
+
+// TestRateLimiterObserve pins the non-replacing Observe hook: it fires exactly once
+// per request with the correct allowed/limited Result and carries the operator-set
+// Name, in BOTH the fast path and the response-writer-wrapping branch, IN ADDITION to
+// (never replacing) ExceededHandler; a nil Observe is a no-op.
+func TestRateLimiterObserve(t *testing.T) {
+	t.Parallel()
+
+	newStrategy := func(take bool) *mockStrategy {
+		return &mockStrategy{
+			takeFunc:  func(string) bool { return take },
+			putFunc:   func(string) {},
+			afterFunc: func(string) time.Duration { return 0 },
+		}
+	}
+
+	// Each case is run through both ServeHandler branches: the fast path
+	// (no release wrapping) and the wrapping branch (ReleaseOnWriteHeader).
+	branches := []struct {
+		name    string
+		wrapped bool
+	}{
+		{"fast path", false},
+		{"wrapping branch", true},
+	}
+
+	for _, b := range branches {
+		b := b
+		t.Run(b.name, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("allowed fires once", func(t *testing.T) {
+				var events []Event
+				m := RateLimiter{
+					Name:                 "rl1",
+					Strategy:             newStrategy(true),
+					ReleaseOnWriteHeader: b.wrapped,
+					Observe:              func(e Event) { events = append(events, e) },
+				}
+				w := httptest.NewRecorder()
+				m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				})).ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+
+				require.Len(t, events, 1, "Observe fires exactly once")
+				assert.Equal(t, ResultAllowed, events[0].Result)
+				assert.Equal(t, "rl1", events[0].Name, "the operator-set Name is carried")
+			})
+
+			t.Run("limited fires once and ExceededHandler still runs", func(t *testing.T) {
+				var events []Event
+				exceeded := false
+				m := RateLimiter{
+					Name:                 "rl2",
+					Strategy:             newStrategy(false),
+					ReleaseOnWriteHeader: b.wrapped,
+					ExceededHandler: func(http.ResponseWriter, *http.Request, time.Duration) {
+						exceeded = true
+					},
+					Observe: func(e Event) { events = append(events, e) },
+				}
+				w := httptest.NewRecorder()
+				m.ServeHandler(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+					assert.Fail(t, "downstream must not run when limited")
+				})).ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+
+				require.Len(t, events, 1, "Observe fires exactly once")
+				assert.Equal(t, ResultLimited, events[0].Result)
+				assert.Equal(t, "rl2", events[0].Name)
+				assert.True(t, exceeded, "Observe is IN ADDITION to ExceededHandler, not a replacement")
+			})
+
+			t.Run("nil Observe is a no-op", func(t *testing.T) {
+				m := RateLimiter{
+					Strategy:             newStrategy(true),
+					ReleaseOnWriteHeader: b.wrapped,
+				}
+				assert.NotPanics(t, func() {
+					w := httptest.NewRecorder()
+					m.ServeHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+						w.WriteHeader(http.StatusOK)
+					})).ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+				})
+			})
+		})
+	}
+}
+
+func TestResultString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "allowed", ResultAllowed.String())
+	assert.Equal(t, "limited", ResultLimited.String())
+	assert.Equal(t, "unknown", Result(99).String())
 }
 
 type mockStrategy struct {


### PR DESCRIPTION
## Motivation

The single fully-invisible failure in parapet's shipped stack: a `RedisFixedWindowStrategy` with `FailOpen=true` (the constructor default) silently **ADMITS everything** when Redis is down — and Redis degradation correlates with traffic storms, exactly when limits matter. Meanwhile `RateLimiter` exposed only `ExceededHandler`, which **replaces** the 429+Retry-After response, so to merely *count* rejections an operator had to reimplement the response. And `pkg/prom` had zero ratelimit integration.

## The hook + name/result labels

Follows the established hook→prom-func pattern (`mirror` / `upstream_state` / `cache`):

- **`RateLimiter.Observe` (`ObserveFunc`)** — a nil-checked, **non-replacing** hook fired on **every** `Take` decision, in **both** `ServeHandler` branches (the fast path and the release-wrapping branch), through a single `observe()` fire point so the allowed/limited accounting can never diverge between them. It runs **in addition to** `ExceededHandler` — observability is independent of the response, so counting rejections no longer means reimplementing the 429.
- **`RateLimiter.Name`** — an operator-set, **bounded** label carried on every `Event`, so several rate limiters are distinguishable in metrics. Never the client key (unbounded cardinality).
- **`Event{Name, Result}` + `Result` (allowed | limited)** live in the new `pkg/ratelimit/observe.go`; `pkg/ratelimit` stays Prometheus-free (the hard decoupling house rule).
- **`prom.RateLimit()`** records `parapet_ratelimit_total{name,result}` on the shared registry.

## The Redis-error seam (and why it doesn't touch the Strategy interface)

`RedisFixedWindowStrategy.Take` swallows a Redis error into the `FailOpen` bool, so the `RateLimiter` can't see it. The `Strategy` interface (`Take`/`Put`/`After`) is a public contract implemented by six strategies — adding a method would break every implementer. Instead the **optional strategy-level `OnError func(error)` hook** surfaces the error without touching the interface.

`prom.RateLimitRedisError()` records it as a **distinct** `parapet_ratelimit_redis_errors_total` counter — deliberately a separate series, **not** a `result="error"` row on `ratelimit_total`:

- `OnError` fires on the *strategy*, which has no access to `RateLimiter.Name` — a folded row would carry a permanently-empty `name` label.
- It fires at a different granularity: a fail-open request **also** increments `result="allowed"` (it WAS admitted). Folding the two would double-count that request in one series or lose the admit.

As its own series it stays honest: when Redis degrades, `redis_errors_total` climbs while `result="limited"` stays flat — the exact otherwise-invisible silent-admit signal to alert on. Both adapters are optional and zero-cost when unset.

## Validation

- New `pkg/ratelimit` tests: `Observe` fires exactly once with the correct `allowed`/`limited` result and carries `Name`, in **both** `ServeHandler` branches; nil `Observe` is a no-op (no panic); `Result.String()` mapping. The existing `TestRedisFixedWindowFailOpenClosed` covers the `OnError` hook firing on a simulated Redis error while `Take` returns `FailOpen`.
- New `pkg/prom` tests: baseline-then-delta per `result` label, count-safe under `-count` against the process-global registry; the swallowed Redis error surfaces as its own counter. Inline `ExampleRateLimit` / `ExampleRateLimitRedisError`.
- Sensitivity: inverting the fast-path result and swallowing the Redis error each made the corresponding test fail, then restored to green.
- `make` (vet + golangci-lint with fieldalignment on + `go test -race ./...`) is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)