### PR TITLE
feat(cache): opt-in CacheChunked — cache GET responses with no Content-Length

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -147,6 +147,24 @@ type Options struct {
 	// the leader always streams in lockstep and holds the fill lock until that stream
 	// and the commit finish (see LockTimeout).
 	DecoupleFill bool
+
+	// CacheChunked, when true, lets a GET response that carries NO Content-Length
+	// (a chunked / streamed body — e.g. an on-the-fly-compressed asset) still be
+	// cached: the body is streamed to storage as usual and, since there is no
+	// declared length to match, completeness is inferred from the upstream handler
+	// returning normally. The MaxFileSize cap is enforced mid-stream (an oversize
+	// body stops caching and is served in full, uncached), and a Server-Sent-Events
+	// response (Content-Type text/event-stream) is never buffered.
+	//
+	// SAFETY: with no Content-Length the cache cannot verify the body is complete by
+	// byte count, so it relies on a TRUNCATED upstream surfacing as a panic /
+	// http.ErrAbortHandler (httputil.ReverseProxy does this for inbound requests),
+	// which unwinds through the leader's deferred cleanup and discards the entry — so
+	// only a cleanly-finished body is committed. Enable this only behind a forwarder
+	// that aborts (rather than silently returns) on a mid-body error; a handler that
+	// swallows the error and returns normally could otherwise cache a partial body.
+	// When false (default), a chunked GET passes through uncached as before.
+	CacheChunked bool
 }
 
 // OverrideMode selects how far an Override reaches over the origin's
@@ -204,19 +222,20 @@ type Override struct {
 // Cache is the HTTP response-cache middleware. It implements parapet.Middleware
 // (ServeHandler). Construct with New, giving it a Storage backend.
 type Cache struct {
-	storage          Storage
-	invalidatedAfter func(r *http.Request, m Meta) int64
-	cacheable        func(r *http.Request) bool
-	override         func(r *http.Request, status int, header http.Header) *Override
-	onResult         ResultFunc
-	primaryVary      map[string][]string  // primaryHex -> Vary header names learned from a stored response
-	locks            map[string]*fillLock // variantHex -> in-flight fill
+	storage           Storage
+	invalidatedAfter  func(r *http.Request, m Meta) int64
+	cacheable         func(r *http.Request) bool
+	override          func(r *http.Request, status int, header http.Header) *Override
+	onResult          ResultFunc
+	primaryVary       map[string][]string  // primaryHex -> Vary header names learned from a stored response
+	locks             map[string]*fillLock // variantHex -> in-flight fill
 	maxFileSize       int64
 	lockTimeout       time.Duration
 	revalidateTimeout time.Duration
 	defaultSWR        time.Duration // Options.DefaultStaleWhileRevalidate, clamped
 	defaultSIE        time.Duration // Options.DefaultStaleIfError, clamped
 	decoupleFill      bool
+	cacheChunked      bool
 
 	pvMu sync.RWMutex
 
@@ -259,6 +278,7 @@ func New(storage Storage, opts Options) *Cache {
 		override:          opts.Override,
 		onResult:          opts.OnResult,
 		decoupleFill:      opts.DecoupleFill,
+		cacheChunked:      opts.CacheChunked,
 		primaryVary:       map[string][]string{},
 		locks:             map[string]*fillLock{},
 	}
@@ -550,6 +570,12 @@ func writeStored(w http.ResponseWriter, r *http.Request, m Meta, body []byte, ta
 	}
 	h.Set("Age", strconv.FormatInt(servedAgeSeconds(m, time.Now()), 10))
 	h.Set("X-Cache", tag)
+	// A chunked-buffered entry was stored without a Content-Length; serve the
+	// definitive length now that the whole body is in hand, so the served response
+	// is itself a well-formed cacheable one (and not re-chunked downstream).
+	if h.Get("Content-Length") == "" && r.Method != http.MethodHead && m.Status != http.StatusNoContent {
+		h.Set("Content-Length", strconv.Itoa(len(body)))
+	}
 	w.WriteHeader(m.Status)
 	if r.Method == http.MethodHead || m.Status == http.StatusNoContent {
 		return

--- a/pkg/cache/chunked_test.go
+++ b/pkg/cache/chunked_test.go
@@ -1,0 +1,106 @@
+package cache
+
+import (
+	"net/http"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// chunkedOrigin serves body with the given headers but DELIBERATELY no
+// Content-Length — the teeWriter sees a chunked/streamed response. extra runs
+// after the body is written (e.g. to panic, simulating a truncated upstream).
+func chunkedOrigin(body []byte, hdr http.Header, calls *int32, extra func()) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(calls, 1)
+		for k, vs := range hdr {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+		if extra != nil {
+			extra()
+		}
+	})
+}
+
+func TestCache_Chunked_CachedWhenEnabled(t *testing.T) {
+	body := []byte("console.log('hi')")
+	hdr := http.Header{"Cache-Control": {"public, max-age=60"}, "Content-Type": {"text/javascript"}}
+
+	t.Run("enabled: no-Content-Length GET is cached", func(t *testing.T) {
+		c := New(NewMemory(1<<20), Options{MaxFileSize: 1 << 20, CacheChunked: true})
+		var calls int32
+		o := chunkedOrigin(body, hdr, &calls, nil)
+
+		rec1 := do(c, o, "GET", "/app.js", nil)
+		assert.Equal(t, "MISS", rec1.Header().Get("X-Cache"))
+
+		rec2 := do(c, o, "GET", "/app.js", nil)
+		assert.Equal(t, "HIT", rec2.Header().Get("X-Cache"))
+		assert.Equal(t, body, rec2.Body.Bytes())
+		// The HIT carries a synthesized Content-Length even though the origin sent none.
+		assert.Equal(t, strconv.Itoa(len(body)), rec2.Header().Get("Content-Length"))
+		assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "second request served from cache")
+	})
+
+	t.Run("disabled (default): no-Content-Length GET is never cached", func(t *testing.T) {
+		c := New(NewMemory(1<<20), Options{MaxFileSize: 1 << 20}) // CacheChunked off
+		var calls int32
+		o := chunkedOrigin(body, hdr, &calls, nil)
+
+		assert.Equal(t, "MISS", do(c, o, "GET", "/app.js", nil).Header().Get("X-Cache"))
+		assert.Equal(t, "MISS", do(c, o, "GET", "/app.js", nil).Header().Get("X-Cache"))
+		assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "chunked stays uncached when disabled")
+	})
+}
+
+func TestCache_Chunked_EventStreamNeverBuffered(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1 << 20, CacheChunked: true})
+	var calls int32
+	// Fresh + cacheable status, but an SSE content-type must never be buffered.
+	o := chunkedOrigin([]byte("data: hi\n\n"),
+		http.Header{"Cache-Control": {"public, max-age=60"}, "Content-Type": {"text/event-stream"}}, &calls, nil)
+
+	assert.Equal(t, "MISS", do(c, o, "GET", "/events", nil).Header().Get("X-Cache"))
+	assert.Equal(t, "MISS", do(c, o, "GET", "/events", nil).Header().Get("X-Cache"))
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "event-stream must not be cached")
+}
+
+func TestCache_Chunked_OverCapNotCached(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 8, CacheChunked: true})
+	body := []byte("way longer than eight bytes")
+	var calls int32
+	o := chunkedOrigin(body, http.Header{"Cache-Control": {"public, max-age=60"}}, &calls, nil)
+
+	rec1 := do(c, o, "GET", "/big.js", nil)
+	assert.Equal(t, "MISS", rec1.Header().Get("X-Cache"))
+	assert.Equal(t, body, rec1.Body.Bytes(), "over-cap body still served in full")
+
+	rec2 := do(c, o, "GET", "/big.js", nil)
+	assert.Equal(t, "MISS", rec2.Header().Get("X-Cache"))
+	assert.Equal(t, body, rec2.Body.Bytes())
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "over-cap chunked body is not cached")
+}
+
+// A truncated upstream surfaces as a panic (httputil.ReverseProxy emits
+// http.ErrAbortHandler); the leader's deferred cleanup must abort the entry so a
+// partial body is never committed and the next request re-fetches.
+func TestCache_Chunked_TruncationNotCommitted(t *testing.T) {
+	c := New(NewMemory(1<<20), Options{MaxFileSize: 1 << 20, CacheChunked: true})
+	var calls int32
+	o := chunkedOrigin([]byte("partial"), http.Header{"Cache-Control": {"public, max-age=60"}}, &calls,
+		func() { panic(http.ErrAbortHandler) })
+
+	doRecover := func() {
+		defer func() { _ = recover() }() // swallow the simulated abort, as net/http's server would
+		do(c, o, "GET", "/x.js", nil)
+	}
+	doRecover()
+	doRecover()
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "a truncated (panicked) fill must not be cached")
+}

--- a/pkg/cache/override_test.go
+++ b/pkg/cache/override_test.go
@@ -61,7 +61,7 @@ func TestDecideForced(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			d := decideForced(http.MethodGet, tc.status, tc.h, tc.auth, maxFile, now, &Override{TTL: time.Hour, Mode: tc.mode})
+			d := decideForced(http.MethodGet, tc.status, tc.h, tc.auth, maxFile, false, now, &Override{TTL: time.Hour, Mode: tc.mode})
 			assert.Equal(t, tc.wantCacheable, d.cacheable)
 			if tc.wantCacheable && tc.wantTTL > 0 {
 				assert.Equal(t, now.Add(tc.wantTTL), d.freshUntil)
@@ -70,7 +70,7 @@ func TestDecideForced(t *testing.T) {
 	}
 
 	t.Run("forces the RFC 5861 windows", func(t *testing.T) {
-		d := decideForced(http.MethodGet, 200, hdr(), false, maxFile, now,
+		d := decideForced(http.MethodGet, 200, hdr(), false, maxFile, false, now,
 			&Override{TTL: time.Hour, StaleWhileRevalidate: 30 * time.Second, StaleIfError: time.Hour})
 		require.True(t, d.cacheable)
 		assert.Equal(t, 30*time.Second, d.staleWhileRevalidate)
@@ -79,19 +79,19 @@ func TestDecideForced(t *testing.T) {
 	})
 
 	t.Run("clamps an absurd TTL", func(t *testing.T) {
-		d := decideForced(http.MethodGet, 200, hdr(), false, maxFile, now, &Override{TTL: 100 * 365 * 24 * time.Hour})
+		d := decideForced(http.MethodGet, 200, hdr(), false, maxFile, false, now, &Override{TTL: 100 * 365 * 24 * time.Hour})
 		require.True(t, d.cacheable)
 		assert.Equal(t, now.Add(maxTTL), d.freshUntil)
 	})
 
 	t.Run("HEAD needs no Content-Length", func(t *testing.T) {
 		h := http.Header{} // no Content-Length
-		d := decideForced(http.MethodHead, 200, h, false, maxFile, now, &Override{TTL: time.Hour})
+		d := decideForced(http.MethodHead, 200, h, false, maxFile, false, now, &Override{TTL: time.Hour})
 		assert.True(t, d.cacheable)
 	})
 
 	t.Run("conservative respects must-revalidate over forced windows", func(t *testing.T) {
-		d := decideForced(http.MethodGet, 200, hdr("Cache-Control", "must-revalidate, max-age=60"), false, maxFile, now,
+		d := decideForced(http.MethodGet, 200, hdr("Cache-Control", "must-revalidate, max-age=60"), false, maxFile, false, now,
 			&Override{TTL: time.Hour, StaleWhileRevalidate: 30 * time.Minute, Mode: OverrideConservative})
 		require.True(t, d.cacheable)
 		assert.True(t, d.noStale)
@@ -100,7 +100,7 @@ func TestDecideForced(t *testing.T) {
 	})
 
 	t.Run("balanced forces windows despite must-revalidate", func(t *testing.T) {
-		d := decideForced(http.MethodGet, 200, hdr("Cache-Control", "must-revalidate, max-age=60"), false, maxFile, now,
+		d := decideForced(http.MethodGet, 200, hdr("Cache-Control", "must-revalidate, max-age=60"), false, maxFile, false, now,
 			&Override{TTL: time.Hour, StaleWhileRevalidate: 30 * time.Minute, Mode: OverrideBalanced})
 		require.True(t, d.cacheable)
 		assert.False(t, d.noStale)
@@ -151,7 +151,9 @@ func TestCache_Override_BalancedIgnoresRequestCookie(t *testing.T) {
 func TestCache_Override_AggressiveCachesAcrossUsers(t *testing.T) {
 	c := New(NewMemory(1<<20), Options{
 		MaxFileSize: 1024,
-		Override:    func(_ *http.Request, _ int, _ http.Header) *Override { return &Override{TTL: time.Hour, Mode: OverrideAggressive} },
+		Override: func(_ *http.Request, _ int, _ http.Header) *Override {
+			return &Override{TTL: time.Hour, Mode: OverrideAggressive}
+		},
 	})
 	o := origin(originSpec{body: []byte("user-data")}, new(int32))
 
@@ -268,7 +270,9 @@ func TestCache_Override_NilHonorsOrigin(t *testing.T) {
 func TestCache_Override_ForcedStaleIfError(t *testing.T) {
 	c := New(NewMemory(1<<20), Options{
 		MaxFileSize: 1024,
-		Override:    func(_ *http.Request, _ int, _ http.Header) *Override { return &Override{TTL: time.Hour, StaleIfError: time.Hour} },
+		Override: func(_ *http.Request, _ int, _ http.Header) *Override {
+			return &Override{TTL: time.Hour, StaleIfError: time.Hour}
+		},
 	})
 	do(c, origin(originSpec{body: []byte("old")}, new(int32)), "GET", "/x", nil) // fill (forced)
 

--- a/pkg/cache/policy.go
+++ b/pkg/cache/policy.go
@@ -68,7 +68,7 @@ type decision struct {
 // commits a body only once written bytes == Content-Length, guaranteeing a
 // truncated response is never stored. A chunked (no Content-Length) GET passes
 // through uncached. HEAD has no body and is unaffected.
-func decide(method string, status int, h http.Header, reqAuthorized bool, maxFileSize int64, now time.Time) decision {
+func decide(method string, status int, h http.Header, reqAuthorized bool, maxFileSize int64, cacheChunked bool, now time.Time) decision {
 	no := decision{}
 	vary, ok := storeRefusals(status, h)
 	if !ok {
@@ -90,7 +90,7 @@ func decide(method string, status int, h http.Header, reqAuthorized bool, maxFil
 	if ttl <= 0 {
 		return no // honor-origin: no explicit freshness -> not cached
 	}
-	if !fitsCap(method, h, maxFileSize) {
+	if !fitsCap(method, h, maxFileSize, cacheChunked) {
 		return no
 	}
 	// Clamp absurd freshness so now+ttl stays within time.UnixNano's range.
@@ -108,7 +108,7 @@ func decide(method string, status int, h http.Header, reqAuthorized bool, maxFil
 // refusals (no-cache, no-store/private, the Authorization gate) still apply and
 // whether the forced TTL overrides the origin's freshness. The caller guarantees
 // ov.TTL > 0.
-func decideForced(method string, status int, h http.Header, reqAuthorized bool, maxFileSize int64, now time.Time, ov *Override) decision {
+func decideForced(method string, status int, h http.Header, reqAuthorized bool, maxFileSize int64, cacheChunked bool, now time.Time, ov *Override) decision {
 	no := decision{}
 	vary, ok := storeRefusals(status, h)
 	if !ok {
@@ -147,7 +147,7 @@ func decideForced(method string, status int, h http.Header, reqAuthorized bool, 
 	if ttl <= 0 {
 		return no
 	}
-	if !fitsCap(method, h, maxFileSize) {
+	if !fitsCap(method, h, maxFileSize, cacheChunked) {
 		return no
 	}
 	if ttl > maxTTL {
@@ -202,16 +202,30 @@ func sharedOptIn(cc cacheControl) bool {
 	return cc.public || cc.hasSMax || cc.mustRevalidate
 }
 
-// fitsCap reports whether a GET response's Content-Length is present and within
-// the per-object cap (HEAD has no body and always fits). A chunked GET (no
-// Content-Length) is not cacheable: the middleware commits only when written
-// bytes match Content-Length, so a truncated response is never stored.
-func fitsCap(method string, h http.Header, maxFileSize int64) bool {
+// fitsCap reports whether a GET response is within the per-object cap (HEAD has
+// no body and always fits). With a Content-Length, it must be present and within
+// the cap. Without one (a chunked / streamed GET), the response is cacheable only
+// when cacheChunked is enabled — and never for a Server-Sent-Events stream; the
+// real cap is then enforced mid-stream by the teeWriter, and completeness comes
+// from the upstream handler finishing cleanly (see teeWriter.finish). When
+// cacheChunked is off, a no-Content-Length GET is not cacheable, as before.
+func fitsCap(method string, h http.Header, maxFileSize int64, cacheChunked bool) bool {
 	if method != http.MethodGet {
 		return true
 	}
 	cl, ok := contentLength(h)
-	return ok && cl >= 0 && cl <= maxFileSize
+	if !ok {
+		return cacheChunked && !isEventStream(h)
+	}
+	return cl >= 0 && cl <= maxFileSize
+}
+
+// isEventStream reports a Server-Sent-Events response (Content-Type
+// text/event-stream, with or without parameters), which is an open-ended stream
+// and must never be buffered for caching.
+func isEventStream(h http.Header) bool {
+	ct := strings.ToLower(strings.TrimSpace(h.Get("Content-Type")))
+	return ct == "text/event-stream" || strings.HasPrefix(ct, "text/event-stream;")
 }
 
 // staleWindows derives the RFC 5861 stale-serving windows from the response

--- a/pkg/cache/policy_test.go
+++ b/pkg/cache/policy_test.go
@@ -23,7 +23,7 @@ func cacheableGET(t *testing.T, h http.Header) bool {
 	if h.Get("Content-Length") == "" {
 		h.Set("Content-Length", "10")
 	}
-	return decide(http.MethodGet, 200, h, false, maxFile, time.Unix(1_000_000, 0)).cacheable
+	return decide(http.MethodGet, 200, h, false, maxFile, false, time.Unix(1_000_000, 0)).cacheable
 }
 
 func TestDecide_HonorsOriginFreshnessOnly(t *testing.T) {
@@ -50,53 +50,53 @@ func TestDecide_AuthorizationRequiresExplicitSharedOptIn(t *testing.T) {
 	now := time.Now()
 
 	// Authorized request: bare max-age (or Expires) is NOT shared-cacheable.
-	assert.False(t, decide(http.MethodGet, 200, cl("max-age=60"), true, maxFile, now).cacheable)
-	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", now.Add(time.Hour).UTC().Format(http.TimeFormat), "Content-Length", "1"), true, maxFile, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, cl("max-age=60"), true, maxFile, false, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", now.Add(time.Hour).UTC().Format(http.TimeFormat), "Content-Length", "1"), true, maxFile, false, now).cacheable)
 
 	// Explicit shared opt-in re-enables caching for an authorized request.
-	assert.True(t, decide(http.MethodGet, 200, cl("public, max-age=60"), true, maxFile, now).cacheable)
-	assert.True(t, decide(http.MethodGet, 200, cl("s-maxage=60"), true, maxFile, now).cacheable)
-	assert.True(t, decide(http.MethodGet, 200, cl("must-revalidate, max-age=60"), true, maxFile, now).cacheable)
+	assert.True(t, decide(http.MethodGet, 200, cl("public, max-age=60"), true, maxFile, false, now).cacheable)
+	assert.True(t, decide(http.MethodGet, 200, cl("s-maxage=60"), true, maxFile, false, now).cacheable)
+	assert.True(t, decide(http.MethodGet, 200, cl("must-revalidate, max-age=60"), true, maxFile, false, now).cacheable)
 
 	// An unauthenticated request is unaffected: bare max-age still caches.
-	assert.True(t, decide(http.MethodGet, 200, cl("max-age=60"), false, maxFile, now).cacheable)
+	assert.True(t, decide(http.MethodGet, 200, cl("max-age=60"), false, maxFile, false, now).cacheable)
 }
 
 func TestDecide_VaryNamedHeaderStillCacheable(t *testing.T) {
-	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "5", "Vary", "Accept-Encoding"), false, maxFile, time.Now())
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "5", "Vary", "Accept-Encoding"), false, maxFile, false, time.Now())
 	assert.True(t, d.cacheable)
 	assert.Equal(t, []string{"accept-encoding"}, d.vary)
 }
 
 func TestDecide_StatusCodes(t *testing.T) {
 	for _, code := range []int{200, 203, 204, 300, 301, 308, 404, 410} {
-		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), false, maxFile, time.Now())
+		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), false, maxFile, false, time.Now())
 		assert.True(t, d.cacheable, "status %d should be cacheable with freshness", code)
 	}
 	for _, code := range []int{201, 302, 401, 403, 500, 502, 206} {
-		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), false, maxFile, time.Now())
+		d := decide(http.MethodGet, code, hdr("Cache-Control", "max-age=60", "Content-Length", "1"), false, maxFile, false, time.Now())
 		assert.False(t, d.cacheable, "status %d should not be cached", code)
 	}
 }
 
 func TestDecide_ContentLengthCapAndPresence(t *testing.T) {
-	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60"), false, maxFile, time.Now()).cacheable)
-	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "9000000"), false, maxFile, time.Now()).cacheable)
-	assert.True(t, decide(http.MethodHead, 200, hdr("Cache-Control", "max-age=60"), false, maxFile, time.Now()).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60"), false, maxFile, false, time.Now()).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Content-Length", "9000000"), false, maxFile, false, time.Now()).cacheable)
+	assert.True(t, decide(http.MethodHead, 200, hdr("Cache-Control", "max-age=60"), false, maxFile, false, time.Now()).cacheable)
 }
 
 func TestDecide_Expires(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	future := now.Add(time.Hour).UTC().Format(http.TimeFormat)
 	past := now.Add(-time.Hour).UTC().Format(http.TimeFormat)
-	assert.True(t, decide(http.MethodGet, 200, hdr("Expires", future, "Content-Length", "1"), false, maxFile, now).cacheable)
-	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", past, "Content-Length", "1"), false, maxFile, now).cacheable)
-	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", "0", "Content-Length", "1"), false, maxFile, now).cacheable)
+	assert.True(t, decide(http.MethodGet, 200, hdr("Expires", future, "Content-Length", "1"), false, maxFile, false, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", past, "Content-Length", "1"), false, maxFile, false, now).cacheable)
+	assert.False(t, decide(http.MethodGet, 200, hdr("Expires", "0", "Content-Length", "1"), false, maxFile, false, now).cacheable)
 }
 
 func TestDecide_FarFutureTTLClamped(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=7445000000", "Content-Length", "1"), false, maxFile, now) // ~236y
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=7445000000", "Content-Length", "1"), false, maxFile, false, now) // ~236y
 	assert.True(t, d.cacheable)
 	// clamped well within UnixNano range (year < 2262)
 	assert.True(t, d.freshUntil.Before(time.Date(2200, 1, 1, 0, 0, 0, 0, time.UTC)))
@@ -134,10 +134,10 @@ func TestFreshness_SubtractsResponseAge(t *testing.T) {
 // response aged past its lifetime is not cached at all.
 func TestDecide_AgeReducesFreshness(t *testing.T) {
 	now := time.Unix(1_700_000_000, 0)
-	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), false, maxFile, now)
+	d := decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "55", "Content-Length", "1"), false, maxFile, false, now)
 	assert.True(t, d.cacheable)
 	assert.Equal(t, now.Add(5*time.Second), d.freshUntil, "freshUntil reflects the ~5s remaining after Age")
 
-	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), false, maxFile, now).cacheable,
+	assert.False(t, decide(http.MethodGet, 200, hdr("Cache-Control", "max-age=60", "Age", "60", "Content-Length", "1"), false, maxFile, false, now).cacheable,
 		"Age >= max-age: already stale, not cached")
 }

--- a/pkg/cache/stale_test.go
+++ b/pkg/cache/stale_test.go
@@ -421,28 +421,28 @@ func TestPolicy_StaleWindows(t *testing.T) {
 	}
 
 	t.Run("parsed", func(t *testing.T) {
-		d := decide("GET", 200, h("max-age=60, stale-while-revalidate=120, stale-if-error=3600"), false, 1<<20, now)
+		d := decide("GET", 200, h("max-age=60, stale-while-revalidate=120, stale-if-error=3600"), false, 1<<20, false, now)
 		require.True(t, d.cacheable)
 		assert.Equal(t, 120*time.Second, d.staleWhileRevalidate)
 		assert.Equal(t, 3600*time.Second, d.staleIfError)
 	})
 
 	t.Run("must-revalidate suppresses both", func(t *testing.T) {
-		d := decide("GET", 200, h("max-age=60, must-revalidate, stale-while-revalidate=120, stale-if-error=3600"), false, 1<<20, now)
+		d := decide("GET", 200, h("max-age=60, must-revalidate, stale-while-revalidate=120, stale-if-error=3600"), false, 1<<20, false, now)
 		require.True(t, d.cacheable)
 		assert.Zero(t, d.staleWhileRevalidate)
 		assert.Zero(t, d.staleIfError)
 	})
 
 	t.Run("proxy-revalidate suppresses both", func(t *testing.T) {
-		d := decide("GET", 200, h("s-maxage=60, proxy-revalidate, stale-while-revalidate=120"), false, 1<<20, now)
+		d := decide("GET", 200, h("s-maxage=60, proxy-revalidate, stale-while-revalidate=120"), false, 1<<20, false, now)
 		require.True(t, d.cacheable)
 		assert.Zero(t, d.staleWhileRevalidate)
 		assert.Zero(t, d.staleIfError)
 	})
 
 	t.Run("absent", func(t *testing.T) {
-		d := decide("GET", 200, h("max-age=60"), false, 1<<20, now)
+		d := decide("GET", 200, h("max-age=60"), false, 1<<20, false, now)
 		require.True(t, d.cacheable)
 		assert.Zero(t, d.staleWhileRevalidate)
 		assert.Zero(t, d.staleIfError)

--- a/pkg/cache/tee.go
+++ b/pkg/cache/tee.go
@@ -67,9 +67,9 @@ func (tw *teeWriter) WriteHeader(code int) {
 	now := time.Now()
 	var dec decision
 	if ov := tw.c.overrideFor(tw.r, code, h); ov != nil {
-		dec = decideForced(tw.method, code, h, reqAuthorized, tw.c.maxFileSize, now, ov)
+		dec = decideForced(tw.method, code, h, reqAuthorized, tw.c.maxFileSize, tw.c.cacheChunked, now, ov)
 	} else {
-		dec = decide(tw.method, code, h, reqAuthorized, tw.c.maxFileSize, now)
+		dec = decide(tw.method, code, h, reqAuthorized, tw.c.maxFileSize, tw.c.cacheChunked, now)
 	}
 	if dec.cacheable {
 		vary := append([]string(nil), dec.vary...)
@@ -109,7 +109,13 @@ func (tw *teeWriter) WriteHeader(code int) {
 	// slow client can't hold the lock from those followers. With no follower waiting
 	// there's nothing to isolate, so the leader streams in lockstep and pays no
 	// added latency. A non-cacheable response (ew == nil) always streams in lockstep.
-	if tw.ew != nil && tw.c.decoupleFill && tw.lock != nil && tw.lock.waiters.Load() > 0 {
+	//
+	// A chunked (no Content-Length) entry never decouples: its leaderBuf is capped
+	// at maxFileSize but we don't know the body fits until the stream ends, so an
+	// over-cap body would serve the leader a truncated response. Streaming it in
+	// lockstep instead always gives the leader exactly what the origin produced; the
+	// storage copy is still capped+aborted independently.
+	if tw.ew != nil && tw.hasCL && tw.c.decoupleFill && tw.lock != nil && tw.lock.waiters.Load() > 0 {
 		tw.deferredClient = true
 		return
 	}
@@ -181,7 +187,15 @@ func (tw *teeWriter) finish() {
 	if tw.ew == nil {
 		return
 	}
-	complete := tw.method == http.MethodHead || (tw.hasCL && tw.written == tw.contentLen)
+	// Completeness: HEAD has no body; a Content-Length body must match exactly (a
+	// truncated one wrote fewer bytes). A chunked body (no Content-Length, only
+	// reached here when CacheChunked opened the writer) has no length to match —
+	// finish runs only when the upstream handler returned NORMALLY (a truncated
+	// upstream panics http.ErrAbortHandler, which unwinds through fill's deferred
+	// cleanup before finish), so reaching here means the stream ended cleanly.
+	complete := tw.method == http.MethodHead ||
+		(tw.hasCL && tw.written == tw.contentLen) ||
+		(!tw.hasCL && tw.c.cacheChunked)
 	if !complete {
 		tw.abort()
 		return


### PR DESCRIPTION
## Problem

The honor-origin policy stores a GET only when it carries a `Content-Length` within the cap, committing once `written == Content-Length` so a truncated response is never stored (`policy.go` `fitsCap`, `tee.go` `finish`). That leaves **on-the-fly-compressed assets** — gzip/br/zstd streamed chunked, with no `Content-Length` — permanently uncacheable, even when they are otherwise perfectly cacheable (`public, max-age=…`).

## Change

Add `Options.CacheChunked` (default **off**, so existing behavior is byte-for-byte unchanged):

- When set, a GET with **no `Content-Length`** is eligible. The body streams to storage as before; the `MaxFileSize` cap is enforced **mid-stream** (an oversize body stops caching and is still served in full); a **Server-Sent-Events** response (`Content-Type: text/event-stream`) is never buffered.
- A served hit **synthesizes a `Content-Length`** from the buffered length, so the cached response is itself well-formed (and not re-chunked downstream).
- Chunked entries never use `DecoupleFill` (the leader buffer is capped, so an over-cap body would truncate the leader's response) — they stream in lockstep.

### Safety: a partial body is never committed

With no `Content-Length` the cache can't verify completeness by byte count, so completeness is inferred from the upstream handler **returning normally**. A truncated upstream surfaces as a panic / `http.ErrAbortHandler` (which `httputil.ReverseProxy` raises for inbound requests on a post-header copy error); that unwinds through the leader's deferred `cleanup()` **before** `finish()` runs, so the entry is aborted, never committed. Over-cap mid-stream aborts the entry too. This is documented on the option, and the trade-off is explicit: enable it only behind a forwarder that aborts (rather than silently returns) on a mid-body error.

## Implementation

- `cache.go`: `Options.CacheChunked` + `Cache.cacheChunked`; `writeStored` synthesizes `Content-Length` when the stored entry has none.
- `policy.go`: thread `cacheChunked` through `decide`/`decideForced`/`fitsCap`; a no-`Content-Length` GET is cacheable only when `cacheChunked` and not `text/event-stream`.
- `tee.go`: `finish` accepts a cleanly-finished chunked body; `DecoupleFill` gated to `Content-Length` responses.

## Testing

- `go test ./pkg/cache/` — full suite green (203 existing + 6 new), `go vet` clean.
- New `chunked_test.go` covers: cached-when-enabled (MISS→HIT, synthesized `Content-Length`), never-cached-when-disabled, `text/event-stream` excluded, over-cap not cached (served in full), and truncation (panic) not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)