### PR TITLE
feat(waf): export standalone CEL Predicate over the request model

### DIFF
--- a/pkg/waf/doc.go
+++ b/pkg/waf/doc.go
@@ -64,6 +64,23 @@
 // thread-safe cel.Program. Evaluation uses ContextEval with a CostLimit and
 // per-request deadline (WAF.EvalTimeout) to keep the request path bounded.
 //
+// # Reusing the CEL surface outside the firewall (Predicate)
+//
+// The same `request` model and custom functions are available standalone via
+// Predicate, a compiled boolean expression with no action/status — it answers
+// only "does this request match". This lets other middleware reuse the WAF's
+// CEL surface without duplicating (or drifting from) the environment; the
+// canonical consumer is rate limiting, which gates a limit on a Predicate:
+//
+//	p, _ := waf.NewPredicate(`request.method == "POST" && request.path.startsWith("/api/")`)
+//	in := waf.NewInput(r, "", country, asn) // one snapshot, reusable across predicates
+//	match, err := p.Eval(r.Context(), in)
+//
+// Build a Predicate once (NewPredicate validates the bool result type and bounds
+// it with the same cost limit as a rule); evaluation is concurrency-safe. Eval
+// returns an error on timeout/cost/type failure, leaving the fail-open vs
+// fail-closed decision to the caller.
+//
 // # Security notes
 //
 //   - Cost limit is enforced (default 1_000_000 units) to prevent runaway rules.

--- a/pkg/waf/predicate.go
+++ b/pkg/waf/predicate.go
@@ -20,8 +20,8 @@ import (
 // Unlike a Rule it carries no action/status/priority: it answers one question,
 // "does this request match", and the caller decides what to do with the answer.
 type Predicate struct {
+	prg         cel.Program // interface (2 ptr words); first to keep the GC scan span minimal (fieldalignment)
 	expression  string
-	prg         cel.Program
 	evalTimeout time.Duration
 }
 

--- a/pkg/waf/predicate.go
+++ b/pkg/waf/predicate.go
@@ -1,0 +1,144 @@
+package waf
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/cel-go/cel"
+)
+
+// Predicate is a standalone compiled CEL boolean expression over the SAME
+// `request` model and helper functions as WAF rules (see package docs for the
+// variables and functions). It exists so other middleware can gate behaviour on
+// request attributes using the WAF's CEL surface without duplicating — or
+// drifting from — the environment. The canonical consumer is rate limiting,
+// which uses a Predicate to decide whether a limit applies to a request.
+//
+// A Predicate is compiled once by NewPredicate and is safe for concurrent Eval.
+// Unlike a Rule it carries no action/status/priority: it answers one question,
+// "does this request match", and the caller decides what to do with the answer.
+type Predicate struct {
+	expression  string
+	prg         cel.Program
+	evalTimeout time.Duration
+}
+
+// predicateConfig holds the resolved options for NewPredicate.
+type predicateConfig struct {
+	costLimit     uint64
+	evalTimeout   time.Duration
+	disableMacros bool
+}
+
+// PredicateOption configures NewPredicate. The defaults match the WAF's own
+// rule compilation (cost limit defaultCostLimit, eval timeout defaultEvalTimeout,
+// macros enabled), so a predicate is bounded exactly like a rule unless the
+// caller tightens it.
+type PredicateOption func(*predicateConfig)
+
+// WithPredicateCostLimit caps CEL evaluator cost per Eval (0 ⇒ defaultCostLimit).
+func WithPredicateCostLimit(n uint64) PredicateOption {
+	return func(c *predicateConfig) { c.costLimit = n }
+}
+
+// WithPredicateEvalTimeout sets the per-Eval deadline (<=0 ⇒ defaultEvalTimeout).
+func WithPredicateEvalTimeout(d time.Duration) PredicateOption {
+	return func(c *predicateConfig) { c.evalTimeout = d }
+}
+
+// WithPredicateDisableMacros refuses expressions that use CEL macros
+// (all/exists/filter/map/comprehensions) — recommended when the expression
+// comes from a less-trusted source, mirroring WAF.DisableMacros.
+func WithPredicateDisableMacros() PredicateOption {
+	return func(c *predicateConfig) { c.disableMacros = true }
+}
+
+// NewPredicate compiles expr into a Predicate using the WAF's CEL environment.
+// expr must be non-empty and evaluate to bool; a compile error, a non-bool
+// result type, or a program-build error is returned (the same checks SetRules
+// applies to a rule expression), so an invalid predicate is caught at
+// construction, never at request time.
+func NewPredicate(expr string, opts ...PredicateOption) (*Predicate, error) {
+	if expr == "" {
+		return nil, fmt.Errorf("waf: predicate: empty expression")
+	}
+
+	cfg := predicateConfig{
+		costLimit:   defaultCostLimit,
+		evalTimeout: defaultEvalTimeout,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.costLimit == 0 {
+		cfg.costLimit = defaultCostLimit
+	}
+	if cfg.evalTimeout <= 0 {
+		cfg.evalTimeout = defaultEvalTimeout
+	}
+
+	var envOpts []cel.EnvOption
+	if cfg.disableMacros {
+		envOpts = append(envOpts, cel.ClearMacros())
+	}
+	env, err := newCELEnv(envOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("waf: predicate: build env: %w", err)
+	}
+
+	ast, iss := env.Compile(expr)
+	if iss.Err() != nil {
+		return nil, fmt.Errorf("waf: predicate: compile: %w", iss.Err())
+	}
+	if !ast.OutputType().IsExactType(cel.BoolType) {
+		return nil, fmt.Errorf("waf: predicate: expression must return bool, got %s", ast.OutputType())
+	}
+	prg, err := env.Program(ast,
+		cel.EvalOptions(cel.OptOptimize),
+		cel.CostLimit(cfg.costLimit),
+		cel.InterruptCheckFrequency(64),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("waf: predicate: program: %w", err)
+	}
+
+	return &Predicate{
+		expression:  expr,
+		prg:         prg,
+		evalTimeout: cfg.evalTimeout,
+	}, nil
+}
+
+// Expression returns the source expression, for logs and introspection.
+func (p *Predicate) Expression() string { return p.expression }
+
+// Input is a materialised `request` snapshot for one HTTP request. Build it once
+// with NewInput and reuse it across several Predicate.Eval calls so the request
+// (headers, cookies, query) is walked only once per request, however many
+// predicates evaluate against it. It is read-only; do not mutate after building.
+type Input struct {
+	m map[string]any
+}
+
+// NewInput materialises the `request` snapshot for r, exposing exactly the
+// fields documented for WAF rules. body is the (caller-truncated) string for
+// request.body — pass "" to leave it empty (no body inspection). country/asn are
+// the resolved GeoIP values for request.country / request.asn — pass "" / 0 when
+// unresolved or unused; the fields are always present so an expression
+// referencing them never errors.
+func NewInput(r *http.Request, body, country string, asn int64) Input {
+	return Input{m: buildRequestMap(r, body, country, asn)}
+}
+
+// Eval evaluates the predicate against in and returns the boolean result. It
+// applies the predicate's own eval timeout (derived from ctx) and cost limit; a
+// timeout, cost-limit breach, runtime type error, or recovered panic is returned
+// as a non-nil error with a false result, leaving the fail-open/fail-closed
+// decision to the caller. ctx may carry the request's cancellation.
+func (p *Predicate) Eval(ctx context.Context, in Input) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, p.evalTimeout)
+	defer cancel()
+	return evalProgram(ctx, p.prg, in.m)
+}

--- a/pkg/waf/predicate_test.go
+++ b/pkg/waf/predicate_test.go
@@ -1,0 +1,197 @@
+package waf_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/moonrhythm/parapet/pkg/waf"
+)
+
+func TestNewPredicate_Validation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty expression rejected", func(t *testing.T) {
+		_, err := waf.NewPredicate("")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty expression")
+	})
+
+	t.Run("non-bool expression rejected", func(t *testing.T) {
+		_, err := waf.NewPredicate(`request.method`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must return bool")
+	})
+
+	t.Run("syntax error rejected", func(t *testing.T) {
+		_, err := waf.NewPredicate(`request.method ==`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "compile")
+	})
+
+	t.Run("unknown variable rejected at compile", func(t *testing.T) {
+		_, err := waf.NewPredicate(`nope == "x"`)
+		require.Error(t, err)
+	})
+
+	t.Run("valid expression compiles", func(t *testing.T) {
+		p, err := waf.NewPredicate(`request.method == "POST"`)
+		require.NoError(t, err)
+		assert.Equal(t, `request.method == "POST"`, p.Expression())
+	})
+}
+
+func TestPredicate_Eval(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		expr string
+		req  func() *http.Request
+		want bool
+	}{
+		{
+			name: "method match true",
+			expr: `request.method == "POST"`,
+			req:  func() *http.Request { return httptest.NewRequest(http.MethodPost, "/api", nil) },
+			want: true,
+		},
+		{
+			name: "method match false",
+			expr: `request.method == "POST"`,
+			req:  func() *http.Request { return httptest.NewRequest(http.MethodGet, "/api", nil) },
+			want: false,
+		},
+		{
+			name: "path prefix",
+			expr: `request.path.startsWith("/api/")`,
+			req:  func() *http.Request { return httptest.NewRequest(http.MethodGet, "/api/v1", nil) },
+			want: true,
+		},
+		{
+			name: "header lookup (lowercased key)",
+			expr: `request.headers["x-api-key"] == "secret"`,
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.Header.Set("X-Api-Key", "secret")
+				return r
+			},
+			want: true,
+		},
+		{
+			name: "ipInCidr helper available",
+			expr: `ipInCidr(request.remote_ip, "10.0.0.0/8")`,
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				r.Header.Set("X-Real-Ip", "10.1.2.3")
+				return r
+			},
+			want: true,
+		},
+		{
+			name: "regexMatch helper available",
+			expr: `regexMatch(request.path, "^/admin")`,
+			req:  func() *http.Request { return httptest.NewRequest(http.MethodGet, "/admin/x", nil) },
+			want: true,
+		},
+		{
+			name: "absent header tested with `in` idiom",
+			expr: `!("x-absent" in request.headers)`,
+			req:  func() *http.Request { return httptest.NewRequest(http.MethodGet, "/", nil) },
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := waf.NewPredicate(tc.expr)
+			require.NoError(t, err)
+			in := waf.NewInput(tc.req(), "", "", 0)
+			got, err := p.Eval(context.Background(), in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPredicate_CountryAndASN(t *testing.T) {
+	t.Parallel()
+
+	p, err := waf.NewPredicate(`request.country == "TH" && request.asn == 13335`)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	in := waf.NewInput(r, "", "TH", 13335)
+	got, err := p.Eval(context.Background(), in)
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	// Unresolved geo (defaults) makes the same expression false, not an error.
+	in2 := waf.NewInput(r, "", "", 0)
+	got2, err := p.Eval(context.Background(), in2)
+	require.NoError(t, err)
+	assert.False(t, got2)
+}
+
+func TestPredicate_DisableMacros(t *testing.T) {
+	t.Parallel()
+
+	const expr = `request.headers.exists(k, k == "x-api-key")`
+	// Macros enabled by default: compiles.
+	_, err := waf.NewPredicate(expr)
+	require.NoError(t, err)
+	// Disabled: the macro is refused at compile.
+	_, err = waf.NewPredicate(expr, waf.WithPredicateDisableMacros())
+	require.Error(t, err)
+}
+
+func TestPredicate_InputReuse(t *testing.T) {
+	t.Parallel()
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1", nil)
+	r.Header.Set("X-Api-Key", "k")
+	in := waf.NewInput(r, "", "", 0)
+
+	pMethod, err := waf.NewPredicate(`request.method == "POST"`)
+	require.NoError(t, err)
+	pPath, err := waf.NewPredicate(`request.path.startsWith("/api/")`)
+	require.NoError(t, err)
+
+	// One snapshot, evaluated by several predicates.
+	gotM, err := pMethod.Eval(context.Background(), in)
+	require.NoError(t, err)
+	assert.True(t, gotM)
+	gotP, err := pPath.Eval(context.Background(), in)
+	require.NoError(t, err)
+	assert.True(t, gotP)
+}
+
+func TestPredicate_CostLimit(t *testing.T) {
+	t.Parallel()
+
+	// A tiny cost limit makes even a trivial comparison exceed budget at eval.
+	p, err := waf.NewPredicate(`request.path == "/x"`, waf.WithPredicateCostLimit(1))
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	_, err = p.Eval(context.Background(), waf.NewInput(r, "", "", 0))
+	require.Error(t, err)
+}
+
+func TestPredicate_EvalTimeoutOptionAccepted(t *testing.T) {
+	t.Parallel()
+
+	// A configured eval timeout doesn't break a fast expression — the timeout
+	// bounds runaway evaluation; deterministically forcing it would need an
+	// expensive expression, which the cost-limit test already exercises.
+	p, err := waf.NewPredicate(`request.path == "/x"`, waf.WithPredicateEvalTimeout(time.Second))
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	got, err := p.Eval(context.Background(), waf.NewInput(r, "", "", 0))
+	require.NoError(t, err)
+	assert.True(t, got)
+}

--- a/pkg/waf/waf.go
+++ b/pkg/waf/waf.go
@@ -362,16 +362,22 @@ func (w *WAF) ServeHandler(h http.Handler) http.Handler {
 	})
 }
 
-// evalRule runs a single CEL program with panic recovery. Panics inside CEL
-// are not expected but a defensive recover ensures one buggy custom function
-// can never take down the proxy.
+// evalRule runs a single rule's CEL program with panic recovery.
 func evalRule(ctx context.Context, rule *compiledRule, input map[string]any) (matched bool, err error) {
+	return evalProgram(ctx, rule.prg, input)
+}
+
+// evalProgram runs a compiled CEL program against input and coerces the result
+// to bool, with panic recovery. Panics inside CEL are not expected but a
+// defensive recover ensures one buggy custom function can never take down the
+// proxy. Shared by WAF rules (evalRule) and the standalone Predicate.
+func evalProgram(ctx context.Context, prg cel.Program, input map[string]any) (matched bool, err error) {
 	defer func() {
 		if rec := recover(); rec != nil {
 			err = fmt.Errorf("panic: %v", rec)
 		}
 	}()
-	out, _, evErr := rule.prg.ContextEval(ctx, input)
+	out, _, evErr := prg.ContextEval(ctx, input)
 	if evErr != nil {
 		return false, evErr
 	}


### PR DESCRIPTION
## What

Adds an exported, standalone CEL **Predicate** to `pkg/waf` so callers outside the firewall can reuse the WAF's CEL surface — the same `request.*` variables and helper functions (`ipInCidr`, `regexMatch`, `containsAny`, `lower`, `urlDecode`, …) — without duplicating, or drifting from, the environment.

- `NewPredicate(expr, opts...) (*Predicate, error)` — compiles, requires a `bool` result, applies the same cost limit / interrupt frequency as a rule. Options: `WithPredicateCostLimit`, `WithPredicateEvalTimeout`, `WithPredicateDisableMacros`.
- `Input` (opaque `request` snapshot via `NewInput(r, body, country, asn)`) so a caller evaluating several predicates per request walks the request once.
- `(*Predicate).Eval(ctx, Input) (bool, error)` — returns the bool result, leaving fail-open vs fail-closed to the caller.

Reuses the existing unexported `newCELEnv` + `buildRequestMap` as-is; `evalRule` now delegates to a shared `evalProgram` so rules and predicates evaluate identically (panic recovery, bool coercion). **Purely additive — no behavior change to WAF rules.**

## Why

The canonical consumer is rate limiting in parapet-ingress-controller, which wants per-route/per-method scoping with the *same* expression language as the WAF. Sharing one CEL environment is the only way the two surfaces can't drift.

## Test

`go test ./pkg/waf/` — 106 pass (16 new predicate cases: validation, eval, helpers, country/asn, macro disable, input reuse, cost limit). `go vet` + `gofmt` clean.

## Release

Additive surface only; intended to ship as **v0.18.3**. parapet-ingress-controller's CEL-filter PR depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)