### PR TITLE
feat(upstream): configurable retry policy + GetBody body-rewind

### DIFF
--- a/pkg/upstream/hedging.go
+++ b/pkg/upstream/hedging.go
@@ -33,10 +33,14 @@ func NewHedgingLoadBalancer(next http.RoundTripper) *HedgingLoadBalancer {
 // client.
 //
 // It is a drop-in http.RoundTripper for upstream.New and composes with every
-// balancer. Only idempotent body-less requests are hedged (GET/HEAD/OPTIONS/TRACE,
-// like the retry path), and a request already inside the proxy's retry loop is not
-// additionally hedged — retries and hedges layer, never multiply. HedgeDelay <= 0
-// disables hedging entirely (no timer, no clone, no goroutine).
+// balancer. Only idempotent body-LESS requests are hedged (GET/HEAD/OPTIONS/TRACE
+// with no body); this is deliberately stricter than the Upstream retry path, which
+// also retries rewindable (GetBody) body-bearing requests. A hedge launches a
+// second concurrent leg, and r.Clone only shallow-copies Body, so two legs would
+// share one reader — hedging a body-bearing request without per-leg GetBody rewind
+// would let a leg send a consumed/empty body. A request already inside the proxy's
+// retry loop is not additionally hedged — retries and hedges layer, never multiply.
+// HedgeDelay <= 0 disables hedging entirely (no timer, no clone, no goroutine).
 //
 // The wrapped balancer's Next.RoundTrip MUST honor request-context cancellation
 // (every transport in this package does): a hedge cancels the losing legs, so a
@@ -96,8 +100,18 @@ func (l *HedgingLoadBalancer) hedgeable(r *http.Request) bool {
 	if l.IsHedgeable != nil {
 		return l.IsHedgeable(r)
 	}
-	if !canRetry(r) {
+	// Hedging is body-LESS by default, deliberately STRICTER than the Upstream
+	// retry path's canRetry. A hedge launches a SECOND concurrent leg; r.Clone
+	// only shallow-copies Body, so two legs would share — and race/consume — one
+	// reader. Rewinding via GetBody per leg would be needed to hedge a
+	// body-bearing request safely; until that is implemented, a request carrying a
+	// body (even a rewindable GetBody one) is NOT hedged, so no leg can ever send a
+	// consumed/empty body. Set IsHedgeable to override.
+	if !canMethodRetry(r.Method) {
 		return false
+	}
+	if r.Body != nil && r.Body != http.NoBody {
+		return false // body-bearing: not hedged (see above)
 	}
 	_, retrying := r.Context().Value(retryContextKey{}).(int)
 	return !retrying // a request already inside the retry loop is not re-hedged

--- a/pkg/upstream/retry_example_test.go
+++ b/pkg/upstream/retry_example_test.go
@@ -1,0 +1,29 @@
+package upstream_test
+
+import (
+	"net/http"
+
+	"github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+// ExampleUpstream_retryPolicy widens retry eligibility to idempotent PUT and DELETE.
+// The default policy retries only GET/HEAD/OPTIONS/TRACE (and only when a body, if
+// present, is rewindable via GetBody). A custom RetryPolicy lets the operator opt in
+// to methods they know their upstream applies idempotently — but a retried request
+// can hit upstreams up to Retries+1 times, so only widen this when the upstream is
+// genuinely idempotent for the method.
+func ExampleUpstream_retryPolicy() {
+	up := upstream.SingleHost("backend:8080", &upstream.HTTPTransport{})
+	up.RetryPolicy = func(r *http.Request) bool {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodPut, http.MethodDelete:
+			// A body-bearing PUT is still only safe to retry when it can be rewound;
+			// require GetBody so each re-attempt resends the full body.
+			return r.Body == nil || r.Body == http.NoBody || r.GetBody != nil
+		default:
+			return false
+		}
+	}
+	_ = up
+	// Output:
+}

--- a/pkg/upstream/retry_test.go
+++ b/pkg/upstream/retry_test.go
@@ -1,0 +1,260 @@
+package upstream_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+// bodyRecorder is a transport that fails every attempt (forcing the retry loop to
+// re-serve) while recording the FULL body bytes it received on each attempt. It is
+// the fake-upstream used to prove a retried body-bearing request is rewound to the
+// complete body — not an empty/consumed one — on every attempt.
+type bodyRecorder struct {
+	mu      sync.Mutex
+	bodies  [][]byte // one entry per attempt, in order
+	failAll bool     // when true, every attempt returns a transport error
+}
+
+func (t *bodyRecorder) RoundTrip(r *http.Request) (*http.Response, error) {
+	var b []byte
+	if r.Body != nil {
+		b, _ = io.ReadAll(r.Body) // drain like a real transport would
+		_ = r.Body.Close()
+	}
+	t.mu.Lock()
+	t.bodies = append(t.bodies, b)
+	t.mu.Unlock()
+	if t.failAll {
+		return nil, fmt.Errorf("can not dial to server")
+	}
+	return httptest.NewRecorder().Result(), nil
+}
+
+func (t *bodyRecorder) recorded() [][]byte {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([][]byte, len(t.bodies))
+	copy(out, t.bodies)
+	return out
+}
+
+// fastBackoff is a small backoff so retry tests stay quick yet still exercise the
+// real exponential-backoff timer path.
+const fastBackoff = time.Millisecond
+
+// TestRetry_DefaultBodylessGetUnchanged proves nil RetryPolicy + a body-less GET
+// retries exactly as today: 1 initial attempt + Retries re-attempts.
+func TestRetry_DefaultBodylessGetUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tr := &bodyRecorder{failAll: true}
+	r := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	Upstream{
+		Transport:     tr,
+		Retries:       3,
+		BackoffFactor: fastBackoff,
+	}.ServeHandler(nil).ServeHTTP(w, r)
+
+	assert.Len(t, tr.recorded(), 4, "1 initial + 3 retries (default body-less behavior unchanged)")
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+// TestRetry_CustomPolicyRetriesPUT proves a custom RetryPolicy allowing PUT actually
+// retries a PUT (the default canRetry would reject it).
+func TestRetry_CustomPolicyRetriesPUT(t *testing.T) {
+	t.Parallel()
+
+	tr := &bodyRecorder{failAll: true}
+	// PUT body-less here to isolate the policy decision from body rewinding.
+	r := httptest.NewRequest("PUT", "/", nil)
+	w := httptest.NewRecorder()
+	Upstream{
+		Transport:     tr,
+		Retries:       3,
+		BackoffFactor: fastBackoff,
+		RetryPolicy: func(r *http.Request) bool {
+			return r.Method == http.MethodPut // operator opts PUT in
+		},
+	}.ServeHandler(nil).ServeHTTP(w, r)
+
+	assert.Len(t, tr.recorded(), 4, "custom RetryPolicy makes a PUT retry: 1 + 3")
+}
+
+// TestRetry_BodyBearingWithGetBodyGetsFullBody proves a body-bearing request whose
+// GetBody is set is retried AND each attempt receives the FULL body (not an empty,
+// already-consumed one). This is the rewind correctness guard.
+func TestRetry_BodyBearingWithGetBodyGetsFullBody(t *testing.T) {
+	t.Parallel()
+
+	const payload = "hello-rewindable-world"
+	tr := &bodyRecorder{failAll: true}
+	// Install Body + GetBody + ContentLength explicitly, exactly as mirror.dispatch
+	// does (httptest's server-side constructor sets neither GetBody nor a matching
+	// ContentLength; and httputil.ReverseProxy nils a body whose ContentLength is 0).
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Body = io.NopCloser(strings.NewReader(payload))
+	r.ContentLength = int64(len(payload))
+	r.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(payload)), nil
+	}
+	require.NotNil(t, r.GetBody, "the rewind hook must be present for this test")
+	w := httptest.NewRecorder()
+	Upstream{
+		Transport:     tr,
+		Retries:       3,
+		BackoffFactor: fastBackoff,
+	}.ServeHandler(nil).ServeHTTP(w, r)
+
+	got := tr.recorded()
+	require.Len(t, got, 4, "a rewindable body-bearing GET retries: 1 + 3")
+	for i, b := range got {
+		assert.Equal(t, payload, string(b), "attempt %d must receive the FULL body, not a consumed one", i)
+	}
+}
+
+// TestRetry_BodyWithoutGetBodyNotRetried proves a request WITH a body but WITHOUT
+// GetBody is NOT retried (unchanged from today's body-less-only rule).
+func TestRetry_BodyWithoutGetBodyNotRetried(t *testing.T) {
+	t.Parallel()
+
+	const payload = "payload"
+	tr := &bodyRecorder{failAll: true}
+	// A body WITH a matching ContentLength (so the proxy keeps it) but NO GetBody:
+	// not rewindable, so the default policy must refuse to retry it.
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Body = io.NopCloser(strings.NewReader(payload))
+	r.ContentLength = int64(len(payload))
+	r.GetBody = nil
+	w := httptest.NewRecorder()
+	Upstream{
+		Transport:     tr,
+		Retries:       3,
+		BackoffFactor: fastBackoff,
+	}.ServeHandler(nil).ServeHTTP(w, r)
+
+	assert.Len(t, tr.recorded(), 1, "a body with no GetBody is not rewindable -> not retried")
+}
+
+// TestRetry_GetBodyErrorStopsRetry proves that if the GetBody rewind itself fails on
+// a re-attempt, the loop gives up retrying and surfaces the original transport error
+// (502) instead of looping or re-sending an empty body. The first attempt runs; the
+// rewind for attempt 2 errors -> no further attempts.
+func TestRetry_GetBodyErrorStopsRetry(t *testing.T) {
+	t.Parallel()
+
+	const payload = "payload"
+	tr := &bodyRecorder{failAll: true}
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Body = io.NopCloser(strings.NewReader(payload))
+	r.ContentLength = int64(len(payload))
+	var calls atomic.Int64
+	r.GetBody = func() (io.ReadCloser, error) {
+		if calls.Add(1) == 1 {
+			return nil, fmt.Errorf("rewind boom") // fail the first rewind (for attempt 2)
+		}
+		return io.NopCloser(strings.NewReader(payload)), nil
+	}
+	w := httptest.NewRecorder()
+	Upstream{
+		Transport:     tr,
+		Retries:       3,
+		BackoffFactor: fastBackoff,
+	}.ServeHandler(nil).ServeHTTP(w, r)
+
+	assert.Len(t, tr.recorded(), 1, "a failed rewind stops retrying after the first attempt")
+	assert.Equal(t, http.StatusBadGateway, w.Code, "the original transport error is surfaced")
+}
+
+// countingFake counts calls and honors context cancellation, like ctxFake but in the
+// external test package. Used to assert the hedging leg count.
+type countingFake struct {
+	calls atomic.Int64
+	delay time.Duration
+}
+
+func (t *countingFake) RoundTrip(r *http.Request) (*http.Response, error) {
+	t.calls.Add(1)
+	if t.delay > 0 {
+		select {
+		case <-time.After(t.delay):
+		case <-r.Context().Done():
+			return nil, r.Context().Err()
+		}
+	}
+	if r.Body != nil {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+	}
+	return httptest.NewRecorder().Result(), nil
+}
+
+func hedgeLB(trs ...http.RoundTripper) *RoundRobinLoadBalancer {
+	targets := make([]*Target, len(trs))
+	for i, tr := range trs {
+		targets[i] = &Target{Host: fmt.Sprintf("t%d", i), Transport: tr}
+	}
+	return NewRoundRobinLoadBalancer(targets)
+}
+
+// TestRetry_HedgingDoesNotHedgeBodyBearing is the OPTION (b) correctness guard: a
+// body-bearing request (even one carrying a rewindable GetBody) is NOT hedged, so no
+// second concurrent leg can share — and consume to empty — the single shared Body.
+// The primary leg is slow so a hedge WOULD fire if the request were eligible; we
+// assert it never does.
+func TestRetry_HedgingDoesNotHedgeBodyBearing(t *testing.T) {
+	t.Parallel()
+
+	primary := &countingFake{delay: 200 * time.Millisecond} // would lose to a hedge if one fired
+	hedge := &countingFake{}
+	h := NewHedgingLoadBalancer(hedgeLB(primary, hedge))
+	h.HedgeDelay = 5 * time.Millisecond // a hedge would fire well before the primary finishes
+
+	// A GET with a rewindable body (GetBody set, as mirror.dispatch installs):
+	// eligible for the Upstream retry path — but body-bearing, so deliberately NOT
+	// hedgeable.
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Body = io.NopCloser(bytes.NewReader([]byte("payload")))
+	r.ContentLength = int64(len("payload"))
+	r.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("payload"))), nil
+	}
+	require.NotNil(t, r.GetBody)
+	resp, err := h.RoundTrip(r)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.EqualValues(t, 1, primary.calls.Load(), "the single (primary) leg served the body-bearing request")
+	assert.EqualValues(t, 0, hedge.calls.Load(), "a body-bearing request is NEVER hedged (option b)")
+}
+
+// TestRetry_HedgingStillHedgesBodylessGet confirms the option (b) change did not
+// disable hedging for the body-LESS GET it has always supported.
+func TestRetry_HedgingStillHedgesBodylessGet(t *testing.T) {
+	t.Parallel()
+
+	slow := &countingFake{delay: time.Second} // primary loses
+	fast := &countingFake{}                    // hedge wins
+	h := NewHedgingLoadBalancer(hedgeLB(slow, fast))
+	h.HedgeDelay = 10 * time.Millisecond
+
+	resp, err := h.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.EqualValues(t, 1, slow.calls.Load(), "primary leg ran")
+	assert.EqualValues(t, 1, fast.calls.Load(), "the body-less GET was hedged as before")
+}

--- a/pkg/upstream/upstream.go
+++ b/pkg/upstream/upstream.go
@@ -21,11 +21,31 @@ var (
 
 // Upstream controls request flow to upstream server via load balancer
 type Upstream struct {
-	Transport     http.RoundTripper
-	ErrorLog      *log.Logger
-	OnRoundTrip   RoundTripFunc // observe each origin round-trip (nil disables); see prom.Upstream
-	Host          string        // override host
-	Path          string        // target prefix path
+	Transport   http.RoundTripper
+	ErrorLog    *log.Logger
+	OnRoundTrip RoundTripFunc // observe each origin round-trip (nil disables); see prom.Upstream
+
+	// RetryPolicy decides whether a request is eligible to be retried after a
+	// transport error. nil uses the default canRetry: an idempotent method
+	// (GET/HEAD/OPTIONS/TRACE) AND a body that is either absent or rewindable
+	// (r.Body is nil/http.NoBody, OR r.GetBody != nil). Set it to widen
+	// eligibility — e.g. to retry an idempotent PUT/DELETE — or to narrow it.
+	//
+	// RETRY AMPLIFICATION — READ BEFORE WIDENING. An eligible request may be sent
+	// to upstreams up to Retries+1 times (one initial attempt plus Retries
+	// re-attempts). If the same Upstream is also fronted by a HedgingLoadBalancer,
+	// each of those attempts can additionally fan out to MaxHedge speculative
+	// copies, so the worst-case origin load multiplies (≈ (Retries+1) × (MaxHedge+1)).
+	// Size Retries (and MaxHedge) for that ceiling, and only mark a request
+	// retryable here when the upstream is genuinely idempotent for it — a retried
+	// non-idempotent request can double-apply a side effect (a duplicate POST, a
+	// second charge). A body-bearing request is only retried when r.GetBody is set
+	// (so each attempt can be rewound to the full body); without GetBody, even an
+	// eligible method is not retried.
+	RetryPolicy func(r *http.Request) bool
+
+	Host          string // override host
+	Path          string // target prefix path
 	Retries       int
 	BackoffFactor time.Duration
 }
@@ -86,18 +106,32 @@ func (m Upstream) ServeHandler(h http.Handler) http.Handler {
 				return
 			}
 
-			if canRetry(r) {
+			if m.retryable(r) {
 				ctx := r.Context()
 				retry, _ := ctx.Value(retryContextKey{}).(int)
 				if retry < m.Retries {
 					select {
 					case <-ctx.Done():
 						// client canceled request
+						return
 					case <-time.After(m.BackoffFactor * time.Duration(1<<uint(retry))):
+						// Rewind a body-bearing request before re-attempting: the
+						// previous attempt consumed r.Body, so a fresh copy from
+						// GetBody is required or the retry would send an empty body.
+						// If the rewind fails, give up retrying and fall through to
+						// surface the original transport error below.
+						if r.GetBody != nil {
+							body, gerr := r.GetBody()
+							if gerr != nil {
+								m.logf("upstream: retry rewind: %v", gerr)
+								break
+							}
+							r.Body = body
+						}
 						r = r.WithContext(context.WithValue(ctx, retryContextKey{}, retry+1))
 						p.ServeHTTP(w, r)
+						return
 					}
-					return
 				}
 			}
 
@@ -172,12 +206,31 @@ func singleJoiningSlash(a, b string) string {
 
 type retryContextKey struct{}
 
+// retryable reports whether r may be retried, consulting the operator's
+// RetryPolicy when set and falling back to the default canRetry otherwise.
+func (m *Upstream) retryable(r *http.Request) bool {
+	if m.RetryPolicy != nil {
+		return m.RetryPolicy(r)
+	}
+	return canRetry(r)
+}
+
+// canRetry is the default retry-eligibility rule: an idempotent method whose
+// body is either absent or rewindable. A body-bearing request qualifies only
+// when r.GetBody is set (the stdlib rewind hook), so each re-attempt can be
+// reset to the full body before being sent again — otherwise a retry would
+// transmit a consumed/empty body. The method set (GET/HEAD/OPTIONS/TRACE) is
+// unchanged; retrying an idempotent PUT/DELETE is opt-in via a custom
+// Upstream.RetryPolicy.
 func canRetry(r *http.Request) bool {
 	if !canMethodRetry(r.Method) {
 		return false
 	}
-
-	return r.Body == http.NoBody || r.Body == nil
+	if r.Body == http.NoBody || r.Body == nil {
+		return true
+	}
+	// A body-bearing request is retryable only if it can be rewound.
+	return r.GetBody != nil
 }
 
 func canMethodRetry(method string) bool {


### PR DESCRIPTION
## Today's limitation

The `Upstream` retry loop is hard-wired: `canRetry` retries a request only when its method is safe (`GET`/`HEAD`/`OPTIONS`/`TRACE`) **AND** it is body-LESS (`r.Body` is `nil`/`http.NoBody`). Any body-bearing request is never retried — even a rewindable one. That is why `mirror.go` sets `r.GetBody` "so the proxy can retry" but it has been a **no-op**: `canRetry` rejected the request before GetBody could ever matter.

## What this adds

### 1. A retry-policy seam — `Upstream.RetryPolicy func(*http.Request) bool`
`nil` preserves the current `canRetry` behavior byte-for-byte. When set, the operator decides eligibility — e.g. to retry an idempotent `PUT`/`DELETE`. The retry loop consults `m.RetryPolicy` and falls back to `canRetry`.

> **Retry amplification — read before widening.** An eligible request may be sent to upstreams up to `Retries+1` times (one initial attempt + `Retries`). If the same `Upstream` is also fronted by a `HedgingLoadBalancer`, each attempt can additionally fan out to `MaxHedge` speculative copies, so worst-case origin load multiplies (≈ `(Retries+1) × (MaxHedge+1)`). Size `Retries`/`MaxHedge` for that ceiling, and only mark a request retryable when the upstream is genuinely idempotent for it.

### 2. Body rewind via `GetBody`
The default `canRetry` now also accepts a body-bearing request **when `r.GetBody != nil`** (the stdlib rewind hook). The method set stays `GET`/`HEAD`/`OPTIONS`/`TRACE`, so `PUT`/`DELETE` remains opt-in via a custom `RetryPolicy`. Before **each** re-attempt the loop rewinds:

```go
if r.GetBody != nil {
    body, err := r.GetBody()
    if err != nil { /* stop retrying; surface the original transport error */ }
    r.Body = body
}
```

This finally makes `mirror.go`'s `GetBody` meaningful — a mirrored body-bearing request is now retryable, and every attempt resends the **full** body, never a consumed/empty one.

## Hedging decision — option (b), body-LESS hedging (the body-corruption hazard it avoids)

Hedging shares the `canRetry` gate, so loosening `canRetry` would make hedging start speculating on body-bearing requests. **A hedge launches a SECOND concurrent leg, and `r.Clone` only shallow-copies `Body`** (per the stdlib docs), so two legs would share one reader — the second leg would send an empty/consumed body → corruption.

This PR keeps hedging **body-LESS**: `hedgeable()` is decoupled from the loosened `canRetry` and explicitly rejects body-bearing requests (even rewindable `GetBody` ones). The GetBody-rewind feature is confined to the sequential `Upstream` retry loop. A body-bearing request is therefore **never hedged**, proven by test. (Option (a) — per-leg `GetBody` rewind for each hedge — was rejected as out-of-scope and harder to verify safe under `-race`.)

## Validation

- `go test -race ./...` — 964 tests pass.
- `go vet ./...` clean; `golangci-lint` clean on the changed packages.
- New tests live in `retry_test.go` / `retry_example_test.go`; `example_test.go` untouched:
  - nil RetryPolicy + body-less GET retries exactly as today (`1 + Retries`)
  - a custom RetryPolicy allowing PUT actually retries a PUT
  - a body-bearing request with `GetBody` is retried AND each attempt receives the FULL body (fake upstream records the body per attempt)
  - a body WITHOUT `GetBody` is not retried (unchanged)
  - a `GetBody` rewind error stops retrying and surfaces the original 502
  - a body-bearing request is NOT hedged; a body-less GET still is
- Sensitivity (mutation, reverted): breaking the body rewind fails the full-body-on-retry test; ignoring `m.RetryPolicy` fails the custom-PUT test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)