### PR TITLE
feat(upstream): optional DialContext seam on transports

### DIFF
--- a/pkg/upstream/transport.go
+++ b/pkg/upstream/transport.go
@@ -26,21 +26,31 @@ const (
 //
 //nolint:govet
 type H2CTransport struct {
-	once   sync.Once
-	dialer *net.Dialer
-	h2     *http2.Transport
-	h1     *http.Transport
+	once sync.Once
+	h2   *http2.Transport
+	h1   *http.Transport
 
 	HTTP2Transport *http2.Transport
 	HTTPTransport  *http.Transport
+
+	// DialContext, if non-nil, replaces the default net.Dialer used to open
+	// TCP connections to the upstream. nil uses an internal net.Dialer with
+	// the default dial timeout and keep-alive (today's behavior, unchanged).
+	// Use it to observe dial errors, re-resolve endpoints, or wrap the
+	// connection. A custom dialer is responsible for honoring its own
+	// timeouts; the default dial timeout is ignored when DialContext is set.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // RoundTrip implement http.RoundTripper
 func (t *H2CTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	t.once.Do(func() {
-		t.dialer = &net.Dialer{
-			Timeout:   defaultDialTimeout,
-			KeepAlive: defaultIdleConnTimeout,
+		dial := t.DialContext
+		if dial == nil {
+			dial = (&net.Dialer{
+				Timeout:   defaultDialTimeout,
+				KeepAlive: defaultIdleConnTimeout,
+			}).DialContext
 		}
 
 		t.h2 = t.HTTP2Transport
@@ -51,14 +61,14 @@ func (t *H2CTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 		t.h2.AllowHTTP = true
 		t.h2.DialTLSContext = func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-			return t.dialer.DialContext(ctx, network, addr)
+			return dial(ctx, network, addr)
 		}
 
 		t.h1 = t.HTTPTransport
 		if t.h1 == nil {
 			t.h1 = &http.Transport{
 				Proxy:                 http.ProxyFromEnvironment,
-				DialContext:           t.dialer.DialContext,
+				DialContext:           dial,
 				DisableCompression:    true,
 				MaxIdleConns:          defaultMaxIdleConns,
 				MaxIdleConnsPerHost:   defaultMaxIdleConns,
@@ -93,6 +103,14 @@ type HTTPTransport struct {
 	IdleConnTimeout       time.Duration
 	ExpectContinueTimeout time.Duration
 	ResponseHeaderTimeout time.Duration
+
+	// DialContext, if non-nil, replaces the default net.Dialer used to open
+	// TCP connections to the upstream. nil uses an internal net.Dialer built
+	// from DialTimeout/TCPKeepAlive (today's behavior, unchanged). Use it to
+	// observe dial errors, re-resolve endpoints, or wrap the connection. A
+	// custom dialer is responsible for honoring its own timeouts; DialTimeout
+	// is ignored when DialContext is set.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // RoundTrip implement http.RoundTripper
@@ -111,12 +129,17 @@ func (t *HTTPTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 			t.ResponseHeaderTimeout = defaultResponseHeaderTimeout
 		}
 
-		t.h = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
+		dial := t.DialContext
+		if dial == nil {
+			dial = (&net.Dialer{
 				Timeout:   t.DialTimeout,
 				KeepAlive: t.TCPKeepAlive,
-			}).DialContext,
+			}).DialContext
+		}
+
+		t.h = &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           dial,
 			DisableKeepAlives:     t.DisableKeepAlives,
 			MaxConnsPerHost:       t.MaxConn,
 			MaxIdleConnsPerHost:   t.MaxIdleConns,
@@ -147,6 +170,15 @@ type HTTPSTransport struct {
 	ExpectContinueTimeout time.Duration
 	ResponseHeaderTimeout time.Duration
 	TLSClientConfig       *tls.Config
+
+	// DialContext, if non-nil, replaces the default net.Dialer used to open
+	// TCP connections to the upstream (the TLS handshake is then performed on
+	// top of that connection). nil uses an internal net.Dialer built from
+	// DialTimeout/TCPKeepAlive (today's behavior, unchanged). Use it to
+	// observe dial errors, re-resolve endpoints, or wrap the connection. A
+	// custom dialer is responsible for honoring its own timeouts; DialTimeout
+	// is ignored when DialContext is set.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // RoundTrip implement http.RoundTripper
@@ -170,12 +202,17 @@ func (t *HTTPSTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 			}
 		}
 
-		t.h = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
+		dial := t.DialContext
+		if dial == nil {
+			dial = (&net.Dialer{
 				Timeout:   t.DialTimeout,
 				KeepAlive: t.TCPKeepAlive,
-			}).DialContext,
+			}).DialContext
+		}
+
+		t.h = &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			DialContext:           dial,
 			TLSClientConfig:       t.TLSClientConfig,
 			DisableKeepAlives:     t.DisableKeepAlives,
 			MaxConnsPerHost:       t.MaxConn,
@@ -258,6 +295,15 @@ type Transport struct {
 	ResponseHeaderTimeout time.Duration
 	DisableCompression    bool
 	TLSClientConfig       *tls.Config
+
+	// DialContext, if non-nil, replaces the default net.Dialer used to open
+	// TCP connections to the upstream for the http and h2c (plaintext) paths.
+	// nil uses an internal net.Dialer built from DialTimeout/TCPKeepAlive
+	// (today's behavior, unchanged). Use it to observe dial errors, re-resolve
+	// endpoints, or wrap the connection. A custom dialer is responsible for
+	// honoring its own timeouts; DialTimeout is ignored when DialContext is
+	// set. The unix-socket path is unaffected.
+	DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // RoundTrip implement http.RoundTripper
@@ -286,9 +332,14 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 			KeepAlive: t.TCPKeepAlive,
 		}
 
+		dial := t.DialContext
+		if dial == nil {
+			dial = t.dialer.DialContext
+		}
+
 		t.httpTr = &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
-			DialContext:           t.dialer.DialContext,
+			DialContext:           dial,
 			TLSClientConfig:       t.TLSClientConfig,
 			DisableKeepAlives:     t.DisableKeepAlives,
 			MaxConnsPerHost:       t.MaxConn,
@@ -302,7 +353,7 @@ func (t *Transport) RoundTrip(r *http.Request) (*http.Response, error) {
 			AllowHTTP:          true,
 			DisableCompression: t.DisableCompression,
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-				return t.dialer.DialContext(ctx, network, addr)
+				return dial(ctx, network, addr)
 			},
 		}
 		t.unixTr = &http.Transport{

--- a/pkg/upstream/transport_dialcontext_example_test.go
+++ b/pkg/upstream/transport_dialcontext_example_test.go
@@ -1,0 +1,33 @@
+package upstream_test
+
+import (
+	"context"
+	"log"
+	"net"
+	"time"
+
+	"github.com/moonrhythm/parapet"
+	"github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+// Wrap the transport's dialer to observe dial failures (e.g. to log them or
+// emit a metric) without changing how the connection is made. DialContext is an
+// optional seam: leaving it nil keeps the default net.Dialer behavior. When it
+// is set, the custom dialer owns its own timeouts — DialTimeout is ignored.
+func ExampleHTTPTransport_dialContext() {
+	base := &net.Dialer{Timeout: 2 * time.Second}
+
+	tr := &upstream.HTTPTransport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := base.DialContext(ctx, network, addr)
+			if err != nil {
+				log.Printf("upstream dial failed: addr=%s err=%v", addr, err)
+				return nil, err
+			}
+			return conn, nil
+		},
+	}
+
+	s := parapet.New()
+	s.Use(upstream.SingleHost("10.0.0.1:8080", tr))
+}

--- a/pkg/upstream/transport_dialcontext_test.go
+++ b/pkg/upstream/transport_dialcontext_test.go
@@ -1,0 +1,362 @@
+package upstream
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// recorderDialer is a test dial func that records whether it was invoked and
+// the address it was asked to dial, then delegates to a real net.Dialer so the
+// request actually succeeds. Synchronization is via atomics so it is safe to
+// assert on under -race without sleeping.
+type recorderDialer struct {
+	called atomic.Bool
+	addr   atomic.Pointer[string]
+}
+
+func (d *recorderDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	d.called.Store(true)
+	a := addr
+	d.addr.Store(&a)
+	return (&net.Dialer{}).DialContext(ctx, network, addr)
+}
+
+func (d *recorderDialer) lastAddr() string {
+	p := d.addr.Load()
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// errDialContext returns a sentinel error without ever touching the network, to
+// assert the seam is actually wired (the error must surface to the caller).
+var errSentinelDial = errors.New("sentinel dial error")
+
+func sentinelDialContext(_ context.Context, _, _ string) (net.Conn, error) {
+	return nil, errSentinelDial
+}
+
+func TestHTTPTransport_DialContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom dialer invoked", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(201)
+			w.Write([]byte("ok"))
+		}))
+		defer ts.Close()
+
+		rec := &recorderDialer{}
+		tr := HTTPTransport{DialContext: rec.DialContext}
+
+		host := strings.TrimPrefix(ts.URL, "http://")
+		r := httptest.NewRequest("GET", "https://example.com", nil)
+		r.URL.Host = host
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			io.ReadAll(resp.Body)
+			resp.Body.Close()
+		}
+		assert.True(t, rec.called.Load(), "custom DialContext must be invoked")
+		assert.Equal(t, host, rec.lastAddr())
+	})
+
+	t.Run("sentinel error surfaces", func(t *testing.T) {
+		t.Parallel()
+
+		tr := HTTPTransport{DialContext: sentinelDialContext}
+		r := httptest.NewRequest("GET", "https://example.com", nil)
+		r.URL.Host = "10.255.255.1:80"
+		_, err := tr.RoundTrip(r)
+		assert.ErrorIs(t, err, errSentinelDial)
+	})
+
+	t.Run("nil dialer still works", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(201)
+			w.Write([]byte("ok"))
+		}))
+		defer ts.Close()
+
+		tr := HTTPTransport{}
+		r := httptest.NewRequest("GET", "https://example.com", nil)
+		r.URL.Host = strings.TrimPrefix(ts.URL, "http://")
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, "ok", string(body))
+		}
+	})
+}
+
+func TestHTTPSTransport_DialContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom dialer invoked", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(201)
+			w.Write([]byte("ok"))
+		}))
+		defer ts.Close()
+
+		rec := &recorderDialer{}
+		tr := HTTPSTransport{DialContext: rec.DialContext}
+
+		host := strings.TrimPrefix(ts.URL, "https://")
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		r.URL.Host = host
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			io.ReadAll(resp.Body)
+			resp.Body.Close()
+		}
+		assert.True(t, rec.called.Load(), "custom DialContext must be invoked")
+		assert.Equal(t, host, rec.lastAddr())
+	})
+
+	t.Run("sentinel error surfaces", func(t *testing.T) {
+		t.Parallel()
+
+		tr := HTTPSTransport{DialContext: sentinelDialContext}
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		r.URL.Host = "10.255.255.1:443"
+		_, err := tr.RoundTrip(r)
+		assert.ErrorIs(t, err, errSentinelDial)
+	})
+
+	t.Run("nil dialer still works", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(201)
+			w.Write([]byte("ok"))
+		}))
+		defer ts.Close()
+
+		tr := HTTPSTransport{}
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		r.URL.Host = strings.TrimPrefix(ts.URL, "https://")
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, "ok", string(body))
+		}
+	})
+}
+
+func TestH2CTransport_DialContext(t *testing.T) {
+	t.Parallel()
+
+	newH2CServer := func(t *testing.T) *httptest.Server {
+		t.Helper()
+		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "HTTP/2.0", r.Proto)
+			w.WriteHeader(201)
+			w.Write([]byte("ok"))
+		}))
+		ts.Config.Protocols = new(http.Protocols)
+		ts.Config.Protocols.SetHTTP1(true)
+		ts.Config.Protocols.SetUnencryptedHTTP2(true)
+		ts.Start()
+		return ts
+	}
+
+	t.Run("custom dialer invoked on h2c path", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newH2CServer(t)
+		defer ts.Close()
+
+		rec := &recorderDialer{}
+		tr := H2CTransport{DialContext: rec.DialContext}
+
+		host := strings.TrimPrefix(ts.URL, "http://")
+		r := httptest.NewRequest("GET", "https://example.com", nil)
+		r.URL.Host = host
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			io.ReadAll(resp.Body)
+			resp.Body.Close()
+		}
+		assert.True(t, rec.called.Load(), "custom DialContext must be invoked on the h2c dial path")
+		assert.Equal(t, host, rec.lastAddr())
+	})
+
+	t.Run("custom dialer invoked on h1 upgrade fallback", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "HTTP/1.1", r.Proto)
+			conn, rw, err := w.(http.Hijacker).Hijack()
+			assert.NoError(t, err)
+			rw.WriteString("HTTP/1.1 200 OK\r\n")
+			rw.WriteString("Content-Length: 2\r\n")
+			rw.WriteString("\r\n")
+			rw.WriteString("ok")
+			rw.Flush()
+			conn.Close()
+		}))
+		ts.Config.Protocols = new(http.Protocols)
+		ts.Config.Protocols.SetHTTP1(true)
+		ts.Config.Protocols.SetUnencryptedHTTP2(true)
+		ts.Start()
+		defer ts.Close()
+
+		rec := &recorderDialer{}
+		tr := H2CTransport{DialContext: rec.DialContext}
+
+		host := strings.TrimPrefix(ts.URL, "http://")
+		r := httptest.NewRequest("GET", "https://example.com", nil)
+		r.URL.Host = host
+		r.Header.Set("Upgrade", "proto")
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, "ok", string(body))
+		}
+		assert.True(t, rec.called.Load(), "custom DialContext must be invoked on the h1 fallback dial path")
+		assert.Equal(t, host, rec.lastAddr())
+	})
+
+	t.Run("sentinel error surfaces on h2c path", func(t *testing.T) {
+		t.Parallel()
+
+		tr := H2CTransport{DialContext: sentinelDialContext}
+		r := httptest.NewRequest("GET", "https://example.com", nil)
+		r.URL.Host = "10.255.255.1:80"
+		_, err := tr.RoundTrip(r)
+		assert.ErrorIs(t, err, errSentinelDial)
+	})
+
+	t.Run("nil dialer still works", func(t *testing.T) {
+		t.Parallel()
+
+		ts := newH2CServer(t)
+		defer ts.Close()
+
+		tr := H2CTransport{}
+		r := httptest.NewRequest("GET", "https://example.com", nil)
+		r.URL.Host = strings.TrimPrefix(ts.URL, "http://")
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, "ok", string(body))
+		}
+	})
+}
+
+func TestTransport_DialContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("custom dialer invoked on http path", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(201)
+			w.Write([]byte("ok"))
+		}))
+		defer ts.Close()
+
+		rec := &recorderDialer{}
+		tr := Transport{DialContext: rec.DialContext}
+
+		r := httptest.NewRequest("GET", ts.URL, nil)
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			io.ReadAll(resp.Body)
+			resp.Body.Close()
+		}
+		assert.True(t, rec.called.Load(), "custom DialContext must be invoked on the http path")
+		assert.Equal(t, strings.TrimPrefix(ts.URL, "http://"), rec.lastAddr())
+	})
+
+	t.Run("custom dialer invoked on h2c path", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "HTTP/2.0", r.Proto)
+			w.WriteHeader(201)
+			w.Write([]byte("ok"))
+		}))
+		ts.Config.Protocols = new(http.Protocols)
+		ts.Config.Protocols.SetHTTP1(true)
+		ts.Config.Protocols.SetUnencryptedHTTP2(true)
+		ts.Start()
+		defer ts.Close()
+
+		rec := &recorderDialer{}
+		tr := Transport{DialContext: rec.DialContext}
+
+		host := strings.TrimPrefix(ts.URL, "http://")
+		r := httptest.NewRequest("GET", "h2c://"+host, nil)
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			io.ReadAll(resp.Body)
+			resp.Body.Close()
+		}
+		assert.True(t, rec.called.Load(), "custom DialContext must be invoked on the h2c dial path")
+		assert.Equal(t, host, rec.lastAddr())
+	})
+
+	t.Run("sentinel error surfaces on h2c path", func(t *testing.T) {
+		t.Parallel()
+
+		tr := Transport{DialContext: sentinelDialContext}
+		r := httptest.NewRequest("GET", "h2c://10.255.255.1:80", nil)
+		_, err := tr.RoundTrip(r)
+		assert.ErrorIs(t, err, errSentinelDial)
+	})
+
+	t.Run("nil dialer still works", func(t *testing.T) {
+		t.Parallel()
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(201)
+			w.Write([]byte("ok"))
+		}))
+		defer ts.Close()
+
+		tr := Transport{}
+		r := httptest.NewRequest("GET", ts.URL, nil)
+		resp, err := tr.RoundTrip(r)
+		assert.NoError(t, err)
+		if assert.NotNil(t, resp) {
+			assert.Equal(t, 201, resp.StatusCode)
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, "ok", string(body))
+		}
+	})
+}


### PR DESCRIPTION
## Motivation

parapet's upstream transports hardcode an internal `net.Dialer`, so callers can't wrap the dial to **observe dial errors**, **re-resolve k8s endpoints**, or **wrap the returned conn**. The flagship parapet-ingress-controller forks the transport just to get this seam. This adds one optional, exported field so that fork can go away.

## What

A single optional field on each network transport:

```go
// DialContext, if non-nil, replaces the default net.Dialer used to open
// TCP connections to the upstream. nil uses an internal net.Dialer built
// from DialTimeout/TCPKeepAlive (today's behavior, unchanged).
DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
```

Added to **`HTTPTransport`**, **`HTTPSTransport`**, **`H2CTransport`**, and the dynamic **`Transport`**.

### Per-transport wiring

Each transport computes the dial func **once** in its `once.Do` init:

```go
dial := t.DialContext
if dial == nil {
    dial = (&net.Dialer{Timeout: t.DialTimeout, KeepAlive: t.TCPKeepAlive}).DialContext
}
```

then uses `dial` everywhere it used to use the inline/`t.dialer` dialer:

- **HTTPTransport / HTTPSTransport** — feeds `http.Transport.DialContext` (HTTPS dials TCP, then the TLS handshake runs on top).
- **H2CTransport** — feeds **both** the h2 `DialTLSContext` plaintext-TCP dial (h2c dials plain TCP, then speaks HTTP/2) **and** the h1 upgrade-fallback `DialContext`.
- **dynamic Transport** — routes **both** the http `DialContext` **and** the h2c `DialTLSContext` plaintext dial through the seam. The unix sub-transport is left dialing `unix` as-is.

### nil = byte-for-byte default

When `DialContext` is nil, the internal dialer is built from the **same** `net.Dialer{Timeout, KeepAlive}` fields as before (or the H2C defaults), so existing behavior is unchanged. `UnixTransport` is intentionally left alone — it always dials a unix socket, so the network-dial seam doesn't apply.

### DialTimeout caveat

A custom dialer is responsible for honoring its own timeouts: **`DialTimeout` is ignored when `DialContext` is set** (documented on each field's godoc).

## Validation

- New tests in `transport_dialcontext_test.go`: for each transport, (a) a recorder dialer is actually invoked (synchronized via atomics, asserts the dialed addr) and a sentinel-error dialer's error surfaces to the caller; (b) the nil path still works against an `httptest.Server`. For H2C and the dynamic Transport the seam is asserted on the **h2c plaintext dial path** specifically (and H2C also on the h1 upgrade fallback).
- New runnable `Example` in `transport_dialcontext_example_test.go` showing the wrap-your-dialer (log dial errors) pattern.
- **Sensitivity check**: temporarily forcing the wiring to ignore `t.DialContext` makes every "custom dialer invoked" / "sentinel error surfaces" subtest fail; restored, all green.
- `go vet ./...` and `go test -race ./...` are green; `golangci-lint run ./pkg/upstream/...` reports 0 issues (fieldalignment ON; structs carry `//nolint:govet`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)