### PR TITLE
fix(ratelimit): janitor goroutine exits when its map drains (no leak per discarded strategy)

### DIFF
--- a/pkg/ratelimit/leakybucket.go
+++ b/pkg/ratelimit/leakybucket.go
@@ -17,9 +17,10 @@ func LeakyBucket(perRequest time.Duration, size int) *RateLimiter {
 //
 //nolint:govet
 type LeakyBucketStrategy struct {
-	mu      sync.RWMutex
-	storage map[string]*leakyItem
-	once    sync.Once
+	mu             sync.RWMutex
+	storage        map[string]*leakyItem
+	cleanupRunning bool          // janitor liveness; guarded by mu (see evictStale)
+	sweepEvery     time.Duration // test seam: sweep cadence + idle age override; <= 0 uses max(PerRequest+1s, 1m)
 
 	PerRequest time.Duration // time per request
 	Size       int           // queue size
@@ -32,8 +33,6 @@ type leakyItem struct {
 
 // Take waits until token can be take, unless queue full will return false
 func (b *LeakyBucketStrategy) Take(key string) bool {
-	b.once.Do(b.cleanupLoop)
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -43,6 +42,15 @@ func (b *LeakyBucketStrategy) Take(key string) bool {
 
 	if b.storage[key] == nil {
 		b.storage[key] = new(leakyItem)
+	}
+
+	// The map is non-empty from here on, so a janitor must be live. mu is the same
+	// lock the janitor stops itself under (evictStale), so the two transitions
+	// serialize: either this Take sees the stop and restarts the loop, or its key
+	// was inserted before the final sweep and kept the janitor alive.
+	if !b.cleanupRunning {
+		b.cleanupRunning = true
+		go b.cleanupLoop()
 	}
 
 	t := b.storage[key]
@@ -106,29 +114,51 @@ func (b *LeakyBucketStrategy) After(key string) time.Duration {
 	return next.Sub(now)
 }
 
+// cleanupLoop evicts keys idle for >= one sweep interval. It runs as its own
+// goroutine, started by Take, and EXITS when a sweep leaves the map empty rather
+// than living for the process lifetime: a discarded strategy drains and becomes
+// fully collectable instead of leaking a goroutine. The next Take restarts it on
+// the idle->active transition — same shape as SlidingWindowStrategy.cleanupLoop.
 func (b *LeakyBucketStrategy) cleanupLoop() {
-	maxDuration := b.PerRequest + time.Second
-	if maxDuration < time.Minute {
-		maxDuration = time.Minute
-	}
-
-	cleanup := func() {
-		deleteBefore := time.Now().Add(-maxDuration)
-
-		b.mu.Lock()
-		defer b.mu.Unlock()
-
-		for k, t := range b.storage {
-			if t.Count <= 0 && t.Last.Before(deleteBefore) {
-				delete(b.storage, k)
-			}
+	every := b.sweepEvery
+	if every <= 0 {
+		every = b.PerRequest + time.Second
+		if every < time.Minute {
+			every = time.Minute
 		}
 	}
 
-	go func() {
-		for {
-			time.Sleep(maxDuration)
-			cleanup()
+	for {
+		time.Sleep(every)
+		if b.evictStale(every) {
+			return
 		}
-	}()
+	}
+}
+
+// evictStale deletes keys with no queued waiters whose last admit is older than
+// maxAge. Items with queued waiters (Count > 0) are never evicted, so the unlocked
+// sleep inside Take cannot lose its item out from under it.
+//
+// It reports whether the sweep left the map empty, having then ALSO marked the
+// janitor stopped — both inside the one mu critical section, so a concurrent Take
+// cannot observe a non-empty map with no janitor: it either sees cleanupRunning ==
+// false and restarts the loop, or its key landed before the sweep and kept the map
+// non-empty.
+func (b *LeakyBucketStrategy) evictStale(maxAge time.Duration) (stopped bool) {
+	deleteBefore := time.Now().Add(-maxAge)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for k, t := range b.storage {
+		if t.Count <= 0 && t.Last.Before(deleteBefore) {
+			delete(b.storage, k)
+		}
+	}
+	if len(b.storage) > 0 {
+		return false
+	}
+	b.cleanupRunning = false
+	return true
 }

--- a/pkg/ratelimit/leakybucket_internal_test.go
+++ b/pkg/ratelimit/leakybucket_internal_test.go
@@ -1,0 +1,94 @@
+package ratelimit
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLeakyBucketJanitorStopOnlyWhenEmpty pins the janitor's stop state machine
+// (same shape as TestSlidingWindowJanitorStopOnlyWhenEmpty): a sweep that leaves
+// live keys keeps it running — including a key protected by a queued waiter — the
+// sweep that empties the map marks it stopped in the SAME critical section, and the
+// next Take arms it again.
+func TestLeakyBucketJanitorStopOnlyWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	b := &LeakyBucketStrategy{PerRequest: time.Millisecond, Size: 1}
+
+	longAgo := time.Now().Add(-time.Hour)
+	b.mu.Lock()
+	b.storage = map[string]*leakyItem{
+		"stale":  {Last: longAgo},           // idle, no waiters: evictable
+		"queued": {Last: longAgo, Count: 1}, // a queued waiter protects the item
+	}
+	b.cleanupRunning = true
+	b.mu.Unlock()
+
+	require.False(t, b.evictStale(time.Minute), "a queued waiter keeps its key and the janitor alive")
+	b.mu.RLock()
+	assert.True(t, b.cleanupRunning)
+	assert.Len(t, b.storage, 1)
+	_, queuedExists := b.storage["queued"]
+	b.mu.RUnlock()
+	assert.True(t, queuedExists, "Count > 0 is never evicted (Take sleeps unlocked on it)")
+
+	// The waiter drains; the emptying sweep stops the janitor.
+	b.mu.Lock()
+	b.storage["queued"].Count = 0
+	b.mu.Unlock()
+	require.True(t, b.evictStale(time.Minute), "the sweep that empties the map reports stop")
+	b.mu.RLock()
+	assert.False(t, b.cleanupRunning, "stop is marked under the same lock as the sweep")
+	assert.Empty(t, b.storage)
+	b.mu.RUnlock()
+
+	// Idle -> active: the next Take restarts the janitor.
+	require.True(t, b.Take("k"))
+	b.mu.RLock()
+	assert.True(t, b.cleanupRunning, "the next Take restarts the janitor")
+	b.mu.RUnlock()
+}
+
+// TestLeakyBucketJanitorExitsWhenIdle drives the REAL cleanupLoop (via the sweep
+// cadence seam) end-to-end: traffic stops, the key ages past the sweep interval,
+// the emptying sweep makes the goroutine exit — the #243 leak — and the strategy
+// is armed again by the next Take.
+func TestLeakyBucketJanitorExitsWhenIdle(t *testing.T) {
+	// not parallel: NumGoroutine is process-global (same reasoning as
+	// TestSlidingWindowSingleCleanupGoroutine).
+	base := runtime.NumGoroutine()
+	b := &LeakyBucketStrategy{PerRequest: time.Millisecond, Size: 1, sweepEvery: 5 * time.Millisecond}
+
+	require.True(t, b.Take("k"))
+	// Assert the invariant, not an instant: a live janitor — or, if this goroutine
+	// stalled past a sweep, an already-drained map (the janitor then stopped
+	// correctly). Requiring cleanupRunning alone would race the 5ms sweep.
+	b.mu.RLock()
+	armed := b.cleanupRunning || len(b.storage) == 0
+	b.mu.RUnlock()
+	require.True(t, armed, "first Take arms the janitor (or it already drained and stopped)")
+
+	// No further traffic: "k" ages past the 5ms sweep interval and the sweep that
+	// evicts it must mark the janitor stopped and exit the goroutine.
+	require.Eventually(t, func() bool {
+		b.mu.RLock()
+		defer b.mu.RUnlock()
+		return !b.cleanupRunning && len(b.storage) == 0
+	}, 2*time.Second, 2*time.Millisecond, "the janitor stops once the map drains")
+	// Plain polling, NOT require.Eventually: Eventually evaluates its condition in a
+	// goroutine of its own, which would inflate NumGoroutine by one forever.
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline) && runtime.NumGoroutine() > base; {
+		time.Sleep(2 * time.Millisecond)
+	}
+	assert.LessOrEqual(t, runtime.NumGoroutine(), base, "the janitor goroutine actually exited (not just flagged stopped)")
+
+	require.True(t, b.Take("k2"))
+	b.mu.RLock()
+	rearmed := b.cleanupRunning || len(b.storage) == 0 // invariant form, as above
+	b.mu.RUnlock()
+	require.True(t, rearmed, "the next Take restarts the janitor (or it already drained and stopped)")
+}

--- a/pkg/ratelimit/slidingwindow.go
+++ b/pkg/ratelimit/slidingwindow.go
@@ -54,9 +54,10 @@ func SlidingWindowPerHour(rate int) *RateLimiter {
 //
 //nolint:govet // fields grouped by role (state, then config) for readability
 type SlidingWindowStrategy struct {
-	mu      sync.RWMutex
-	storage map[string]*slidingItem
-	once    sync.Once
+	mu             sync.RWMutex
+	storage        map[string]*slidingItem
+	cleanupRunning bool          // janitor liveness; guarded by mu (see evictStale)
+	sweepEvery     time.Duration // test seam: sweep cadence override; <= 0 uses max(2*Size, 1m)
 
 	Max  int           // Max token per window; Max <= 0 admits nothing
 	Size time.Duration // Window size (the trailing interval the limit applies over)
@@ -109,8 +110,6 @@ func weightedCount(prev, curr int, now, size int64) float64 {
 // Max for uniform/front-loaded traffic; see the type doc for the boundary
 // approximation). Max <= 0 admits nothing.
 func (b *SlidingWindowStrategy) Take(key string) bool {
-	b.once.Do(b.cleanupLoop)
-
 	size := b.size()
 	now := time.Now().UnixNano()
 	currentWindow := now / size
@@ -127,6 +126,15 @@ func (b *SlidingWindowStrategy) Take(key string) bool {
 		b.storage[key] = t
 	}
 	t.roll(currentWindow)
+
+	// The map is non-empty from here on, so a janitor must be live. mu is the same
+	// lock the janitor stops itself under (evictStale), so the two transitions
+	// serialize: either this Take sees the stop and restarts the loop, or its key
+	// was inserted before the final sweep and kept the janitor alive.
+	if !b.cleanupRunning {
+		b.cleanupRunning = true
+		go b.cleanupLoop()
+	}
 
 	// Count the request under decision against the limit so the cap holds over the
 	// trailing window, not just within the fixed window.
@@ -217,26 +225,39 @@ func afterAt(maxTokens, prev, curr int, size, now int64) time.Duration {
 }
 
 // cleanupLoop evicts keys idle for >= 2 windows (their curr == prev == 0 after roll,
-// so they contribute nothing). Started once via sync.Once and lives for the
-// process lifetime — same shape as LeakyBucketStrategy.cleanupLoop.
+// so they contribute nothing). It runs as its own goroutine, started by Take, and
+// EXITS when a sweep leaves the map empty rather than living for the process
+// lifetime: a discarded strategy (hot-reloaded config, per-tenant limiters built and
+// dropped at runtime) drains within ~2 sweeps and becomes fully collectable instead
+// of leaking a goroutine. The next Take restarts it on the idle->active transition —
+// same shape as LeakyBucketStrategy.cleanupLoop.
 func (b *SlidingWindowStrategy) cleanupLoop() {
-	maxDuration := 2 * time.Duration(b.size())
-	if maxDuration < time.Minute {
-		maxDuration = time.Minute
+	every := b.sweepEvery
+	if every <= 0 {
+		every = 2 * time.Duration(b.size())
+		if every < time.Minute {
+			every = time.Minute
+		}
 	}
 
-	go func() {
-		for {
-			time.Sleep(maxDuration)
-			b.evictStale()
+	for {
+		time.Sleep(every)
+		if b.evictStale() {
+			return
 		}
-	}()
+	}
 }
 
 // evictStale deletes keys >= 2 windows old (window < currentWindow-1): roll has
 // already zeroed both their counts, so deleting them loses nothing. A key one window
 // old still has a live prev and survives, deleted on a later sweep.
-func (b *SlidingWindowStrategy) evictStale() {
+//
+// It reports whether the sweep left the map empty, having then ALSO marked the
+// janitor stopped — both inside the one mu critical section, so a concurrent Take
+// cannot observe a non-empty map with no janitor: it either sees cleanupRunning ==
+// false and restarts the loop, or its key landed before the sweep and kept the map
+// non-empty.
+func (b *SlidingWindowStrategy) evictStale() (stopped bool) {
 	deleteBefore := time.Now().UnixNano()/b.size() - 1
 
 	b.mu.Lock()
@@ -247,4 +268,9 @@ func (b *SlidingWindowStrategy) evictStale() {
 			delete(b.storage, k)
 		}
 	}
+	if len(b.storage) > 0 {
+		return false
+	}
+	b.cleanupRunning = false
+	return true
 }

--- a/pkg/ratelimit/slidingwindow_internal_test.go
+++ b/pkg/ratelimit/slidingwindow_internal_test.go
@@ -234,7 +234,7 @@ func TestSlidingWindowSingleCleanupGoroutine(t *testing.T) {
 	base := runtime.NumGoroutine()
 	b := &SlidingWindowStrategy{Max: 1 << 30, Size: time.Hour}
 
-	b.Take("k") // first Take arms the (long-sleeping, never-exiting) cleanup loop
+	b.Take("k") // first Take arms the (long-sleeping; exits only when the map drains) cleanup loop
 	require.Eventually(t, func() bool { return runtime.NumGoroutine() >= base+1 }, time.Second, 5*time.Millisecond,
 		"the first Take starts the cleanup loop")
 	after := runtime.NumGoroutine()
@@ -243,4 +243,85 @@ func TestSlidingWindowSingleCleanupGoroutine(t *testing.T) {
 		b.Take("k")
 	}
 	assert.LessOrEqual(t, runtime.NumGoroutine(), after, "no additional goroutine per Take")
+}
+
+// TestSlidingWindowJanitorStopOnlyWhenEmpty pins the janitor's stop state machine:
+// a sweep that leaves live keys keeps it running; the sweep that empties the map
+// marks it stopped in the SAME critical section (so no Take can observe a non-empty
+// map with no janitor); the next Take arms it again.
+func TestSlidingWindowJanitorStopOnlyWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	b := &SlidingWindowStrategy{Max: 10, Size: time.Hour}
+
+	cur := time.Now().UnixNano() / b.size()
+	b.mu.Lock()
+	b.storage = map[string]*slidingItem{
+		"stale": {window: 0, curr: 1},   // epoch: many windows old
+		"fresh": {window: cur, curr: 1}, // current window: survives the sweep
+	}
+	b.cleanupRunning = true
+	b.mu.Unlock()
+
+	require.False(t, b.evictStale(), "a surviving key keeps the janitor running")
+	b.mu.RLock()
+	assert.True(t, b.cleanupRunning)
+	assert.Len(t, b.storage, 1)
+	b.mu.RUnlock()
+
+	// Age the survivor out; the emptying sweep stops the janitor.
+	b.mu.Lock()
+	b.storage["fresh"].window = 0
+	b.mu.Unlock()
+	require.True(t, b.evictStale(), "the sweep that empties the map reports stop")
+	b.mu.RLock()
+	assert.False(t, b.cleanupRunning, "stop is marked under the same lock as the sweep")
+	assert.Empty(t, b.storage)
+	b.mu.RUnlock()
+
+	// Idle -> active: the next Take restarts the janitor.
+	require.True(t, b.Take("k"))
+	b.mu.RLock()
+	assert.True(t, b.cleanupRunning, "the next Take restarts the janitor")
+	b.mu.RUnlock()
+}
+
+// TestSlidingWindowJanitorExitsWhenIdle drives the REAL cleanupLoop (via the sweep
+// cadence seam) end-to-end: traffic stops, the keys go stale within ~2 windows, the
+// emptying sweep makes the goroutine exit — the #243 leak — and the strategy is
+// armed again by the next Take.
+func TestSlidingWindowJanitorExitsWhenIdle(t *testing.T) {
+	// not parallel: NumGoroutine is process-global (same reasoning as
+	// TestSlidingWindowSingleCleanupGoroutine).
+	base := runtime.NumGoroutine()
+	b := &SlidingWindowStrategy{Max: 10, Size: 10 * time.Millisecond, sweepEvery: 5 * time.Millisecond}
+
+	require.True(t, b.Take("k"))
+	// Assert the invariant, not an instant: a live janitor — or, if this goroutine
+	// stalled past a sweep, an already-drained map (the janitor then stopped
+	// correctly). Requiring cleanupRunning alone would race the 5ms sweep.
+	b.mu.RLock()
+	armed := b.cleanupRunning || len(b.storage) == 0
+	b.mu.RUnlock()
+	require.True(t, armed, "first Take arms the janitor (or it already drained and stopped)")
+
+	// No further traffic: "k" is >= 2 windows old after ~20ms and the sweep that
+	// evicts it must mark the janitor stopped and exit the goroutine.
+	require.Eventually(t, func() bool {
+		b.mu.RLock()
+		defer b.mu.RUnlock()
+		return !b.cleanupRunning && len(b.storage) == 0
+	}, 2*time.Second, 2*time.Millisecond, "the janitor stops once the map drains")
+	// Plain polling, NOT require.Eventually: Eventually evaluates its condition in a
+	// goroutine of its own, which would inflate NumGoroutine by one forever.
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline) && runtime.NumGoroutine() > base; {
+		time.Sleep(2 * time.Millisecond)
+	}
+	assert.LessOrEqual(t, runtime.NumGoroutine(), base, "the janitor goroutine actually exited (not just flagged stopped)")
+
+	require.True(t, b.Take("k2"))
+	b.mu.RLock()
+	rearmed := b.cleanupRunning || len(b.storage) == 0 // invariant form, as above
+	b.mu.RUnlock()
+	require.True(t, rearmed, "the next Take restarts the janitor (or it already drained and stopped)")
 }


### PR DESCRIPTION
## Problem

`SlidingWindowStrategy` and `LeakyBucketStrategy` started their cleanup janitor on the first `Take` via `sync.Once`, with no stop channel and no exit condition. Any system that rebuilds strategies at runtime — hot-reloadable rate-limit config, per-tenant limiters created and dropped on the fly — leaked one goroutine (plus its pinned `storage` map) per discarded strategy, forever.

## Fix

Exit-when-empty, no API change:

- The sweep that leaves `len(storage) == 0` marks the janitor stopped and the goroutine returns. A dropped strategy drains within ~2 sweeps and becomes fully collectable.
- `sync.Once` is replaced by a `cleanupRunning` bool guarded by the existing `mu`. The stop decision shares one critical section with the sweep, and the restart check shares one critical section with the key insert in `Take` — so a concurrent `Take` either observes the stop and restarts the loop, or its key lands before the final sweep and keeps the janitor alive. **Invariant: a non-empty map always has a live janitor; at most one active janitor per strategy.**
- The leaky bucket's queued waiter (`Count > 0`, sleeping unlocked inside `Take`) is never evicted, so the unlocked sleep can't lose its item or its janitor.
- Steady-state behavior for long-lived strategies is unchanged; the goroutine restarts on the next idle→active transition.

## Testing

- End-to-end lifecycle tests drive the **real** `cleanupLoop` via an unexported `sweepEvery` test seam (ms-scale cadence) and observe `runtime.NumGoroutine()` actually return to baseline — plain polling, not `require.Eventually`, whose own condition goroutine would inflate the count. Mutation-tested: with the janitor's exit removed (the old behavior), both tests fail on the leaked goroutine.
- State-machine tests pin the stop/restart transitions: a surviving key (including a `Count > 0` waiter) keeps the janitor running; the emptying sweep stops it under the same lock; the next `Take` rearms it.
- Adversarially reviewed across liveness / mutual-exclusion / eviction-semantics / test-quality lenses; the two confirmed findings (instantaneous flag reads racing the fast-seam janitor) are fixed by asserting the invariant form (`cleanupRunning || len(storage) == 0`).
- `make` (vet + golangci-lint + `go test -race ./...`) green; lifecycle tests pass 10× under `-race` stress.

Fixes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)