### PR TITLE
fix(ratelimit): compute FixedWindowStrategy.After reset on Take's epoch grid

### DIFF
--- a/pkg/ratelimit/fixedwindow.go
+++ b/pkg/ratelimit/fixedwindow.go
@@ -115,7 +115,11 @@ func (b *FixedWindowStrategy) After(key string) time.Duration {
 		return 0
 	}
 
-	// no more token left
-	nextWindow := now.Truncate(b.Size).Add(b.Size)
-	return nextWindow.Sub(now)
+	// no more token left; the reset must be computed on the same Unix-epoch grid
+	// Take buckets on (UnixNano()/Size). time.Truncate rounds on the year-1 grid,
+	// which only coincides with the epoch grid when Size divides the year1->epoch
+	// offset (true for 1s/1m/1h, not arbitrary sizes) — on any other Size it can
+	// report a wait short enough to retry into another denial.
+	nextWindow := (currentWindow + 1) * int64(b.Size)
+	return time.Duration(nextWindow - now.UnixNano())
 }

--- a/pkg/ratelimit/fixedwindow_test.go
+++ b/pkg/ratelimit/fixedwindow_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/moonrhythm/parapet/pkg/ratelimit"
 )
@@ -35,4 +36,48 @@ func TestFixedWindowPerHour(t *testing.T) {
 
 	m := FixedWindowPerHour(2)
 	assert.IsType(t, &FixedWindowStrategy{}, m.Strategy)
+}
+
+// TestFixedWindowAfterMatchesTakeGrid: After must compute the reset on the same
+// Unix-epoch grid Take buckets on. Size=7s makes the grids distinguishable:
+// time.Truncate's year-1 grid is offset by 62135596800 mod 7 = 4s from the epoch
+// grid, so the old Truncate-based After is wrong at EVERY instant for this Size —
+// any in-bounds result proves the grids now agree.
+func TestFixedWindowAfterMatchesTakeGrid(t *testing.T) {
+	t.Parallel()
+
+	const size = 7 * time.Second
+
+	for attempt := 0; ; attempt++ {
+		// Fresh strategy per attempt: a retry starts in a new window, where the
+		// previous attempt's half-consumed state would invert the Take results.
+		s := &FixedWindowStrategy{Max: 1, Size: size}
+
+		before := time.Now()
+		ok1 := s.Take("k")
+		ok2 := s.Take("k")
+		got := s.After("k")
+		after := time.Now()
+
+		// Re-stage if a 7s boundary fell inside the bracket — the second Take then
+		// legitimately lands in a fresh window and After legitimately reports 0, so
+		// no assertion below is meaningful. A retry starts just past the boundary,
+		// so it cannot cross again.
+		if before.UnixNano()/int64(size) != after.UnixNano()/int64(size) {
+			require.Less(t, attempt, 3, "the window boundary kept crossing the bracket")
+			continue
+		}
+
+		require.True(t, ok1)
+		require.False(t, ok2, "budget of 1 is spent within the same window")
+
+		// The true reset on Take's grid, bracketed by the two clock reads: After ran
+		// at some instant within [before, after], so its result must lie within the
+		// matching interval. The 4s-offset Truncate grid can never land in it.
+		nextWindow := (before.UnixNano()/int64(size) + 1) * int64(size)
+		assert.Positive(t, got, "blocked key never reports 0 within the window")
+		assert.GreaterOrEqual(t, got, time.Duration(nextWindow-after.UnixNano()))
+		assert.LessOrEqual(t, got, time.Duration(nextWindow-before.UnixNano()))
+		break
+	}
 }

--- a/pkg/ratelimit/redis.go
+++ b/pkg/ratelimit/redis.go
@@ -157,11 +157,10 @@ func (b *RedisFixedWindowStrategy) Put(string) {}
 // is anchored to the SAME integer epoch (now/Size) folded into the Redis key, so the
 // returned duration is exactly the time to the end of the current window's key.
 //
-// This intentionally DIVERGES from FixedWindowStrategy.After, which uses
-// time.Truncate (anchored to time.Time's year-1 zero) and is therefore only correct
-// for windows that divide an hour; epoch anchoring is correct for ANY Size. The
-// middleware only calls After after a rejecting Take, so it always reflects a window
-// the key is currently in.
+// This is the same epoch grid FixedWindowStrategy.{Take,After} use, and it is
+// correct for ANY Size (unlike time.Truncate's year-1 anchoring, which only matches
+// for sizes that divide the year1->epoch offset). The middleware only calls After
+// after a rejecting Take, so it always reflects a window the key is currently in.
 func (b *RedisFixedWindowStrategy) After(string) time.Duration {
 	b.once.Do(b.init) // resolve b.size even if After races ahead of the first Take
 	now := time.Now()


### PR DESCRIPTION
## Problem

`FixedWindowStrategy.Take` buckets requests on the **Unix-epoch** grid (`UnixNano()/Size`), but `After` computed the reset with `time.Time.Truncate`, which rounds on the **year-1** grid. The grids coincide only when `Size` divides the year-1→epoch offset (62,135,596,800 s) — true for `1s`/`1m`/`1h`, not arbitrary sizes — so for any other window `After` could under-report the wait by up to `offset mod Size`, and a client that sleeps exactly `Retry-After` retries into another denial.

## Fix

Compute the reset on the same grid as `Take`:

```go
nextWindow := (currentWindow + 1) * int64(b.Size)
return time.Duration(nextWindow - now.UnixNano())
```

This also converges with `RedisFixedWindowStrategy.After`, which already used the epoch grid; its doc comment documenting the intentional divergence is updated accordingly.

## Testing

- `TestFixedWindowAfterMatchesTakeGrid` uses `Size=7s` (grid offset `62135596800 mod 7 = 4s`), brackets `After` between two clock reads, and asserts the result lands on Take's grid — a window the year-1 grid can never satisfy at any instant. A boundary-crossing re-stage loop with a fresh strategy per attempt keeps it deterministic under CI load.
- Mutation-tested: the test fails against the old `Truncate`-based code with the issue's exact repro numbers (reports ~5.28s when the true reset is ~2.28s), and passes 5/5 with the fix under `-race`.
- `make` (vet + golangci-lint + `go test -race ./...`) green.

Fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)