### PR TITLE
feat(upstream): bulkhead saturation observability (inflight gauge + shed cause)

### DIFF
--- a/pkg/prom/upstream_inflight.go
+++ b/pkg/prom/upstream_inflight.go
@@ -1,0 +1,156 @@
+package prom
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/moonrhythm/parapet/pkg/upstream"
+)
+
+// --- (1) per-target in-flight gauge: a scrape-time Collector, zero hot-path cost ---
+
+// inflightMetrics is a single process-global scrape-time Collector fed by a list of
+// LeastConn balancers. One collector (registered once) rather than one-per-balancer:
+// two collectors exporting the same Desc would panic at MustRegister, so a list lets
+// an operator observe several upstream pools and keeps the test and the example from
+// colliding.
+//
+//nolint:govet // fields grouped for readability, not pointer-packing
+type inflightMetrics struct {
+	once     sync.Once
+	inflight *prometheus.Desc
+	capacity *prometheus.Desc
+	mu       sync.Mutex
+	lbs      []*upstream.LeastConnLoadBalancer
+}
+
+var _upstreamInflight inflightMetrics
+
+func (p *inflightMetrics) init() {
+	p.once.Do(func() {
+		p.inflight = prometheus.NewDesc(
+			Namespace+"_upstream_inflight",
+			"Current in-flight requests per least-conn target (bulkhead occupancy).",
+			[]string{"host"}, nil)
+		p.capacity = prometheus.NewDesc(
+			Namespace+"_upstream_inflight_capacity",
+			"MaxConcurrent bulkhead cap per least-conn target (bounded targets only).",
+			[]string{"host"}, nil)
+		reg.MustRegister(p)
+	})
+}
+
+func (p *inflightMetrics) add(lb *upstream.LeastConnLoadBalancer) {
+	p.mu.Lock()
+	p.lbs = append(p.lbs, lb)
+	p.mu.Unlock()
+}
+
+func (p *inflightMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- p.inflight
+	ch <- p.capacity
+}
+
+func (p *inflightMetrics) Collect(ch chan<- prometheus.Metric) {
+	p.mu.Lock()
+	lbs := append([]*upstream.LeastConnLoadBalancer(nil), p.lbs...)
+	p.mu.Unlock()
+	// Dedup by host: a host registered twice (a re-registered balancer, or one host
+	// appearing in two pools) would otherwise emit a duplicate label set and fail the
+	// scrape's Gather. First writer wins.
+	seen := make(map[string]struct{})
+	for _, lb := range lbs {
+		for _, t := range lb.Inflight() { // live atomic snapshot, read at scrape time
+			if _, dup := seen[t.Host]; dup {
+				continue
+			}
+			seen[t.Host] = struct{}{}
+			ch <- prometheus.MustNewConstMetric(p.inflight, prometheus.GaugeValue, float64(t.Active), t.Host)
+			// Emit capacity only for bounded targets: an unbounded target (Cap==0) has
+			// no saturation point, and a cap=0 series would mislead an inflight/capacity
+			// panel.
+			if t.Cap > 0 {
+				ch <- prometheus.MustNewConstMetric(p.capacity, prometheus.GaugeValue, float64(t.Cap), t.Host)
+			}
+		}
+	}
+}
+
+// UpstreamInflight registers a LeastConnLoadBalancer with a scrape-time collector
+// that exports its live bulkhead occupancy on the shared registry:
+//
+//	lb := upstream.NewLeastConnLoadBalancer(targets)
+//	prom.UpstreamInflight(lb)
+//	s.Use(upstream.New(lb))
+//
+// It exports two gauges, both read live at scrape time from lb.Inflight() — nothing
+// runs on the claim/dec hot path:
+//
+//	{namespace}_upstream_inflight{host}           in-flight requests on the target right now
+//	{namespace}_upstream_inflight_capacity{host}  the target's MaxConcurrent cap (bounded targets only)
+//
+// Saturation of a target is inflight/inflight_capacity; a target pinned at 1.0 is the
+// one driving any upstream_shed_total{reason="saturated"} (see prom.UpstreamShed). The
+// host label is the operator-configured upstream target (bounded). Call it for each
+// LeastConn pool you want observed; the single underlying collector is registered once
+// per process. Host labels must be unique across registered pools: if the same host
+// appears in two pools the collector dedups it (first registered pool wins, INCLUDING
+// its inflight and capacity values) to keep the scrape valid. Keeping the wiring here
+// leaves pkg/upstream free of any Prometheus dependency.
+func UpstreamInflight(lb *upstream.LeastConnLoadBalancer) {
+	_upstreamInflight.init()
+	_upstreamInflight.add(lb)
+}
+
+// --- (2) shed counter: a cheap push hook ---
+
+//nolint:govet
+type upstreamShedMetrics struct {
+	once  sync.Once
+	sheds *prometheus.CounterVec
+}
+
+var _upstreamShed upstreamShedMetrics
+
+func (p *upstreamShedMetrics) init() {
+	p.once.Do(func() {
+		p.sheds = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Name:      "upstream_shed_total",
+		}, []string{"reason"})
+		reg.MustRegister(p.sheds)
+	})
+}
+
+func (p *upstreamShedMetrics) observe(reason upstream.ShedReason) {
+	if c, err := p.sheds.GetMetricWith(prometheus.Labels{"reason": reason.String()}); err == nil {
+		c.Inc()
+	}
+}
+
+// UpstreamShed returns an upstream.ShedFunc that counts LeastConnLoadBalancer sheds
+// on the shared registry, for wiring into LeastConnLoadBalancer.OnShed:
+//
+//	lb := upstream.NewLeastConnLoadBalancer(targets)
+//	lb.OnShed = prom.UpstreamShed()
+//	s.Use(upstream.New(lb))
+//
+// It registers one metric (lazily, once per process):
+//
+//	{namespace}_upstream_shed_total{reason}  counter of pre-round-trip sheds, reason:
+//	    "saturated" — every gate-up target was at its MaxConcurrent cap (the brownout)
+//	    "empty"     — the pool had no targets configured
+//	    "all_dark"  — the active-HC gate marked the whole pool down
+//
+// This disambiguates a capacity brownout (reason="saturated") from a dead/empty pool
+// (reason="empty"/"all_dark") and from a circuit-breaker all-open shed (a different
+// balancer, reported via prom.UpstreamState) — all of which otherwise collapse into
+// prom.Upstream's host-less upstream_fast_rejects_total{host=""}. Alert on the RATE of
+// reason="saturated" to catch sustained bulkhead overload. The reason label is a
+// closed three-value set, so the series can never grow unbounded. The wiring here
+// leaves pkg/upstream free of any Prometheus dependency.
+func UpstreamShed() upstream.ShedFunc {
+	_upstreamShed.init()
+	return _upstreamShed.observe
+}

--- a/pkg/prom/upstream_inflight_test.go
+++ b/pkg/prom/upstream_inflight_test.go
@@ -1,0 +1,102 @@
+package prom_test
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/upstream"
+
+	. "github.com/moonrhythm/parapet/pkg/prom"
+)
+
+func TestUpstreamShed(t *testing.T) {
+	observe := UpstreamShed()
+	require.NotNil(t, observe)
+
+	for _, r := range []upstream.ShedReason{upstream.ShedSaturated, upstream.ShedEmpty, upstream.ShedAllDark} {
+		lbl := map[string]string{"reason": r.String()}
+		base := counterValue(t, "parapet_upstream_shed_total", lbl)
+		observe(r)
+		got := counterValue(t, "parapet_upstream_shed_total", lbl)
+		assert.EqualValues(t, 1, countDelta(base, got), "shed reason %q records into its own series once", r.String())
+	}
+}
+
+// noopRT is a transport that never actually serves — the inflight test only reads the
+// gauge from configured state, with no traffic.
+type noopRT struct{}
+
+func (noopRT) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Body: http.NoBody, Header: http.Header{}}, nil
+}
+
+// registered once across -count runs (the underlying collector registers once; a
+// second registration of the same balancer/hosts would duplicate the scrape).
+var inflightOnce sync.Once
+
+func TestUpstreamInflight(t *testing.T) {
+	inflightOnce.Do(func() {
+		lb := upstream.NewLeastConnLoadBalancer([]*upstream.Target{
+			{Host: "prom-inflight-bounded", Transport: noopRT{}, MaxConcurrent: 5},
+			{Host: "prom-inflight-unbounded", Transport: noopRT{}}, // Cap 0
+		})
+		UpstreamInflight(lb)
+	})
+
+	// No traffic: inflight 0 for both; the bounded target has a capacity series, the
+	// unbounded one does not (gaugeValue returns -1 for an absent series).
+	assert.EqualValues(t, 0, gaugeValue(t, "parapet_upstream_inflight",
+		map[string]string{"host": "prom-inflight-bounded"}))
+	assert.EqualValues(t, 5, gaugeValue(t, "parapet_upstream_inflight_capacity",
+		map[string]string{"host": "prom-inflight-bounded"}))
+	assert.EqualValues(t, 0, gaugeValue(t, "parapet_upstream_inflight",
+		map[string]string{"host": "prom-inflight-unbounded"}))
+	assert.EqualValues(t, -1, gaugeValue(t, "parapet_upstream_inflight_capacity",
+		map[string]string{"host": "prom-inflight-unbounded"}),
+		"an unbounded target emits no capacity series")
+}
+
+// registered once across -count runs.
+var dedupOnce sync.Once
+
+// The load-bearing guarantee of the single-global-collector design: registering the
+// SAME host via two balancers must NOT produce a duplicate label set (which fails the
+// whole scrape's Gather with "collected before with the same label values"). The
+// collector dedups by host, first writer wins.
+func TestUpstreamInflight_DedupSameHost(t *testing.T) {
+	dedupOnce.Do(func() {
+		lb1 := upstream.NewLeastConnLoadBalancer([]*upstream.Target{
+			{Host: "prom-inflight-dup", Transport: noopRT{}, MaxConcurrent: 7},
+		})
+		lb2 := upstream.NewLeastConnLoadBalancer([]*upstream.Target{
+			{Host: "prom-inflight-dup", Transport: noopRT{}, MaxConcurrent: 99},
+		})
+		UpstreamInflight(lb1)
+		UpstreamInflight(lb2)
+	})
+
+	// gaugeValue's internal Registry().Gather() require.NoError fails if the dedup is
+	// removed (the duplicate series errors the scrape). First writer (lb1) wins.
+	assert.EqualValues(t, 0, gaugeValue(t, "parapet_upstream_inflight",
+		map[string]string{"host": "prom-inflight-dup"}))
+	assert.EqualValues(t, 7, gaugeValue(t, "parapet_upstream_inflight_capacity",
+		map[string]string{"host": "prom-inflight-dup"}),
+		"a duplicate host dedups to the first writer; the scrape stays valid")
+}
+
+// Bulkhead saturation observability: a live per-target in-flight gauge plus a
+// shed-by-cause counter, so a dashboard shows which target is pinned at its cap and
+// whether the balancer is shedding because it's saturated vs an empty/dark pool.
+func ExampleUpstreamInflight() {
+	lb := upstream.NewLeastConnLoadBalancer([]*upstream.Target{
+		{Host: "10.0.0.1:8080", Transport: &upstream.HTTPTransport{}, MaxConcurrent: 100},
+		{Host: "10.0.0.2:8080", Transport: &upstream.HTTPTransport{}, MaxConcurrent: 100},
+	})
+	UpstreamInflight(lb)       // gauges: parapet_upstream_inflight{host} + _capacity{host}
+	lb.OnShed = UpstreamShed() // counter: parapet_upstream_shed_total{reason}
+	_ = lb                     // s.Use(upstream.New(lb))
+}

--- a/pkg/upstream/bulkhead_test.go
+++ b/pkg/upstream/bulkhead_test.go
@@ -274,7 +274,7 @@ func TestLeastConnBulkhead(t *testing.T) {
 		l.peers[1].active.Store(5) // at cap
 		l.i.Store(math.MaxUint32)  // next pick computes start = Add(1)-1 = MaxUint32
 
-		p, ok := l.pick(3)
+		p, ok, _ := l.pick(3)
 		require.True(t, ok, "the lone under-cap peer must be found despite the cursor wrap")
 		assert.Same(t, &l.peers[2], p, "t2 (the only under-cap peer) is selected, not a false shed")
 	})

--- a/pkg/upstream/leastconn.go
+++ b/pkg/upstream/leastconn.go
@@ -37,6 +37,13 @@ type LeastConnLoadBalancer struct {
 
 	// Targets is the set of upstreams to balance across.
 	Targets []*Target
+
+	// OnShed observes a shed (this balancer returned ErrUnavailable before any
+	// round-trip): ShedEmpty for no targets, ShedSaturated when every gate-up target
+	// is at its MaxConcurrent cap, ShedAllDark when the active-HC gate marked the
+	// whole pool down. Nil disables it at zero hot-path cost; see prom.UpstreamShed.
+	// It fires synchronously on the request goroutine, before ErrUnavailable returns.
+	OnShed ShedFunc
 }
 
 // lcPeer holds one target's least-connection state.
@@ -64,12 +71,14 @@ func (l *LeastConnLoadBalancer) RoundTrip(r *http.Request) (*http.Response, erro
 	l.once.Do(l.init)
 	n := len(l.peers)
 	if n == 0 {
+		l.shed(ShedEmpty)
 		return nil, ErrUnavailable
 	}
 
-	p, ok := l.pick(n)
+	p, ok, reason := l.pick(n)
 	if !ok {
-		return nil, ErrUnavailable // every target at its MaxConcurrent cap -> shed (503)
+		l.shed(reason) // saturated (all at cap) or all_dark (probe-dark pool) -> shed (503)
+		return nil, ErrUnavailable
 	}
 	// pick already claimed the slot (active +1) atomically, so the cap is never
 	// exceeded; the matching decrement is the dec below (panic-safe + at body close).
@@ -128,7 +137,7 @@ func (l *LeastConnLoadBalancer) RoundTrip(r *http.Request) (*http.Response, erro
 // candidate set non-monotonic. But total in-flight is bounded by sum(cap) and every
 // losing CAS corresponds to a sibling that made progress (a claim or release), so
 // the system is livelock-free.
-func (l *LeastConnLoadBalancer) pick(n int) (*lcPeer, bool) {
+func (l *LeastConnLoadBalancer) pick(n int) (*lcPeer, bool, ShedReason) {
 	start := l.i.Add(1) - 1
 	// failOpen ignores the active-HC gate for this pick. It engages only when the
 	// gate has marked EVERY target down: a saturated-but-healthy pool sheds (the
@@ -170,10 +179,17 @@ func (l *LeastConnLoadBalancer) pick(n int) (*lcPeer, bool) {
 				failOpen = true
 				continue
 			}
-			return nil, false // saturated, or down-and-saturated -> shed
+			// sawUp here means this (possibly fail-open) scan saw a gate-up peer, all
+			// at cap -> saturated; !sawUp means we reached here via the fail-open
+			// re-scan with the whole pool gate-down -> all_dark. A nil gate makes
+			// sawUp always true, so a no-HC pool always sheds saturated.
+			if sawUp {
+				return nil, false, ShedSaturated
+			}
+			return nil, false, ShedAllDark
 		}
 		if l.claim(best, bestA) {
-			return best, true
+			return best, true, 0 // reason ignored when ok==true
 		}
 		// best filled between the read and the CAS; re-scan (it will now be skipped).
 	}

--- a/pkg/upstream/leastconn_observe.go
+++ b/pkg/upstream/leastconn_observe.go
@@ -1,0 +1,87 @@
+package upstream
+
+// ShedReason classifies why LeastConnLoadBalancer shed a request before any
+// round-trip (it returned ErrUnavailable, which the proxy maps to 503). It is a
+// CLOSED set — a bounded Prometheus label, never unbounded — reported via ShedFunc.
+// A capacity shed is pool-wide (no single host), so it is named by reason only.
+type ShedReason uint8
+
+const (
+	// ShedEmpty: the pool has no targets at all (len(peers) == 0). A
+	// misconfiguration or torn-down pool, not load — distinct from a saturated one.
+	ShedEmpty ShedReason = iota
+	// ShedSaturated: every gate-up target is at its MaxConcurrent cap. The bulkhead
+	// working as designed under overload — the brownout signal.
+	ShedSaturated
+	// ShedAllDark: the active-HC gate marked every target down and the fail-open
+	// re-scan still found nothing admittable. A probe-dark/dead pool, distinct from a
+	// merely-saturated healthy one. Unreachable without an active-HC gate installed
+	// (a nil gate is "all up", so a no-HC pool sheds as ShedSaturated, never here).
+	// The saturated/all_dark split is best-effort under health-state churn: a gate
+	// that flips up between the gated scan and the fail-open re-scan can briefly
+	// attribute a freshly-saturated shed to all_dark (the shed itself is unaffected).
+	ShedAllDark
+)
+
+func (r ShedReason) String() string {
+	switch r {
+	case ShedSaturated:
+		return "saturated"
+	case ShedAllDark:
+		return "all_dark"
+	default:
+		return "empty"
+	}
+}
+
+// ShedFunc observes a LeastConnLoadBalancer shed: the balancer returned
+// ErrUnavailable for the given reason before any round-trip. Assign one to
+// LeastConnLoadBalancer.OnShed to make bulkhead saturation observable — see
+// prom.UpstreamShed. It is invoked synchronously on the request goroutine at the
+// shed site, exactly once per shed, before ErrUnavailable is returned, and never on
+// a successful pick or on pick's internal CAS re-scan. Nil disables it at zero
+// hot-path cost. Sheds can be high-frequency under sustained overload, so the callee
+// must be cheap and allocation-free (the prom impl is a single counter Inc). The
+// callee owns its own concurrency.
+type ShedFunc func(ShedReason)
+
+// TargetLoad is one target's live bulkhead occupancy, returned by
+// LeastConnLoadBalancer.Inflight for scrape-time observability and tests. Cap is 0
+// when the target is unbounded (Target.MaxConcurrent <= 0). Active is a point-in-time
+// atomic load taken without locking, so across a returned slice the Active values are
+// each individually exact but not a single frozen pool-wide instant — which is exactly
+// what a per-target saturation gauge wants (each bulkhead is independent).
+//
+//nolint:govet // fields ordered for readability, not pointer-packing
+type TargetLoad struct {
+	Host   string // resolved upstream target (operator-configured, bounded label)
+	Active int64  // in-flight requests right now
+	Cap    int64  // MaxConcurrent bulkhead cap; 0 == unbounded
+}
+
+// Inflight returns a live snapshot of every target's current in-flight count and
+// bulkhead cap, for scrape-time metrics (see prom.UpstreamInflight) or tests. It is
+// safe to call concurrently with serving: each Active is a lone atomic load that adds
+// no contention to the claim/dec hot path, and Cap is immutable after init. It is
+// also safe before the first request — it forces init (l.once), so the configured
+// targets are always present (Active 0 until traffic arrives), and a scrape that
+// races the first RoundTrip never sees a nil peers slice. The returned slice is
+// freshly allocated and owned by the caller; call it at scrape cadence, never on the
+// request path.
+func (l *LeastConnLoadBalancer) Inflight() []TargetLoad {
+	l.once.Do(l.init) // config-only; idempotent with RoundTrip's own l.once.Do(l.init)
+	out := make([]TargetLoad, len(l.peers))
+	for i := range l.peers {
+		p := &l.peers[i]
+		out[i] = TargetLoad{Host: p.target.Host, Active: p.active.Load(), Cap: p.cap}
+	}
+	return out
+}
+
+// shed fires OnShed if wired. Cold and allocation-free; the nil-check keeps the shed
+// path free of cost when no observer is attached.
+func (l *LeastConnLoadBalancer) shed(reason ShedReason) {
+	if l.OnShed != nil {
+		l.OnShed(reason)
+	}
+}

--- a/pkg/upstream/leastconn_observe_test.go
+++ b/pkg/upstream/leastconn_observe_test.go
@@ -1,0 +1,157 @@
+package upstream
+
+import (
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shedRecorder captures the reasons OnShed fired with.
+type shedRecorder struct {
+	mu sync.Mutex
+	r  []ShedReason
+}
+
+func (s *shedRecorder) fn() ShedFunc {
+	return func(r ShedReason) {
+		s.mu.Lock()
+		s.r = append(s.r, r)
+		s.mu.Unlock()
+	}
+}
+
+func (s *shedRecorder) all() []ShedReason {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]ShedReason(nil), s.r...)
+}
+
+func TestShedReasonString(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "empty", ShedEmpty.String())
+	assert.Equal(t, "saturated", ShedSaturated.String())
+	assert.Equal(t, "all_dark", ShedAllDark.String())
+	assert.Equal(t, "empty", ShedReason(99).String(), "an out-of-range value never produces an unbounded label")
+}
+
+func TestInflightSnapshotInitial(t *testing.T) {
+	t.Parallel()
+	l := NewLeastConnLoadBalancer([]*Target{
+		{Host: "t0", Transport: freshBody(), MaxConcurrent: 3},
+		{Host: "t1", Transport: freshBody()}, // unbounded
+	})
+	got := l.Inflight() // forces init; no traffic, no panic on a fresh balancer
+	require.Len(t, got, 2)
+	assert.Equal(t, TargetLoad{Host: "t0", Active: 0, Cap: 3}, got[0])
+	assert.Equal(t, TargetLoad{Host: "t1", Active: 0, Cap: 0}, got[1], "unbounded target reports Cap 0")
+}
+
+func TestInflightSnapshotLive(t *testing.T) {
+	t.Parallel()
+	tr := &blockingTransport{release: make(chan struct{})}
+	l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: tr, MaxConcurrent: 3}})
+
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+			if err == nil && resp != nil && resp.Body != nil {
+				resp.Body.Close() // releases the slot (dec on body close)
+			}
+		}()
+	}
+	// Both requests claimed a slot and are now blocked in the transport.
+	require.Eventually(t, func() bool { return l.Inflight()[0].Active == 2 }, time.Second, time.Millisecond,
+		"the snapshot reflects live claims")
+	close(tr.release)
+	wg.Wait()
+	require.Eventually(t, func() bool { return l.Inflight()[0].Active == 0 }, time.Second, time.Millisecond,
+		"the snapshot reflects the dec when the body is closed")
+}
+
+func TestOnShedSaturated(t *testing.T) {
+	t.Parallel()
+	var rec shedRecorder
+	l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: freshBody(), MaxConcurrent: 1}})
+	l.OnShed = rec.fn()
+	l.once.Do(l.init)
+	l.peers[0].active.Store(1) // pin the single slot at cap
+
+	resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	assert.Nil(t, resp)
+	assert.Equal(t, ErrUnavailable, err)
+	assert.Equal(t, []ShedReason{ShedSaturated}, rec.all(), "one shed, reason saturated")
+
+	// Free the slot; a request now succeeds and fires NO shed.
+	l.peers[0].active.Store(0)
+	resp2, err2 := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	require.NoError(t, err2)
+	if resp2 != nil && resp2.Body != nil {
+		resp2.Body.Close()
+	}
+	assert.Equal(t, []ShedReason{ShedSaturated}, rec.all(), "a successful pick fires no shed")
+}
+
+func TestOnShedEmpty(t *testing.T) {
+	t.Parallel()
+	var rec shedRecorder
+	l := NewLeastConnLoadBalancer(nil)
+	l.OnShed = rec.fn()
+
+	resp, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+	assert.Nil(t, resp)
+	assert.Equal(t, ErrUnavailable, err)
+	assert.Equal(t, []ShedReason{ShedEmpty}, rec.all())
+}
+
+func TestOnShedAllDarkVsSaturated(t *testing.T) {
+	t.Parallel()
+
+	// All three reach pick's give-up path with the single target at cap; only the
+	// active-HC gate state distinguishes saturated (gate up / no gate) from all_dark
+	// (gate down — the fail-open re-scan still finds nothing admittable).
+	newSaturated := func() (*LeastConnLoadBalancer, *shedRecorder) {
+		rec := &shedRecorder{}
+		l := NewLeastConnLoadBalancer([]*Target{{Host: "t0", Transport: freshBody(), MaxConcurrent: 1}})
+		l.OnShed = rec.fn()
+		l.once.Do(l.init)
+		l.peers[0].active.Store(1) // at cap
+		return l, rec
+	}
+
+	t.Run("gate down and saturated -> all_dark", func(t *testing.T) {
+		t.Parallel()
+		l, rec := newSaturated()
+		gate := make([]atomic.Bool, 1) // zero value false == down
+		l.setHealthGate(gate)
+		_, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Equal(t, ErrUnavailable, err)
+		assert.Equal(t, []ShedReason{ShedAllDark}, rec.all())
+	})
+
+	t.Run("gate up and saturated -> saturated", func(t *testing.T) {
+		t.Parallel()
+		l, rec := newSaturated()
+		gate := make([]atomic.Bool, 1)
+		gate[0].Store(true) // up
+		l.setHealthGate(gate)
+		_, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Equal(t, ErrUnavailable, err)
+		assert.Equal(t, []ShedReason{ShedSaturated}, rec.all())
+	})
+
+	t.Run("no gate and saturated -> saturated", func(t *testing.T) {
+		t.Parallel()
+		l, rec := newSaturated()
+		_, err := l.RoundTrip(httptest.NewRequest("GET", "/", nil))
+		assert.Equal(t, ErrUnavailable, err)
+		assert.Equal(t, []ShedReason{ShedSaturated}, rec.all())
+	})
+}


### PR DESCRIPTION
## Why (backlog item #4 — the last feature before v0.18.0)

LeastConn's `MaxConcurrent` bulkhead was invisible:
- **No per-target in-flight signal** — yet "which target is pinned at its cap" is the first brownout question, and the answer already sits in `lcPeer.active`.
- **The capacity shed is conflated** — when every target is at cap, `RoundTrip` sheds `ErrUnavailable`, which `prom.Upstream()` counts in `upstream_fast_rejects_total{host=""}` (upstream clears `r.URL.Host` before pick), indistinguishable from an empty-pool or a circuit-breaker all-open shed.

## What

**Per-target in-flight gauge** — new `(*LeastConnLoadBalancer).Inflight()` returns a live snapshot (`[]TargetLoad{Host,Active,Cap}`) of the existing `active` atomics; `prom.UpstreamInflight(lb)` wires a **scrape-time `prometheus.Collector`** reading it → `parapet_upstream_inflight{host}` + `parapet_upstream_inflight_capacity{host}` (capacity for bounded targets only). **Zero hot-path cost** — nothing on the `claim`/`dec` path; the collector reads the atomics live at scrape.

**Shed-cause signal** — a nil-checked `OnShed ShedFunc` with a closed `ShedReason {empty, saturated, all_dark}`, fired once at each `ErrUnavailable` site; `pick` now returns the reason, derived from its existing `sawUp`/`failOpen` scan distinction. `prom.UpstreamShed()` → `parapet_upstream_shed_total{reason}`, so a capacity brownout (`saturated`) is distinct from a dead/empty pool. `fast_rejects{host}` schema is untouched.

### One design call worth flagging
The design proposed a fresh Collector *per balancer*, but **two collectors exporting the same `Desc` panic at `MustRegister`** (breaks multi-pool use + test/example coexistence + `-count`). I switched to **one process-global collector holding a balancer list** (registered once), dedup-by-host so a host in two pools can't fail the scrape. Scrutiny empirically confirmed both the panic and the fix.

`pkg/upstream` stays Prometheus-free; labels are bounded; the hot path gains only a register-resident `uint8` return.

## Validation

- Full `make` green; new upstream + prom tests pass `-race`, prom `-count`-safe (baseline-then-delta)
- Design + **3-lens adversarial scrutiny** (shed-reason / collector-design / test-honesty): **no correctness defect** — every gate/cap shed-reason combination was traced (incl. partial-gate multi-target → `saturated`), and the collector deviation confirmed correct. The one finding (the dedup branch was untested) is now covered by a **mutation-proven** test: defeating the dedup fails the scrape's `Gather` with "collected before with the same label values".
- Two doc nits folded: the `saturated`/`all_dark` split is documented best-effort under health-gate churn; dedup first-writer-wins (incl. capacity) documented.

Zero new `go.mod` dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)